### PR TITLE
Update ChemicalEnvironments SMIRKS parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ script:
 
 env:
   matrix:
-    - python=2.7  CONDA_PY=27
     - python=3.5  CONDA_PY=35
     - python=3.6  CONDA_PY=36
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ script:
   #- pip install $OPENEYE_CHANNEL openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
   # Use beta version for partial bond orders
   - pip install --pre -i https://pypi.anaconda.org/openeye/simple openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
+  # Install RDKit
+  - conda install --yes -c rdkit rdkit
   # Build the recipe
   - conda build devtools/conda-recipe
   # Use oeommtools for improper test

--- a/openforcefield/tests/test_chemicalenvironment.py
+++ b/openforcefield/tests/test_chemicalenvironment.py
@@ -97,11 +97,12 @@ class TestChemicalEnvironments(TestCase):
                 [ "[$(c1ccccc1)]", None, ChemicalEnvironment],
                 ]
 
-        for [smirks, checkType, chemEnv] in smirksList:
-            env = chemEnv(smirks = smirks, replacements = replacements)
-            Type = env.getType()
-            self.assertEqual(Type,checkType,
-                    "SMIRKS (%s) clasified as %s instead of %s" % (smirks, Type, checkType))
+        for toolkit in ['openeye', 'rdkit']:
+            for [smirks, checkType, chemEnv] in smirksList:
+                env = chemEnv(smirks = smirks, replacements = replacements, toolkit=toolkit)
+                Type = env.getType()
+                self.assertEqual(Type,checkType,
+                        "SMIRKS (%s) clasified as %s instead of %s using %s toolkit" % (smirks, Type, checkType, toolkit))
 
     def test_environment_functions(self):
         """

--- a/openforcefield/tests/test_chemicalenvironment.py
+++ b/openforcefield/tests/test_chemicalenvironment.py
@@ -93,7 +93,8 @@ class TestChemicalEnvironments(TestCase):
                 [ "[#6$([#6X4](~[$ewg1])(~[#8]~[#1])):1]1=CCCC1", 'Atom', AtomChemicalEnvironment],
                 [ "[*:1]-[#7X3:2](-[#6a$(*1ccc(-[#8-1X1])cc1):3])-[*:4]", 'ImproperTorsion', ImproperChemicalEnvironment],
                 [ "[#6X4:1]1~[*:2]~[*$(*~[#1]):3]1", 'Angle', AngleChemicalEnvironment],
-                [ "[$([#7]1~[#6]-CC1)]", None, ChemicalEnvironment]
+                [ "[$([#7]1~[#6]-CC1)]", None, ChemicalEnvironment],
+                [ "[$(c1ccccc1)]", None, ChemicalEnvironment],
                 ]
 
         for [smirks, checkType, chemEnv] in smirksList:

--- a/openforcefield/tests/test_chemicalenvironment.py
+++ b/openforcefield/tests/test_chemicalenvironment.py
@@ -79,18 +79,22 @@ class TestChemicalEnvironments(TestCase):
                 ('ewg2', '[#7!-1,#8,#16]') ]
 
         smirksList = [ ["[#6](-[#1])-[#8]", None, ChemicalEnvironment],
-                ["[#6&X4&H0:1](-[#1])-[#6&X4]", 'VdW', AtomChemicalEnvironment],
+                ["[#6&X4&H0:1](-[#1])-[#6&X4]", 'Atom', AtomChemicalEnvironment],
                 [ "[#6&X4&H0:1](-[#1])-[#6&X4:2]", 'Bond', BondChemicalEnvironment],
                 [ "[*:1]-[*:2](-[#6&X4])-[*:3]", 'Angle', AngleChemicalEnvironment],
-                [ "[#6&X4&H0:1](-[#1])-[#6&X4:2]-[#6&X4&H0:3](-[#1])-[#6&X4:4]", 'Torsion', TorsionChemicalEnvironment],
-                [ "[#1:1]-[#6&X4:2](-[#8:3])-[#1:4]", 'Improper', ImproperChemicalEnvironment],
+                [ "[#6&X4&H0:1](-[#1])-[#6&X4:2]-[#6&X4&H0:3](-[#1])-[#6&X4:4]", 'ProperTorsion', TorsionChemicalEnvironment],
+                [ "[#1:1]-[#6&X4:2](-[#8:3])-[#1:4]", 'ImproperTorsion', ImproperChemicalEnvironment],
                 [ "[#1:1]-[#6&X4:2](-[#8:3])-[*:4](-[#6&H1])-[#8:5]", None, ChemicalEnvironment],
                 [ "[#6$(*~[#6]=[#8])$(*-,=$ewg2)]", None, ChemicalEnvironment],
                 [ "CCC", None, ChemicalEnvironment],
-                [ "[#6:1]1(-;!@[#1,#6])=;@[#6]-;@[#6]1", 'VdW', ChemicalEnvironment],
+                [ "[#6:1]1(-;!@[#1,#6])=;@[#6]-;@[#6]1", 'Atom', ChemicalEnvironment],
                 [ "C(O-[#7,#8])CC=[*]", None, ChemicalEnvironment],
-                [ "[#6$([#6X4](~[$ewg1])(~[#8]~[#1])):1]-[#6X2H2;+0:2]-,=,:;!@;!#[$ewg2:3]-[#4:4]", 'Torsion', TorsionChemicalEnvironment],
-                [ "[#6$([#6X4](~[$ewg1])(~[#8]~[#1])):1]1=CCCC1", 'VdW', AtomChemicalEnvironment] ]
+                [ "[#6$([#6X4](~[$ewg1])(~[#8]~[#1])):1]-[#6X2H2;+0:2]-,=,:;!@;!#[$ewg2:3]-[#4:4]", 'ProperTorsion', TorsionChemicalEnvironment],
+                [ "[#6$([#6X4](~[$ewg1])(~[#8]~[#1])):1]1=CCCC1", 'Atom', AtomChemicalEnvironment],
+                [ "[*:1]-[#7X3:2](-[#6a$(*1ccc(-[#8-1X1])cc1):3])-[*:4]", 'ImproperTorsion', ImproperChemicalEnvironment],
+                [ "[#6X4:1]1~[*:2]~[*$(*~[#1]):3]1", 'Angle', AngleChemicalEnvironment],
+                [ "[$([#7]1~[#6]-CC1)]", None, ChemicalEnvironment]
+                ]
 
         for [smirks, checkType, chemEnv] in smirksList:
             env = chemEnv(smirks = smirks, replacements = replacements)

--- a/openforcefield/tests/test_chemicalenvironment.py
+++ b/openforcefield/tests/test_chemicalenvironment.py
@@ -85,7 +85,7 @@ class TestChemicalEnvironments(TestCase):
                 [ "[#6&X4&H0:1](-[#1])-[#6&X4:2]-[#6&X4&H0:3](-[#1])-[#6&X4:4]", 'ProperTorsion', TorsionChemicalEnvironment],
                 [ "[#1:1]-[#6&X4:2](-[#8:3])-[#1:4]", 'ImproperTorsion', ImproperChemicalEnvironment],
                 [ "[#1:1]-[#6&X4:2](-[#8:3])-[*:4](-[#6&H1])-[#8:5]", None, ChemicalEnvironment],
-                [ "[#6$(*~[#6]=[#8])$(*-,=$ewg2)]", None, ChemicalEnvironment],
+                [ "[#6$(*~[#6]=[#8])$(*-,=[$ewg2,#7])]", None, ChemicalEnvironment],
                 [ "CCC", None, ChemicalEnvironment],
                 [ "[#6:1]1(-;!@[#1,#6])=;@[#6]-;@[#6]1", 'Atom', ChemicalEnvironment],
                 [ "C(O-[#7,#8])CC=[*]", None, ChemicalEnvironment],

--- a/openforcefield/typing/chemistry/environment.py
+++ b/openforcefield/typing/chemistry/environment.py
@@ -121,13 +121,8 @@ def _convert_embedded_SMIRKS(smirks):
             embedded = embedded[2:]
 
         else: # embedded starts with a "no bracket" atom such as 'C'
-            # covers element symbols, i.e. N,C,O,Br not followed by a number
-            element_sym = "!?[A-Z][a-z]?"
-            # covers element symbols that are aromatic:
-            aro_sym = "!?[cnops]"
-            # replacement strings
-            replace_str = "\$\w+"
-            no_bracket = r'('+'|'.join([element_sym, aro_sym, replace_str])+')'
+            # atoms by symbol don't need brackets, this covers atomic symbols and aromatic atoms
+            no_bracket = r'(!?[A-Z][a-z]?|!?[cnops])'
             embedded = embedded[1:] # remove leading '('
             match = re.match(no_bracket, embedded)
             if match is not None:
@@ -554,6 +549,7 @@ into ChemicalEnvironments." % smirks)
             smirks = self._asSMIRKS()
         if self.replacements is not None:
             smirks = oechem.OESmartsLexReplace(smirks, self.replacements)
+            print("replaced SMIRKS", smirks)
         return oechem.OEParseSmarts(qmol, smirks)
 
     def _parse_smirks(self,input_smirks):

--- a/openforcefield/typing/chemistry/environment.py
+++ b/openforcefield/typing/chemistry/environment.py
@@ -436,7 +436,6 @@ class ChemicalEnvironment(object):
         if toolkit.lower() == 'openeye':
             try:
                 from openeye import oechem
-                print('I found openeye')
                 self.toolkit = 'openeye'
             except:
                 raise Exception("Could not import openeye.oechem")
@@ -491,7 +490,7 @@ class ChemicalEnvironment(object):
             # Check that it is a valid SMIRKS
             if not self.isValid(smirks):
                 raise SMIRKSParsingError("Error Provided SMIRKS ('%s') was \
-not parseable with OpenEye tools" % smirks)
+not parseable with %s tools" % (smirks, self.toolkit))
 
             # Check for SMIRKS not supported by Chemical Environments
             if smirks.find('.') != -1:
@@ -574,6 +573,8 @@ into ChemicalEnvironments." % smirks)
             for substring, replace_with in self.replacements:
                 smirks = smirks.replace(substring, '('+replace_with+')')
         ss = Chem.MolFromSmarts(smirks)
+        if ss is None:
+            print(smirks, 'not parsed')
         return ss is not None
 
     def _oe_isValid(self, smirks):

--- a/openforcefield/typing/chemistry/environment.py
+++ b/openforcefield/typing/chemistry/environment.py
@@ -79,7 +79,6 @@ def _convert_embedded_SMIRKS(smirks):
     new_smirks = _convert_embedded_SMIRKS(initial_smirks)
     # new_smirks = [#1:1]~[#6]
     """
