### PR TITLE
Update setup.py to list 0.0.4 version (which we'd now be working towards)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def find_package_data(data_root, package_root):
 
 setup(
     name = "openforcefield",
-    version = "0.0.3",
+    version = "0.0.4",
     author = "John Chodera, David Mobley, and others",
     author_email = "john.chodera@choderalab.org",
     description = ("Open Force Field Group tools"),


### PR DESCRIPTION
We were way overdue for a point release, because the 0.0.2 version on `omnia` doesn't work with present-day networkx, so I just made an 0.0.3 point release. This updates setup.py for ongoing development.