### PR TITLE
Fix an issue with impropers where they could only keep things planar; switches impropers from six-fold to three-fold

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
   # Build the recipe
   - conda build devtools/conda-recipe
   # Use oeommtools for improper test
-  - conda install -c openeye/label/Orion oeommtools -c omnia
+  - conda install --yes -c openeye/label/Orion oeommtools -c omnia
   # Install
   - conda install --yes --use-local openforcefield
   # Run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ script:
   #- pip install $OPENEYE_CHANNEL openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
   # Use beta version for partial bond orders
   - pip install --pre -i https://pypi.anaconda.org/openeye/simple openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
+  # Use oeommtools for improper test
+  - conda install -c openeye/label/Orion oeommtools -c omnia
   # Build the recipe
   - conda build devtools/conda-recipe
   # Install

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ script:
   #- pip install $OPENEYE_CHANNEL openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
   # Use beta version for partial bond orders
   - pip install --pre -i https://pypi.anaconda.org/openeye/simple openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
-  # Use oeommtools for improper test
-  - conda install -c openeye/label/Orion oeommtools -c omnia
   # Build the recipe
   - conda build devtools/conda-recipe
+  # Use oeommtools for improper test
+  - conda install -c openeye/label/Orion oeommtools -c omnia
   # Install
   - conda install --yes --use-local openforcefield
   # Run tests

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This repository contains a number of tools from the [Open Forcefield Consortium](http://github.com/openforcefield) for the development and use of modern molecular mechanics forcefields based on direct chemical perception and parameterized with rigorous statistical methods.
 
 This repository hosts tools that we have committed to stably maintain throughout their lifetimes:
-* The [SMIRks Native Open Force Field (SMIRNOFF)](https://github.com/openforcefield/openforcefield/blob/master/The-SMIRNOFF-force-field-format.md) direct chemical perception forcefield specification language
+* The [SMIRKS Native Open Force Field (SMIRNOFF)](https://github.com/openforcefield/openforcefield/blob/master/The-SMIRNOFF-force-field-format.md) direct chemical perception forcefield specification language
 * Tools for direct chemical environment perception and manipulation
 
 ## Installation
@@ -30,7 +30,7 @@ conda install --yes -c conda-forge -c omnia openforcefield
 
 # Tools
 
-## `SMIRNOFF`: SMIRks Native Open Force Field
+## `SMIRNOFF`: SMIRKS Native Open Force Field
 
 This repository houses the SMIRNOFF SMIRKS-based force field format, along with classes to parameterize OpenMM systems given [SMIRNOFF `.offxml` format files](https://github.com/openforcefield/openforcefield/blob/master/The-SMIRNOFF-force-field-format.md).
 

--- a/The-SMIRNOFF-force-field-format.md
+++ b/The-SMIRNOFF-force-field-format.md
@@ -1,4 +1,4 @@
-# The SMIRks Native Open Force Field (SMIRNOFF) v0.1
+# The SMIRKS Native Open Force Field (SMIRNOFF) v0.1
 
 The SMIRNOFF format is based on the [`OpenMM`](http://openmm.org) [`ForceField`](http://docs.openmm.org/7.0.0/api-python/generated/simtk.openmm.app.forcefield.ForceField.html#simtk.openmm.app.forcefield.ForceField) class and provides an XML format for encoding force fields based on [SMIRKS](http://www.daylight.com/dayhtml/doc/theory/theory.smirks.html)-based chemical perception.
 While designed for [`OpenMM`](http://openmm.org), parameters encoded in this format can be applied to systems and then these systems converted via [`ParmEd`](http://parmed.github.io/ParmEd) and [`InterMol`](https://github.com/shirtsgroup/InterMol) for simulations in a variety of other simulation packages.

--- a/The-SMIRNOFF-force-field-format.md
+++ b/The-SMIRNOFF-force-field-format.md
@@ -116,8 +116,8 @@ Impropers are applied in the same manner as proper torsions, via `PeriodicTorsio
 ```
 
 **Improper torsions deviate profoundly from AMBER handling of impropers** in two ways.
-First, to eliminate ambiguity, we treat impropers as a [trefoil](https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Trefoil_knot_left.svg/2000px-Trefoil_knot_left.svg.png) and apply the same set of parameters to all six paths around the trefoil.
-*Because of this, all barrier heights are divided by six before we apply them*, for consistency with AMBER force fields. Second, the *second* atom in an improper (in the example above, the trivalent carbon) is the central atom in the trefoil.
+First, to eliminate ambiguity, we treat impropers as a [trefoil](https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Trefoil_knot_left.svg/2000px-Trefoil_knot_left.svg.png) and apply the same set of parameters to all three paths around the trefoil that have the same handedness.
+*Because of this, all barrier heights are divided by three before we apply them*, for consistency with AMBER force fields. Second, the *second* atom in an improper (in the example above, the trivalent carbon) is the central atom in the trefoil.
 
 ### GBSA parameters
 

--- a/openforcefield/data/forcefield/ammonia_minimal.offxml
+++ b/openforcefield/data/forcefield/ammonia_minimal.offxml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='ASCII'?>
+<SMIRNOFF version="0.1" aromaticity_model="OEAroModel_MDL">
+  <!-- SMIRNOFF (SMIRKS Native Open Force Field) file -->
+  <Date>Date: Apr. 05, 2018</Date>
+  <Author>V. T. Lim, UC Irvine</Author>
+  <!-- Minimal SMIRNOFF file for testing partly pyramidal geometry of ammonia. -->
+  <!-- This file is meant for processing via openforcefield.typing.engines.smirnoff -->
+  <!-- WARNING: AMBER functional forms drop the factor of 2 in the bond energy term, so cross-comparing this file with a corresponding .frcmod file, it will appear that the values here are twice as large as they should be. -->
+  <HarmonicBondForce length_unit="angstroms" k_unit="kilocalories_per_mole/angstrom**2">
+    <Bond smirks="[#7:1]-[#1:2]" id="b86" k="868.0" length="1.010"/>
+  </HarmonicBondForce>
+  <!-- WARNING: AMBER functional forms drop the factor of 2 in the angle energy term, so cross-comparing this file with a corresponding .frcmod file, it will appear that the values here are twice as large as they should be. -->
+  <HarmonicAngleForce angle_unit="degrees" k_unit="kilocalories_per_mole/radian**2">
+    <Angle smirks="[*:1]-[#7X4,#7X3,#7X2-1:2]-[*:3]" angle="109.5" id="a17" k="140.0"/>
+    <Angle smirks="[#1:1]-[#7X4,#7X3,#7X2-1:2]-[*:3]" angle="109.5" id="a18" k="100.0"/>
+  </HarmonicAngleForce>
+  <PeriodicTorsionForce phase_unit="degrees" k_unit="kilocalories_per_mole">
+    <Improper smirks="[#1:1]~[#7X3:2](~[#1:3])~[#1:4]" id="i3" k1="100" periodicity1="2" phase1="150."/>
+  </PeriodicTorsionForce>
+  <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
+  <NonbondedForce coulomb14scale="0.833333" lj14scale="0.5" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole">
+    <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
+    <Atom smirks="[#1:1]-[#7]" epsilon="0.0157" id="n11" rmin_half="0.6000"/>
+    <Atom smirks="[#7:1]" epsilon="0.1700" id="n20" rmin_half="1.8240"/>
+  </NonbondedForce>
+</SMIRNOFF>

--- a/openforcefield/tests/test_smirnoff.py
+++ b/openforcefield/tests/test_smirnoff.py
@@ -526,7 +526,7 @@ def test_improper(verbose = False):
 
     # Check that torsional energies the same to 1 in 10^6
     rel_error = np.abs(( g0['torsion']-g1['torsion'])/ g0['torsion'])
-    if rel_error > 6e-3: #Note that this will not be tiny because we use six-fold impropers and they use a single improper
+    if rel_error > 6e-3: #Note that this will not be tiny because we use three-fold impropers and they use a single improper
         raise Exception("Improper torsion energy for benzene differs too much (relative error %.4g) between AMBER and SMIRNOFF." % rel_error )
 
 def test_improper_pyramidal(verbose = False):

--- a/openforcefield/tests/test_smirnoff.py
+++ b/openforcefield/tests/test_smirnoff.py
@@ -526,7 +526,7 @@ def test_improper(verbose = False):
 
     # Check that torsional energies the same to 1 in 10^6
     rel_error = np.abs(( g0['torsion']-g1['torsion'])/ g0['torsion'])
-    if rel_error > 2e-5: #Note that this will not be tiny because we use six-fold impropers and they use a single improper
+    if rel_error > 6e-3: #Note that this will not be tiny because we use six-fold impropers and they use a single improper
         raise Exception("Improper torsion energy for benzene differs too much (relative error %.4g) between AMBER and SMIRNOFF." % rel_error )
 
 def test_improper_pyramidal(verbose = False):
@@ -572,9 +572,10 @@ def test_improper_pyramidal(verbose = False):
         ang2 = math.degrees(oechem.OEGetAngle(outmol, nbors[1],atom,nbors[2]))
         ang3 = math.degrees(oechem.OEGetAngle(outmol, nbors[2],atom,nbors[0]))
     ang_sum = math.fsum([ang1,ang2,ang3])
-    # Check that sum of angles around N is within 1 degree of 352
-    if abs(ang_sum-352.) > 1.0:
-        raise Exception("Improper torsion for ammonia differs too much from partly pyramidal geometry having sum of H-N-H angles (3x) at 352 degrees.")
+    # Check that sum of angles around N is within 1 degree of 353.5
+    if abs(ang_sum-353.5) > 1.0:
+        raise Exception("Improper torsion for ammonia differs too much from reference partly pyramidal geometry."
+        "The reference case has a sum of H-N-H angles (3x) at 353.5 degrees; the test case has a sum of {}.".format(ang_sum))
 
 def test_MDL_aromaticity(verbose=False):
     """Test support for alternate aromaticity models."""

--- a/openforcefield/tests/test_smirnoff.py
+++ b/openforcefield/tests/test_smirnoff.py
@@ -551,7 +551,7 @@ def test_improper_pyramidal(verbose = False):
     oechem.OETriposAtomTypes(mol)
     oechem.OETriposAtomNames(mol)
     # Set up minimization
-    ff = ForceField('ammonia_minimal.offxml')
+    ff = ForceField(get_data_filename('forcefield/ammonia_minimal.offxml'))
     topology, positions = oemol_to_openmmTop(mol)
     system = ff.createSystem(topology, [mol], verbose=verbose)
     positions = extractPositionsFromOEMol(mol)

--- a/openforcefield/tests/test_smirnoff.py
+++ b/openforcefield/tests/test_smirnoff.py
@@ -576,7 +576,6 @@ def test_improper_pyramidal(verbose = False):
     if abs(ang_sum-352.) > 1.0:
         raise Exception("Improper torsion for ammonia differs too much from partly pyramidal geometry having sum of H-N-H angles (3x) at 352 degrees.")
 
-
 def test_MDL_aromaticity(verbose=False):
     """Test support for alternate aromaticity models."""
     ffxml = StringIO(ffxml_MDL_contents)

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -1843,10 +1843,11 @@ class PeriodicTorsionGenerator(object):
             for (periodicity, phase, k) in zip(improper.periodicity, improper.phase, improper.k):
                 # Permute non-central atoms
                 others = [ atom_indices[0], atom_indices[2], atom_indices[3] ]
-                for p in itertools.permutations( others ):
-                    force.addTorsion(p[0], atom_indices[1], p[1], p[2], periodicity, phase, k)
-
-        if verbose: print('%d impropers added, each applied in a six-fold manner' % (len(impropers)))
+                #for p in itertools.permutations( others ):
+                #    force.addTorsion(p[0], atom_indices[1], p[1], p[2], periodicity, phase, k)
+                # TEMPORARY DEBUGGING: Don't permute, just add in the order in which they are
+                force.addTorsion(atom_indices[0], atom_indices[1], atom_indices[2], atom_indices[3], periodicity, phase, k)
+        #if verbose: print('%d impropers added, each applied in a six-fold manner' % (len(impropers)))
 
 
 

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -1839,15 +1839,13 @@ class PeriodicTorsionGenerator(object):
             assert topology._isBonded(atom_indices[1], atom_indices[2]), 'Atom indices %d and %d are not bonded in topology' % (atom_indices[1], atom_indices[2])
             assert topology._isBonded(atom_indices[1], atom_indices[3]), 'Atom indices %d and %d are not bonded in topology' % (atom_indices[1], atom_indices[3])
 
-            # Impropers are applied to all six paths around the trefoil
+            # Impropers are applied in three paths around the trefoil having the same handedness
             for (periodicity, phase, k) in zip(improper.periodicity, improper.phase, improper.k):
-                # Permute non-central atoms
                 others = [ atom_indices[0], atom_indices[2], atom_indices[3] ]
-                #for p in itertools.permutations( others ):
-                #    force.addTorsion(p[0], atom_indices[1], p[1], p[2], periodicity, phase, k)
-                # TEMPORARY DEBUGGING: Don't permute, just add in the order in which they are
-                force.addTorsion(atom_indices[0], atom_indices[1], atom_indices[2], atom_indices[3], periodicity, phase, k)
-        #if verbose: print('%d impropers added, each applied in a six-fold manner' % (len(impropers)))
+                force.addTorsion(atom_indices[1], atom_indices[0], atom_indices[2], atom_indices[3], periodicity, phase, k)
+                force.addTorsion(atom_indices[1], atom_indices[2], atom_indices[3], atom_indices[0], periodicity, phase, k)
+                force.addTorsion(atom_indices[1], atom_indices[3], atom_indices[0], atom_indices[2], periodicity, phase, k)
+        if verbose: print('%d impropers added, three per each smirks pattern' % (len(impropers)*3))
 
 
 

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -1841,7 +1841,6 @@ class PeriodicTorsionGenerator(object):
 
             # Impropers are applied in three paths around the trefoil having the same handedness
             for (periodicity, phase, k) in zip(improper.periodicity, improper.phase, improper.k):
-                others = [ atom_indices[0], atom_indices[2], atom_indices[3] ]
                 force.addTorsion(atom_indices[1], atom_indices[0], atom_indices[2], atom_indices[3], periodicity, phase, k)
                 force.addTorsion(atom_indices[1], atom_indices[2], atom_indices[3], atom_indices[0], periodicity, phase, k)
                 force.addTorsion(atom_indices[1], atom_indices[3], atom_indices[0], atom_indices[2], periodicity, phase, k)
@@ -1894,10 +1893,9 @@ class PeriodicTorsionGenerator(object):
             force_terms.append( ([atom_indices[0], atom_indices[1], atom_indices[2], atom_indices[3]], torsion.pid, torsion.smirks) )
         # Add all impropers to the output list
         for (atom_indices, improper) in impropers.items():
-            # Permute non-central atoms
-            others = [ atom_indices[0], atom_indices[2], atom_indices[3] ]
-            for p in itertools.permutations( others ):
-                force_terms.append( ([p[0], atom_indices[1], p[1], p[2]], improper.pid, improper.smirks) )
+            force_terms.append( ([atom_indices[1], atom_indices[0], atom_indices[2], atom_indices[3]], improper.pid, improper.smirks) )
+            force_terms.append( ([atom_indices[1], atom_indices[2], atom_indices[3], atom_indices[0]], improper.pid, improper.smirks) )
+            force_terms.append( ([atom_indices[1], atom_indices[3], atom_indices[0], atom_indices[2]], improper.pid, improper.smirks) )
 
         return force_terms
 


### PR DESCRIPTION
For the section in the ammonia test function that sums the angles around nitrogen, I get an oechem warning: `Warning: No principle axes found during inertial alignment` but it doesn't seem to create an issue.

This is referring to the `test_smirnoff.py` file in the `test_improper_pyramidal` function at the line starting with `for atom in outmol.GetAtoms(oechem.OEIsInvertibleNitrogen())`.