-    print('input smirks', smirks)
     a_out = 0
     while smirks.find('$(') != -1:
         # Find first atom
@@ -98,13 +97,12 @@ def _convert_embedded_SMIRKS(smirks):
 
         # Check for ring index, i.e. the 1s in "[#6:1]1-CCCCC1"
         match = re.match(r'(\d+)',post_smirks)
-        print('looking for a ring in embedded', post_smirks)
         if match is not None: # leftover starts with int
-            print('Found ring in embedded conversion', post_smirks)
-            ring = re.findall(r'(\d+)',post_smirks)[0]
-            leftover = post_smirks[match.end():]
+            ring_out = re.findall(r'(\d+)',post_smirks)[0]
+            # update post_smirks
+            post_smirks = post_smirks[match.end():]
         else:
-            ring = ''
+            ring_out = ''
 
         embedded, p_in, p_out = _find_embedded_brackets(atom, '\(', '\)')
         # two forms of embedded strings $(*~stuff) or $([..]~stuff)
@@ -113,19 +111,44 @@ def _convert_embedded_SMIRKS(smirks):
             first, f_in, f_out = _find_embedded_brackets(embedded, '\[','\]')
             first = _convert_embedded_SMIRKS(first)
             new_atom = atom[:d]+first[1:-1]+atom[p_out+1:]
-            embedded = '('+embedded[f_out+1:]
+            embedded = embedded[f_out+1:]
             # if embedded is empty between brackets, remove it
             if embedded.replace('(','').replace(')','') == '':
                 embedded = ''
 
-        else: # embedded[1] = *
+        elif embedded[1] == '*': # embedded[1] = *
             new_atom = atom[:d]+atom[p_out+1:]
-            embedded = '('+embedded[2:]
+            embedded = embedded[2:]
+
+        else: # embedded starts with a "no bracket" atom such as 'C'
+            # covers element symbols, i.e. N,C,O,Br not followed by a number
+            element_sym = "!?[A-Z][a-z]?"
+            # covers element symbols that are aromatic:
+            aro_sym = "!?[cnops]"
+            # replacement strings
+            replace_str = "\$\w+"
+            no_bracket = r'('+'|'.join([element_sym, aro_sym, replace_str])+')'
+            embedded = embedded[1:] # remove leading '('
+            match = re.match(no_bracket, embedded)
+            if match is not None:
+                new_atom = atom[:d]+embedded[:match.end()]+atom[p_out+1:]
+                embedded = embedded[match.end():]
+            else:
+                new_atom = atom[:d]+atom[p_out+1]
+
+        # Look for ring insided embedded SMIRKS "[#6$(*1CCC1)]"
+        match = re.match(r'(\d+)', embedded)
+        if match is not None: # embedded starts with an int
+            ring_in = re.findall(r'(\d+)', embedded)[0]
+            embedded = '(' + embedded[match.end():]
+        else:
+            ring_in = ''
+            if embedded != '':
+                embedded = '(' + embedded
 
         # Make new smirks
-        smirks = pre_smirks+new_atom+ring+embedded+post_smirks
+        smirks = pre_smirks+new_atom+ring_out+ring_in+embedded+post_smirks
 
-    print('returning smirks', smirks)
     return smirks
 
 def _remove_blanks_repeats(init_list, remove_list = ['']):
@@ -569,7 +592,6 @@ into ChemicalEnvironments." % smirks)
         # Check for ring index, i.e. the 1s in "[#6:1]1-CCCCC1"
         match = re.match(r'(\d+)',leftover)
         if match is not None: # leftover starts with int
-            print("Found a ring in ", leftover)
             ring = re.findall(r'(\d+)',leftover)[0]
             leftover = leftover[match.end():]
         else:
@@ -582,7 +604,6 @@ into ChemicalEnvironments." % smirks)
         atoms[idx] = new_atom
 
         while len(leftover) > 0:
-            print(leftover)
             idx += 1
 
             # Check for branching
@@ -608,7 +629,6 @@ into ChemicalEnvironments." % smirks)
             bond_split = re.split(self.no_bracket_atom_reg, bond_string)
             # Next atom is not in brackets for example C in "[#7:1]-C"
             if len(bond_split) > 1:
-                print('found no bracket atom', bond_split)
                 bond_string = bond_split[0]
                 atom_string = '['+bond_split[1]+']'
                 # update leftover for this condition
@@ -1392,7 +1412,7 @@ class TorsionChemicalEnvironment(AngleChemicalEnvironment):
         self.bond3 = self._graph_get_edge_data(self.atom3, self.atom4)['bond']
 
     def _checkType(self):
-        return (self.getType() == 'Torsion'), 'Torsion'
+        return (self.getType() == 'ProperTorsion'), 'ProperTorsion'
 
 class ImproperChemicalEnvironment(AngleChemicalEnvironment):
     """Chemical environment matching four marked atoms (improper).
@@ -1417,4 +1437,4 @@ class ImproperChemicalEnvironment(AngleChemicalEnvironment):
         self.bond3 = self._graph_get_edge_data(self.atom2, self.atom4)['bond']
 
     def _checkType(self):
-        return (self.getType() == 'Improper'), 'Improper'
+        return (self.getType() == 'ImproperTorsion'), 'ImproperTorsion'

--- a/openforcefield/typing/chemistry/environment.py
+++ b/openforcefield/typing/chemistry/environment.py
@@ -121,9 +121,9 @@ def _convert_embedded_SMIRKS(smirks):
             embedded = embedded[2:]
 
         else: # embedded starts with a "no bracket" atom such as 'C'
+            embedded = embedded[1:] # remove leading '('
             # atoms by symbol don't need brackets, this covers atomic symbols and aromatic atoms
             no_bracket = r'(!?[A-Z][a-z]?|!?[cnops])'
-            embedded = embedded[1:] # remove leading '('
             match = re.match(no_bracket, embedded)
             if match is not None:
                 new_atom = atom[:d]+embedded[:match.end()]+atom[p_out+1:]

--- a/openforcefield/typing/chemistry/environment.py
+++ b/openforcefield/typing/chemistry/environment.py
@@ -79,6 +79,7 @@ def _convert_embedded_SMIRKS(smirks):
     new_smirks = _convert_embedded_SMIRKS(initial_smirks)
     # new_smirks = [#1:1]~[#6]
     """
+    print('input smirks', smirks)
     a_out = 0
     while smirks.find('$(') != -1:
         # Find first atom
@@ -97,7 +98,9 @@ def _convert_embedded_SMIRKS(smirks):
 
         # Check for ring index, i.e. the 1s in "[#6:1]1-CCCCC1"
         match = re.match(r'(\d+)',post_smirks)
+        print('looking for a ring in embedded', post_smirks)
         if match is not None: # leftover starts with int
+            print('Found ring in embedded conversion', post_smirks)
             ring = re.findall(r'(\d+)',post_smirks)[0]
             leftover = post_smirks[match.end():]
         else:
@@ -122,6 +125,7 @@ def _convert_embedded_SMIRKS(smirks):
         # Make new smirks
         smirks = pre_smirks+new_atom+ring+embedded+post_smirks
 
+    print('returning smirks', smirks)
     return smirks
 
 def _remove_blanks_repeats(init_list, remove_list = ['']):
@@ -431,6 +435,7 @@ class ChemicalEnvironment(object):
         chirality = "!?[@]\d+|!?[@]@?"
 
         # Generate RegEx string for decorators:
+        self.no_bracket_atom_reg = r'('+'|'.join([element_sym, aro_sym, replace_str])+')'
         self.atom_reg = '|'.join([element_num, aro_ali, needs_int,
             optional_int, chirality, replace_str, element_sym, aro_sym])
         self.atom_reg = r'('+self.atom_reg+')'
@@ -547,8 +552,7 @@ into ChemicalEnvironments." % smirks)
                 start_string = smirks
 
             # Check for atoms not between square brackets
-            reg = r'(\$\w+|[A-Z][a-z]?)'
-            split = re.split(reg, start_string)
+            split = re.split(self.no_bracket_atom_reg, start_string)
             atom_string = split[1]
 
             # update leftover for this condition
@@ -565,6 +569,7 @@ into ChemicalEnvironments." % smirks)
         # Check for ring index, i.e. the 1s in "[#6:1]1-CCCCC1"
         match = re.match(r'(\d+)',leftover)
         if match is not None: # leftover starts with int
+            print("Found a ring in ", leftover)
             ring = re.findall(r'(\d+)',leftover)[0]
             leftover = leftover[match.end():]
         else:
@@ -577,6 +582,7 @@ into ChemicalEnvironments." % smirks)
         atoms[idx] = new_atom
 
         while len(leftover) > 0:
+            print(leftover)
             idx += 1
 
             # Check for branching
@@ -599,10 +605,10 @@ into ChemicalEnvironments." % smirks)
                 bond_string = leftover
 
             # Check for atoms not between square brackets
-            reg = r'(\$\w+|[A-Z][a-z]?)'
-            bond_split = re.split(reg, bond_string)
+            bond_split = re.split(self.no_bracket_atom_reg, bond_string)
             # Next atom is not in brackets for example C in "[#7:1]-C"
             if len(bond_split) > 1:
+                print('found no bracket atom', bond_split)
                 bond_string = bond_split[0]
                 atom_string = '['+bond_split[1]+']'
                 # update leftover for this condition

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -1679,7 +1679,7 @@ class PeriodicTorsionGenerator(object):
             try:
                 chemenv = ChemicalEnvironment(self.smirks)
                 thistype = chemenv.getType()
-                if thistype != 'Torsion':
+                if thistype != 'ProperTorsion':
                     raise Exception("Error: SMIRKS pattern %s (parameter %s) does not specify a %s torsion, but it is supposed to." % (self.smirks, self.pid, 'Proper'))
             except SMIRKSParsingError:
                 print("Warning: Could not confirm whether smirks pattern %s is a valid %s torsion." % (self.smirks, self.torsiontype))
@@ -1721,7 +1721,7 @@ class PeriodicTorsionGenerator(object):
             try:
                 chemenv = ChemicalEnvironment(self.smirks)
                 thistype = chemenv.getType()
-                if thistype != 'Improper':
+                if thistype != 'ImproperTorsion':
                     raise Exception("Error: SMIRKS pattern %s (parameter %s) does not specify a %s torsion, but it is supposed to." % (self.smirks, self.pid, 'Improper'))
             except SMIRKSParsingError:
                 print("Warning: Could not confirm whether smirks pattern %s is a valid %s torsion." % (self.smirks, self.torsiontype))


### PR DESCRIPTION
I have updated ChemicalEnvironments to parse more SMIRKS, per issue #106. Please note, I pulled the changes @jchodera made in to ChemicalEnvironments in #86 into this PR. I had pulled that code into my branch after writing issue #100. I haven't addressed issue #100 yet, if we just want to replace things with snake case I should be able to do that fairly easily with find and replace and could add it to this PR. When I wrote that issue I was imagining changing the `Get` and `Set` functions to also be more pythonic with `@property` and `setter` methods instead. I don't think this will take me very long, but its been REALY low on the priority list with SAMPL and MolSSI deadlines approaching. 

So currently this PR addresses only issue #106 which involved more than one bug that I found:

1. aromatic atom symbols weren't recognized when looking for atoms not in brackets. For example, `'c1ccccc1'` is technically a SMIRKS string, but before ChemicalEnvironments would have complained because it didn't know that `'c'` was an atom. Now it does. 

2. You can specify rings in recursive SMIRKS such as `"[#6X3$(*1-C=C-C1):1]"` could be used to look for a butene like group. However, the parsing didn't put the first `1` after the `*` in the right place before. 

3. While addressing 2, I discovered another bug with recursive SMIRKS. The first atom inside the recursion always refers to the first or "top" atom. In my mind, there are 3 options for what that atom could look like. 
    1.  `*` which means there is no additional information `"[#6X3$(*~[#7,#8,#9,#17,#35,#53]):1]"`. These are the most common version of this type of SMIRKS pattern
    2. a "square bracketed atom" such as `"[$(#6X3~[#7,#8,#9,#17,#35,#53])]"`. These aren't that common in human written SMIRKS, but they can appear if you had a replacement string such as `"$ewg"` where you did the replacement before making the `ChemicalEnvironment`
    3. Atomic or aromatic symbols that do not require brackets which look like: `"[$(c1ccccc1)]"`. This last type was not handled at all in the parsing, I've added coverage for this scenario. 

I've tried to add tests to cover all three of these cases. However, I would like to take this bug as an example of reasons why just "can we put it into a `ChemicalEnvironment`" is not a sufficient test. Many of these are caught because of type mismatches or because after pulling the SMIRKS into a `ChemicalEnvironment` we check that SMIRKS created by that environment is actually valid in some other toolkit. I could update the `isValid` function to check for openeye or rdkit and use which ever is available. That function is the only place `ChemicalEnvironments` are dependent on OpenEye. 

@jchodera or @davidlmobley take a look at this description and let me know if you want me to change things to snake case or address the isValid issue before we merge this. 
