### PR TITLE
Reimplement comparison between amber and SMIRNOFF parameters

### DIFF
--- a/examples/SMIRNOFF_comparison/compare_molecule_energies.py
+++ b/examples/SMIRNOFF_comparison/compare_molecule_energies.py
@@ -28,3 +28,5 @@ forcefield = ForceField('forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml')
 # Compare energies
 from openforcefield.tests.utils import compare_amber_smirnoff
 results = compare_amber_smirnoff(prmtop_filepath, inpcrd_filepath, forcefield, molecule)
+
+print(results)

--- a/examples/SMIRNOFF_comparison/compare_molecule_energies.py
+++ b/examples/SMIRNOFF_comparison/compare_molecule_energies.py
@@ -7,27 +7,24 @@ import os
 datapath = './AlkEthOH_inputfiles/AlkEthOH_rings_filt1'
 #molname = 'AlkEthOH_r0' #That fails, but it's complicated. Try cyclobutane
 molname = 'AlkEthOH_r51'
-mol_filename = os.path.join( datapath, molname+'.mol2')
-prmtop_filename = os.path.join( datapath, molname+'.top')
-inpcrd_filename = os.path.join( datapath, molname+'.crd')
+mol_filepath = os.path.join(datapath, molname + '.mol2')
+prmtop_filepath = os.path.join(datapath, molname + '.top')
+inpcrd_filepath = os.path.join(datapath, molname + '.crd')
 
-from openforcefield.utils import get_data_filename
-offxml_filename = get_data_filename('forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml')
-
-# Check if we have this data file; if not we have to extract the archive
-if not os.path.isfile( mol_filename):
-    print "Extracting archived molecule files."
+# Check if we have this data file; if not we have to extract the archive.
+if not os.path.isfile(mol_filepath):
+    print("Extracting archived molecule files.")
     tarfile = 'AlkEthOH_inputfiles.tar.gz'
     os.system('tar -xf AlkEthOH_inputfiles.tar.gz')
 
 # Load molecule
-from openmmtools.topology import Molecule
-molecule = Molecule.from_file(mol_filename)
+from openforcefield.topology import Molecule
+molecule = Molecule.from_file(mol_filepath)
 
 # Load forcefield
 from openforcefield.typing.engines.smirnoff import ForceField
-forcefield = ForceField(offxml_filename)
+forcefield = ForceField('forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml')
 
 # Compare energies
 from openforcefield.tests.utils import compare_molecule_energies
-results = compare_molecule_energies(prmtop_filename, inpcrd_filename, forcefield, molecule)
+results = compare_molecule_energies(prmtop_filepath, inpcrd_filepath, forcefield, molecule)

--- a/examples/SMIRNOFF_comparison/compare_molecule_energies.py
+++ b/examples/SMIRNOFF_comparison/compare_molecule_energies.py
@@ -26,5 +26,5 @@ from openforcefield.typing.engines.smirnoff import ForceField
 forcefield = ForceField('forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml')
 
 # Compare energies
-from openforcefield.tests.utils import compare_molecule_energies
-results = compare_molecule_energies(prmtop_filepath, inpcrd_filepath, forcefield, molecule)
+from openforcefield.tests.utils import compare_amber_smirnoff
+results = compare_amber_smirnoff(prmtop_filepath, inpcrd_filepath, forcefield, molecule)

--- a/examples/SMIRNOFF_comparison/compare_set_energies.py
+++ b/examples/SMIRNOFF_comparison/compare_set_energies.py
@@ -2,41 +2,38 @@
 import os
 import glob
 
+
 # Cross-check energies of molecules from AlkEthOH set using SMIRNOFF xml file
 # versus energies from AMBER .prmtop and .crd files (parm@frosst params)
 
 #datapath = './AlkEthOH_inputfiles/AlkEthOH_chain_filt1'
 datapath = './AlkEthOH_inputfiles/AlkEthOH_rings_filt1'
 
-from openforcefield.utils import get_data_filename
-offxml_filename = get_data_filename('forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml')
-
-#Check if this is a directory, if not, extract it
-# Check if we have this data file; if not we have to extract the archive
-if not os.path.isdir( datapath ):
-    print "Extracting archived molecule files."
+# Check if we have this data file; if not we have to extract the archive.
+if not os.path.isdir(datapath):
+    print("Extracting archived molecule files.")
     tarfile = 'AlkEthOH_inputfiles.tar.gz'
     os.system('tar -xf AlkEthOH_inputfiles.tar.gz')
 
 #Obtain list of molecules
-mol_filenames = glob.glob( datapath+'/*.mol2')
-mol_filenames = [ fnm for fnm in mol_filenames if not 'c1302' in fnm ] #Skip water
+mol_filepaths = glob.glob(datapath+'/*.mol2')
+mol_filepaths = [fnm for fnm in mol_filepaths if not 'c1302' in fnm]  # Skip water.
 
-for mol_filename in mol_filenames:
-    molname = os.path.basename( mol_filename).replace('.mol2','')
-    print("Comparing %s (%s/%s)..." % (molname, mol_filenames.index(mol_filename), len(mol_filenames) ) )
+# Load forcefield
+from openforcefield.typing.engines.smirnoff import ForceField
+forcefield = ForceField('Frosst_AlkEthOH_parmAtFrosst.offxml')
 
-    prmtop_filename = os.path.join(datapath, molname+'.top')
-    inpcrd_filename = os.path.join(datapath, molname+'.crd')
+from openforcefield.topology import Molecule
+for mol_filepath in mol_filepaths:
+    # Load molecule.
+    molecule = Molecule.from_file(mol_filepath)
 
-    # Load molecule
-    from openmmtools.topology import Molecule
-    molecule = Molecule.from_file(mol_filename)
+    molname = os.path.basename( mol_filepath).replace('.mol2','')
+    print("Comparing {} ({}/{})...".format(molname, mol_filepaths.index(mol_filepath), len(mol_filepaths)))
 
-    # Load forcefield
-    from openforcefield.typing.engines.smirnoff import ForceField
-    forcefield = ForceField(offxml_filename)
+    prmtop_filepath = os.path.join(datapath, molname+'.top')
+    inpcrd_filepath = os.path.join(datapath, molname+'.crd')
 
     # Compare energies
     from openforcefield.tests.utils import compare_molecule_energies
-    results = compare_molecule_energies(prmtop_filename, inpcrd_filename, forcefield, molecule)
+    results = compare_molecule_energies(prmtop_filepath, inpcrd_filepath, forcefield, molecule)

--- a/examples/SMIRNOFF_comparison/compare_set_energies.py
+++ b/examples/SMIRNOFF_comparison/compare_set_energies.py
@@ -21,7 +21,7 @@ mol_filepaths = [fnm for fnm in mol_filepaths if not 'c1302' in fnm]  # Skip wat
 
 # Load forcefield
 from openforcefield.typing.engines.smirnoff import ForceField
-forcefield = ForceField('Frosst_AlkEthOH_parmAtFrosst.offxml')
+forcefield = ForceField('forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml')
 
 from openforcefield.topology import Molecule
 for mol_filepath in mol_filepaths:

--- a/examples/SMIRNOFF_comparison/compare_set_energies.py
+++ b/examples/SMIRNOFF_comparison/compare_set_energies.py
@@ -35,5 +35,5 @@ for mol_filepath in mol_filepaths:
     inpcrd_filepath = os.path.join(datapath, molname+'.crd')
 
     # Compare energies
-    from openforcefield.tests.utils import compare_molecule_energies
-    results = compare_molecule_energies(prmtop_filepath, inpcrd_filepath, forcefield, molecule)
+    from openforcefield.tests.utils import compare_amber_smirnoff
+    results = compare_amber_smirnoff(prmtop_filepath, inpcrd_filepath, forcefield, molecule)

--- a/examples/SMIRNOFF_comparison/compare_set_energies.py
+++ b/examples/SMIRNOFF_comparison/compare_set_energies.py
@@ -16,8 +16,10 @@ if not os.path.isdir(datapath):
     os.system('tar -xf AlkEthOH_inputfiles.tar.gz')
 
 #Obtain list of molecules
-mol_filepaths = glob.glob(datapath+'/*.mol2')
+mol_filepaths = glob.glob(datapath+'/*sybyl.mol2')
 mol_filepaths = [fnm for fnm in mol_filepaths if not 'c1302' in fnm]  # Skip water.
+
+print('Found {} files to test'.format(len(mol_filepaths)))
 
 # Load forcefield
 from openforcefield.typing.engines.smirnoff import ForceField
@@ -28,7 +30,7 @@ for mol_filepath in mol_filepaths:
     # Load molecule.
     molecule = Molecule.from_file(mol_filepath)
 
-    molname = os.path.basename( mol_filepath).replace('.mol2','')
+    molname = os.path.basename( mol_filepath).replace('_sybyl.mol2','')
     print("Comparing {} ({}/{})...".format(molname, mol_filepaths.index(mol_filepath), len(mol_filepaths)))
 
     prmtop_filepath = os.path.join(datapath, molname+'.top')
@@ -36,4 +38,12 @@ for mol_filepath in mol_filepaths:
 
     # Compare energies
     from openforcefield.tests.utils import compare_amber_smirnoff
-    results = compare_amber_smirnoff(prmtop_filepath, inpcrd_filepath, forcefield, molecule)
+    from openforcefield.tests.utils import FailedParameterComparisonError, FailedEnergyComparisonError
+    try:
+        results = compare_amber_smirnoff(prmtop_filepath, inpcrd_filepath, forcefield, molecule)
+    except FailedParameterComparisonError as e:
+        print(e)
+    except FailedEnergyComparisonError as e:
+        print(e)
+        
+        

--- a/openforcefield/data/forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml
+++ b/openforcefield/data/forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml
@@ -47,7 +47,7 @@
    <Improper smirks="[a,A:1]~[#6X3:2]([a,A:3])~[OX1:4]" periodicity1="2" phase1="180.0" k1="10.5" id="i0001" parent_id="i0001"/> <!-- X -X -C -O  from frcmod.Frosst_AlkEthOH; none in set but here as format placeholder -->
 </ImproperTorsions>
 <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-<vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0*angstroms" cutoff="9.0*angstroms" long_range_dispersion="isotropic">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstroms" cutoff="9.0" cutoff_unit="angstroms" long_range_dispersion="isotropic">
    <!-- rmin_half is in angstroms, epsilon is in kcal/mol -->
    <Atom smirks="[#1:1]" rmin_half="1.4870" epsilon="0.0157" id="n0001" parent_id="n0001"/> <!-- making HC the generic hydrogen -->
    <Atom smirks="[$([#1]-C):1]" rmin_half="1.4870" epsilon="0.0157" id="n0002" parent_id="n0001"/> <!-- HC from frcmod.Frosst_AlkEthOH -->

--- a/openforcefield/tests/test_smirnoff.py
+++ b/openforcefield/tests/test_smirnoff.py
@@ -725,7 +725,7 @@ class TestForceFieldEnergies(unittest.TestCase):
         # Load AMBER files and compare
         inpcrd = get_data_filename('molecules/benzene.crd')
         prmtop = get_data_filename('molecules/benzene.top')
-        g0, g1, e0, e1 = compare_molecule_energies(prmtop, inpcrd, ff, mol, skip_assert=True)
+        g0, g1, e0, e1 = compare_amber_smirnoff(prmtop, inpcrd, ff, mol, skip_assert=True)
 
         # Check that torsional energies the same to 1 in 10^6
         rel_error = np.abs((g0['torsion']-g1['torsion'])/ g0['torsion'])

--- a/openforcefield/tests/test_smirnoff.py
+++ b/openforcefield/tests/test_smirnoff.py
@@ -39,7 +39,7 @@ pytestmark = pytest.mark.skip
 
 from openforcefield.utils import get_data_filename#, generateTopologyFromOEMol, read_molecules
 #from openforcefield.utils import check_energy_is_finite, get_energy
-from openforcefield.tests.utils import get_amber_system, get_packmol_pdbfile, get_monomer_mol2file, compare_system_energies
+from openforcefield.tests.utils import get_packmol_pdbfile, get_monomer_mol2file, compare_system_energies
 
 from .utils import *
 

--- a/openforcefield/tests/test_utils_structure.py
+++ b/openforcefield/tests/test_utils_structure.py
@@ -48,7 +48,7 @@ def test_merge_system():
     # Create System from AMBER
     # TODO: Add create_system_from_amber convenience function
     from openforcefield.typing.engines.smirnoff import create_system_from_amber
-    prmtop_filename, inpcrd_filename = get_amber_system('cyclohexane_ethanol_0.4_0.6')
+    prmtop_filename, inpcrd_filename = get_amber_filepaths('cyclohexane_ethanol_0.4_0.6')
     topology0, system0, positions0 = create_system_from_amber(prmtop_filename, inpcrd_filename)
 
     # TODO:

--- a/openforcefield/tests/utils.py
+++ b/openforcefield/tests/utils.py
@@ -5,7 +5,7 @@
 #=============================================================================================
 
 """
-Utilities for testing
+Utilities for testing.
 
 """
 
@@ -13,14 +13,21 @@ Utilities for testing
 # GLOBAL IMPORTS
 #=============================================================================================
 
-from openforcefield.utils import get_data_filename #, generateTopologyFromOEMol, read_molecules
-#from openforcefield.utils import check_energy_is_finite, get_energy
+import collections
+import copy
+import functools
+import itertools
+import os
+import pprint
 
+import numpy as np
 from simtk import unit, openmm
-from simtk.openmm import app
+
+from openforcefield.utils import get_data_filename
+
 
 #=============================================================================================
-# UTILITIES
+# Shortcut functions to get file paths to test data.
 #=============================================================================================
 
 
@@ -78,155 +85,829 @@ def get_monomer_mol2file(prefix='ethanol'):
     mol2_filename = get_data_filename(prefix+'.pdb')
     return mol2_filename
 
-def compare_system_energies(self, topology0, topology1, system0, system1, positions0, positions1=None, label0="AMBER system", label1="SMIRNOFF system", verbose=True, skip_assert=False, skip_improper=False):
-    """
-    Given two OpenMM systems, check that their energies and component-wise
-    energies are consistent, and return these. The same positions will be used
-    for both systems unless a second set of positions is provided.
+
+#=============================================================================================
+# Shortcut functions to create System objects from system files.
+#=============================================================================================
+
+def create_system_from_amber(prmtop_filepath, inpcrd_filepath, *args, **kwargs):
+    """Create an OpenMM System and Topology from the AMBER files.
 
     Parameters
     ----------
-    topology0 : OpenMM Topology
-        Topology of first system
-    topology1 : OpenMM Topology
-        Topology of second system
-    system0 : OpenMM System
-        First system for comparison (usually from AMBER)
-    system1 : OpenMM System
-        Second system for comparison (usually from SMIRNOFF)
-    positions0 : simtk.unit.Quantity wrapped
-        Positions to use for energy evaluation comparison
-    positions1 (optional) : simtk.unit.Quantity wrapped (optional)
-        Positions to use for second OpenMM system; original positions are used
-        if this is not provided
-    label0 (optional) : str
-        String labeling system0 for output. Default, "AMBER system"
-    label1 (optional) : str
-        String labeling system1 for output. Default, "SMIRNOFF system"
-    verbose (optional) : bool
-        Print out info on energies, True/False (default True)
-    skip_assert (optional) : bool
-        Skip assertion that energies must be equal within specified tolerance. Default False.
-    skip_improper (optional) : bool
-        Skip detailed checking of force terms on impropers (helpful here if comparing with AMBER force fields using different definitions of impropers.) Default False.
+    prmtop_filepath : str
+        Path to the topology/parameter file in AMBER prmtop format.
+    inpcrd_filepath : str
+        Path to the coordinates file in AMBER inpcrd or rst7 format.
+    *args
+    **kwargs
+        Other parameters to pass to ``simtk.openmm.app.AmberPrmtopFile.createSystem``.
 
     Returns
-    ----------
-        groups0 : dict
-            As returned by openmoltools.system_checker.check_energy_groups,
-            a dictionary with keys "bond", "angle", "nb", "torsion" and values
-            corresponding to the energies of these components for the first simulation object
-        groups1 : dict
-            As returned by openmoltools.system_checker.check_energy_groups,
-            a dictionary with keys "bond", "angle", "nb", "torsion" and values
-            corresponding to the energies of these components for the second simulation object
-        energy0 : simtk.unit.Quantity
-            Energy of first system
-        energy1 : simtk.unit.Quantity
-            Energy of second system
+    -------
+    system : simtk.openmm.System
+        The OpenMM ``System`` object with the parameters.
+    topology : simtk.openmm.app.Topology
+        The OpenMM ``Topology`` object loaded from the AMBER files.
+    positions : simtk.unit.Quantity
+        Initial positions loaded from the inpcrd or restart file.
 
-    TO DO:
-        Allow energy extraction/comparison of terms specified by particular
-        SMARTS queries i.e. for specific bond, angle, or torsional terms.
+    """
+    prmtop_file = openmm.app.AmberPrmtopFile(prmtop_filepath)
+    # AmberInpcrdFile parses also rst7 files.
+    inpcrd_file = openmm.app.AmberInpcrdFile(inpcrd_filepath)
+    # Create system and update box vectors (if needed)
+    system = prmtop_file.createSystem(*args, **kwargs)
+    if inpcrd_file.boxVectors is not None:
+        system.setDefaultPeriodicBoxVectors(*inpcrd_file.boxVectors)
+    # Store numpy positions.
+    positions = inpcrd_file.getPositions(asNumpy=True)
+    return system, prmtop_file.topology, positions
+
+
+#=============================================================================================
+# Utility functions for energy comparisons.
+#=============================================================================================
+
+def quantities_allclose(quantity1, quantity2):
+    """Check if two Quantity objects are close.
+
+    If the quantities are arrays, all their elements must be close.
+    If the given arguments are unitless, this simply calls numpy.allclose().
+
+    Parameters
+    ----------
+    quantity1 : simtk.unit.Quantity
+        The first unit to compare.
+    quantity2 : simtk.unit.Quantity
+        The second unit to compare.
+
+    Returns
+    -------
+    is_close : bool
+        True if the two quantities are close, False otherwise.
+
+    """
+    if isinstance(quantity1, unit.Quantity):
+        # Check that the two Quantities have compatible units.
+        if not quantity1.unit.is_compatible(quantity2.unit):
+            raise ValueError("The two quantities don't have compatible units: "
+                             "{} and {}".format(quantity1.unit, quantity2.unit))
+        # Compare the values stripped of the units.
+        quantity1 = quantity1.value_in_unit_system(unit.md_unit_system)
+        quantity2 = quantity2.value_in_unit_system(unit.md_unit_system)
+    return np.allclose(quantity1, quantity2)
+
+
+def get_context_potential_energy(context, positions, box_vectors=None,
+                                 by_force_group=True):
+    """Compute the potential energy of a System in a Context object.
+
+    This is simply a shortcut that takes care of setting
+    box vectors and positions before computing the energy.
+
+    Parameters
+    ----------
+    context : simtk.openmm.Context
+        The Context object containing the system.
+    positions : simtk.unit.Quantity
+        A n_atoms x 3 arrays of coordinates with units of length.
+    box_vectors : simtk.unit.Quantity, optional
+        If specified, this should be a 3 x 3 array. Each row should
+        be a box vector.
+    by_force_group : bool, optional
+        If True, it returns a dictionary mapping force groups to
+        their potential energies. Default is True.
+
+    Returns
+    -------
+    potential_energy : simtk.unit.Quantity or Dict[type, Quantity]
+        The potential energy of the system at the given coordinates.
+        If ``by_force_group`` is True, then this is a dictionary
+        mapping force groups to their potential energy.
+
+    """
+    # Box vectors must be updated before positions are set.
+    if box_vectors is not None:
+        context.setPeriodicBoxVectors(*box_vectors)
+    context.setPositions(positions)
+
+    # If we don't have energies by force group,
+    # just return the energy of the full System.
+    if not by_force_group:
+        return context.getState(getEnergy=True).getPotentialEnergy()
+
+    # Determine how many force groups we need to compute.
+    force_groups = {f.getForceGroup() for f in context.getSystem().getForces()}
+
+    # Compute potential energies of all groups.
+    potential_energies = {}
+    for force_group in force_groups:
+        state = context.getState(getEnergy=True, groups={force_group})
+        potential_energies[force_group] = state.getPotentialEnergy()
+    return potential_energies
+
+
+class FailedEnergyComparisonError(AssertionError):
+    """Error raised when the energy comparison between two system fails.
+
+    Attributes
+    ----------
+    potential_energy1
+    potential_energy2
+
+    """
+    def __init__(self, err_msg, potential_energy1, potential_energy2):
+        super().__init__(err_msg)
+        self.potential_energy1 = potential_energy1
+        self.potential_energy2 = potential_energy2
+
+
+def compare_context_energies(context1, context2, *args, **kwargs):
+    """Compare energies of two Contexts given the same positions.
+
+    Parameters
+    ----------
+    context1 : simtk.openmm.Context
+        The first Context object to compare containing the system.
+    context2 : simtk.openmm.Context
+        The second Context object to compare containing the system.
+    positions : simtk.unit.Quantity
+        A n_atoms x 3 arrays of coordinates with units of length.
+    box_vectors : simtk.unit.Quantity, optional
+        If specified, this should be a 3 x 3 array. Each row should
+        be a box vector.
+    by_force_group : bool, optional
+        If True, the energies of each force groups are compared.
+        Default is True.
+
+    Returns
+    -------
+    potential_energy1 : simtk.unit.Quantity or Dict[int, Quantity]
+        The potential energy of context1 at the given coordinates.
+        If ``by_force_group`` is True, then this is a dictionary
+        mapping force groups to their potential energy.
+    potential_energy2 : simtk.unit.Quantity or Dict[int, Quantity]
+        The potential energy of context2 at the given coordinates.
+        If ``by_force_group`` is True, then this is a dictionary
+        mapping force groups to their potential energy.
+
+    Raises
+    ------
+    FailedEnergyComparisonError
+        If the potential energies of the two contexts are different
+        or if the two Systems in the contexts have forces divided into
+        different force groups. The potential energies of context1 and
+        context2 can be accessed in the Exception through the attributes
+        potential_energy1 and potential_energy2 respectively.
+
+    """
+    potential_energy1 = get_context_potential_energy(context1, *args, **kwargs)
+    potential_energy2 = get_context_potential_energy(context2, *args, **kwargs)
+
+    def raise_assert(assertion, err_msg, format_args):
+        """Shortcut to raise a custom error and format the error message."""
+        if not assertion:
+            raise FailedEnergyComparisonError(
+                err_msg.format(*format_args), potential_energy1, potential_energy2
+            )
+
+    # If by_force_group is True, then the return value will be a
+    # dictionary and we need to compare force group by force group.
+    if isinstance(potential_energy1, unit.Quantity):
+        raise_assert(
+            assertion=quantities_allclose(potential_energy1, potential_energy2),
+            err_msg='potential energy 1 {}, potential energy 2: {}',
+            format_args=(potential_energy1, potential_energy2)
+        )
+    else:  # potential_energy1 is a dict.
+        # If the two context expose different force groups raise an error.
+        raise_assert(
+            assertion=set(potential_energy1) == set(potential_energy2),
+            err_msg='The two contexts have different force groups: context1 {}, context2 {}',
+            format_args=(sorted(potential_energy1), sorted(potential_energy2))
+        )
+
+        # Check the potential energies of all force groups.
+        for force_group in potential_energy1:
+            energy1 = potential_energy1[force_group]
+            energy2 = potential_energy2[force_group]
+            raise_assert(
+                assertion=quantities_allclose(energy1, energy2),
+                err_msg='Force group {} do not have the same energies: context1 {}, context2 {}',
+                format_args=(force_group, energy1, energy2)
+            )
+
+    return potential_energy1, potential_energy2
+
+
+def compare_system_energies(system1, system2, positions, box_vectors=None,
+                            by_force_type=True, modify_system=False):
+    """Compare energies of two Systems given the same positions.
+
+    Parameters
+    ----------
+    system1 : simtk.openmm.System
+        The first Context object to compare containing the system.
+    system2 : simtk.openmm.System
+        The second Context object to compare containing the system.
+    positions : simtk.unit.Quantity
+        A n_atoms x 3 arrays of coordinates with units of length.
+    box_vectors : simtk.unit.Quantity, optional
+        If specified, this should be a 3 x 3 array. Each row should
+        be a box vector.
+    by_force_type : bool, optional
+        If True, the contribution to the energy of each force type
+        is compared instead of just the overall potential energy.
+        Default is True.
+    modify_system : bool, optional
+        If ``by_force_type`` is True, the function will change the
+        force groups of two ``Systems`` to compute the separate
+        contributions. Set this to False to work on a copy and avoid
+        modifying the original objects. Default is False.
+
+    Returns
+    -------
+    potential_energy1 : simtk.unit.Quantity or Dict[str, Quantity]
+        The potential energy of context1 at the given coordinates.
+        If ``by_force_type`` is True, then this is a dictionary
+        mapping force names to their potential energy.
+    potential_energy2 : simtk.unit.Quantity or Dict[str, Quantity]
+        The potential energy of context2 at the given coordinates.
+        If ``by_force_type`` is True, then this is a dictionary
+        mapping force names to their potential energy.
+
+    Raises
+    ------
+    FailedEnergyComparisonError
+        If the potential energies of the two contexts are different
+        or if the two Systems in the contexts have forces divided into
+        different force groups. The potential energies of context1 and
+        context2 can be accessed in the Exception through the attributes
+        potential_energy1 and potential_energy2 respectively.
+
+    """
+    if by_force_type:
+        if not modify_system:
+            system1 = copy.deepcopy(system1)
+            system2 = copy.deepcopy(system2)
+
+        # First check that the two systems have the same force types.
+        force_names1 = {f.__class__.__name__ for f in system1.getForces()}
+        force_names2 = {f.__class__.__name__ for f in system2.getForces()}
+        err_msg = 'The two systems have difference force types: system1 {}, system2 {}'
+        assert force_names1 == force_names2, err_msg.format(force_names1, force_names2)
+
+        # Create a map from force group to force class and viceversa.
+        group_to_force = {i: force_name for i, force_name in enumerate(force_names1)}
+        force_to_group = {force_name: i for i, force_name in group_to_force.items()}
+
+        # Assign force groups.
+        for system in [system1, system2]:
+            for force in system.getForces():
+                force.setForceGroup(force_to_group[force.__class__.__name__])
+
+    # Create Contexts and compare the energies.
+    integrator = openmm.VerletIntegrator(1.0*unit.femtoseconds)
+    context1 = openmm.Context(system1, integrator)
+    context2 = openmm.Context(system2, copy.deepcopy(integrator))
+
+    def map_energies_by_force_type(potential_energy1, potential_energy2):
+        """Convert dictionary force_group -> energy to force_type -> energy."""
+        potential_energy1 = {group_to_force[group]: energy
+                             for group, energy in potential_energy1.items()}
+        potential_energy2 = {group_to_force[group]: energy
+                             for group, energy in potential_energy2.items()}
+        return potential_energy1, potential_energy2
+
+    # Catch the exception and log table force type -> energy.
+    try:
+        potential_energy1, potential_energy2 = compare_context_energies(
+            context1, context2, positions, box_vectors,
+            by_force_group=by_force_type
+        )
+    except FailedEnergyComparisonError as e:
+        # We don't need to convert force groups into force types
+        if not by_force_type:
+            raise
+        # Add to the error message the table of energies by force type.
+        potential_energy1, potential_energy2 = map_energies_by_force_type(
+            e.potential_energy1, e.potential_energy2
+        )
+        # Pretty-print the dictionaries.
+        table = '\n\npotential energy system1:\n' + pprint.pformat(potential_energy1)
+        table += '\n\npotential energy system2:\n{}' + pprint.pformat(potential_energy2)
+        raise type(e)(str(e) + table, e.potential_energy1, e.potential_energy2)
+
+    return potential_energy1, potential_energy2
+
+
+#=============================================================================================
+# Utility functions for parameters comparisons.
+#=============================================================================================
+
+class _ParametersComparer:
+    """This is just a convenience class to compare and print parameters.
+
+    Parameters
+    ----------
+    **kwargs
+        All the parameters to compare.
+
+    Attributes
+    ----------
+    parameters : dict
+        The dictionary of parameters.
+
+    Examples
+    --------
+    >>> import copy
+    >>> from simtk import unit
+    >>> par1 = _ParametersComparer(charge=1.0*unit.elementary_charge,
+    ...                            rmin_half=1.5*unit.angstrom)
+    >>> par2 = copy.deepcopy(par1)
+    >>> par3 = _ParametersComparer(charge=-1.0*unit.elementary_charge,
+    ...                            rmin_half=0.15*unit.nanometers)
+    >>> par1 == par2
+    True
+    >>> par1 == par3
+    False
+    >>> str(par1)
+    '(charge: 1 e**2, rmin_half: 0.15 nm)'
+
     """
 
-    # Create integrator
-    timestep = 1.0 * unit.femtoseconds
-    integrator0 = simtk.openmm.VerletIntegrator( timestep )
-    integrator1 = simtk.openmm.VerletIntegrator( timestep )
+    def __init__(self, **parameters):
+        self.parameters = parameters
 
-    # Grab second positions
-    if positions1 == None:
-        positions1 = copy.deepcopy( positions0 )
+    def __eq__(self, other):
+        for par_name, par1_value in self.parameters.items():
+            par2_value = other.parameters[par_name]
+            # Determine whether this parameter is close or not.
+            if not quantities_allclose(par1_value, par2_value):
+                return False
+        return True
 
-    # Create simulations
-    platform = simtk.openmm.Platform.getPlatformByName("Reference")
+    def __str__(self):
+        # Reorder the parameters to print in deterministic order.
+        parameter_order = sorted(self.parameters)
+        # Quantities in a dictionary are normally printed in the
+        # format "Quantity(value, unit=unit)" so we make it prettier.
+        par_str = ', '.join('{}: {}'.format(p, self.parameters[p]) for p in parameter_order)
+        return '(' + par_str + ')'
 
-    simulation0 = app.Simulation( topology0, system0, integrator0, platform = platform )
-    simulation0.context.setPositions(positions0)
-    simulation1 = app.Simulation( topology1, system1, integrator1, platform = platform )
-    simulation1.context.setPositions(positions1)
 
-    # Print what torsions were found if verbose
-    if verbose:
-        # Build list of atoms for debugging info
-        atoms0 = [ atom for atom in simulation0.topology.atoms() ]
-        atoms1 = [ atom for atom in simulation1.topology.atoms() ]
-        # Loop over first system and print torsion info
-        for force in simulation0.system.getForces():
-            if type(force) == mm.PeriodicTorsionForce:
-                print("Num (type) \t Num (type) \t Num (type) \t Num (type) \t per \t phase \t k0")
-                for k in range(force.getNumTorsions()):
-                    i0, i1, i2, i3, per, phase, k0 = force.getTorsionParameters(k)
-                    print("%3s (%3s)- %3s (%3s)- \t %s (%3s)- \t %3s (%3s)- \t %f \t %f \t %f " % (i0, atoms0[i0].name, i1, atoms0[i1].name, i2, atoms0[i2].name, i3, atoms0[i3].name, per, phase/unit.degree, k0/unit.kilojoule_per_mole) )
-        for force in simulation1.system.getForces():
-            if type(force) == mm.PeriodicTorsionForce:
-                print("Num (type) \t Num (type) \t Num (type) \t Num (type) \t per \t phase \t k0")
-                for k in range(force.getNumTorsions()):
-                    i0, i1, i2, i3, per, phase, k0 = force.getTorsionParameters(k)
-                    print("%3s (%3s)- %3s (%3s)- %3s (%3s)- %3s (%3s) - %f \t %f \t %f " % (i0, atoms1[i0].name, i1, atoms1[i1].name, i2, atoms1[i2].name, i3, atoms1[i3].name, per, phase/unit.degree, k0/unit.kilojoule_per_mole) )
+class _TorsionParametersComparer:
+    """A ParametersComparer class for torsions.
 
-    # Do energy comparison, print info if desired
-    syscheck = system_checker.SystemChecker( simulation0, simulation1 )
-    if not skip_assert:
-        # Only check force terms if we want to make sure energies are identical
-        syscheck.check_force_parameters(skipImpropers = skip_improper)
-    groups0, groups1 = syscheck.check_energy_groups(skip_assert = skip_assert)
-    energy0, energy1 = syscheck.check_energies(skip_assert = skip_assert)
-    if verbose:
-        print("Energy of %s: " % label0, energy0 )
-        print("Energy of %s: " % label1, energy1 )
-        print("\nComponents of %s:" % label0 )
-        for key in groups0.keys():
-            print("%s: " % key, groups0[key] )
-        print("\nComponents of %s:" % label1 )
-        for key in groups1.keys():
-            print("%s: " % key, groups1[key] )
+    Torsions require a different comparison because multiple set of
+    (periodicity, phase, k) parameters can be associated to the same
+    four atoms.
 
-    # Return
-    return groups0, groups1, energy0, energy1
+    Parameters
+    ----------
+    *parameters
+        Variable length arguments. Each is a _ParametersComparer instance.
 
-def compare_molecule_energies( prmtop, crd, forcefield, mol, verbose = True, skip_assert=False, skip_improper = False):
+    Attributes
+    ----------
+    parameters : List[_ParametersComparer]
+        The list of _ParametersComparer instances.
+
+    Examples
+    --------
+    >>> from simtk import unit
+    >>> par1 = _ParametersComparer(periodicity=2, phase=0.0*unit.degrees)
+    >>> par2 = _ParametersComparer(periodicity=4, phase=180.0*unit.degrees)
+    >>> torsion_par = _TorsionParametersComparer(par1, par2)
+
+    """
+
+    def __init__(self, *parameters):
+        # *args is a tuple. Convert it to a list to make it appendable.
+        self.parameters = list(parameters)
+
+    def __eq__(self, other):
+        # Find at least 1 set of parameters in the list that are equal.
+        for parameters1 in self.parameters:
+            if all(parameters1 != parameters2 for parameters2 in other.parameters):
+                return False
+        return True
+
+    def __str__(self):
+        # Reorder the parameters by periodicity to print in deterministic order.
+        parameters = sorted(self.parameters, key=lambda x: x['periodicity'])
+        # Quantities in a dictionary are normally printed in the
+        # format "Quantity(value, unit=unit)" so we make it prettier.
+        return '[' + ', '.join(str(pars) for pars in parameters) + ']'
+
+
+class FailedParameterComparisonError(AssertionError):
+    """Error raised when the parameter comparison between two forces fails.
+
+    Attributes
+    ----------
+    different_parameters : Dict[Hashable, Tuple[_ParameterComparer]]
+        All the parameters for which a differences was detected.
+        different_parameters[atom_indices] is a tuple
+        (parameter_force1, parameter_force2).
+
+    """
+    def __init__(self, err_msg, different_parameters):
+        super().__init__(err_msg)
+        self.different_parameters = different_parameters
+
+
+def _compare_parameters(parameters_force1, parameters_force2, interaction_type):
+    """Compare the parameters of 2 forces and raises an exception if they are different.
+
+    Parameters
+    ----------
+    parameters_force1 : Dict[Hashable, _ParametersComparer]
+        A dictionary associating a _ParametersComparer entry to a key
+        that is usually a set of atom indices (e.g., the atom index
+        for nonbonded interactions, two atom indices for bonds and
+        1-4 exceptions, 3 indices for angles, and 4 for torsions).
+    parameters_force2 : Dict[Hashable, _ParametersComparer]
+        The parameters of the force to compare.
+    interaction_type : str
+        A string describing the type of interactions (e.g., "bond",
+        "particle exception", "proper torsion"). This is only used to
+        improve the error message where differences between the two
+        forces are detected.
+
+    Raises
+    ------
+    FailedParameterComparisonError
+        If there are differences in the parameters of the two forces.
+        The exceptions exposes an attribute ``different_parameters``
+        with the different parameters.
+
+    """
+    diff_msg = ''
+
+    # First check the parameters that are unique to only one of the forces.
+    unique_keys1 = set(parameters_force1) - set(parameters_force2)
+    unique_keys2 = set(parameters_force2) - set(parameters_force1)
+    err_msg = '\n\nForce{} has the following unique ' + interaction_type + 's: {}\n'
+    if len(unique_keys1) != 0:
+        diff_msg += err_msg.format(1, sorted(unique_keys1))
+    if len(unique_keys2) != 0:
+        diff_msg += err_msg.format(2, sorted(unique_keys2))
+
+    # Create a diff for entries that have same keys but different parameters.
+    different_parameters = {}
+    for key in set(parameters_force1).intersection(set(parameters_force2)):
+        if parameters_force1[key] != parameters_force2[key]:
+            different_parameters[key] = (parameters_force1[key], parameters_force2[key])
+
+    # Print error.
+    if len(different_parameters) > 0:
+        diff_msg += ('\n\nThe following {}s have different parameters '
+                     'in the two forces:'.format(interaction_type))
+        for key, (param1, param2) in different_parameters.items():
+            diff_msg += '\n{}: {} != {}'.format(key, param1, param2)
+
+    if diff_msg != '':
+        diff_msg = ('A difference between {} was detected. '
+                    'Details follow.').format(interaction_type) + diff_msg
+        raise FailedParameterComparisonError(diff_msg + '\n', different_parameters)
+
+
+@functools.singledispatch
+def _get_force_parameters(force, system):
+    """This function builds a _ParameterComparer representation of the
+    force parameters that can be used for comparison to other forces
+    with _compare_parameters.
+
+    Each _ParameterComparer must be associated to a key, which is usually
+    a tuple of atom indices (e.g., the atom index for nonbonded interactions,
+    two atom indices for bonds and 1-4 exceptions, 3 indices for angles,
+    and 4 for torsions).
+
+    A single force can generate multiple representations (e.g., a NonbondedForce
+    can generate one representations for particle parameters and one for
+    parameter exceptions.
+
+    Parameters
+    ----------
+    force
+        The OpenMM Force object.
+    system : simtk.openmm.System
+        The System to which this force belongs to.
+
+    Returns
+    -------
+    force_parameters : Dict[str, Dict[Hashable, _ParameterComparer]]
+        The parameter representation. force_parameters[interaction_type]
+        is a dictionary mapping a tuple of atom indices to the
+        associated parameters. interaction_type can be any string
+        identifying the type of parameters (e.g. "particle exception",
+        "proper torsion", "bond").
+
+    """
+    raise NotImplementedError('Comparison between {}s is not currently '
+                              'supported.'.format(type(force)))
+
+
+@_get_force_parameters.register(openmm.HarmonicBondForce)
+def _get_bond_force_parameters(force, _):
+    """Implementation of _get_force_parameters for HarmonicBondForces."""
+    # Build the dictionary of the parameters of a single force.
+    force_parameters = {}
+    for bond_idx in range(force.getNumBonds()):
+        atom1, atom2, r0, k = force.getBondParameters(bond_idx)
+
+        # Ignore bonds with 0.0 spring constant that don't affect the energy.
+        if (k / k.unit) == 0.0:
+            continue
+
+        # Reorder the bond to have a canonical key.
+        bond_key = tuple(sorted([atom1, atom2]))
+        force_parameters[bond_key] = _ParametersComparer(r0=r0, k=k)
+
+    return {'bond': force_parameters}
+
+
+@_get_force_parameters.register(openmm.HarmonicAngleForce)
+def _get_angle_force_parameters(force, _):
+    """Implementation of _get_force_parameters for HarmonicAngleForces."""
+    # Build the dictionary of the parameters of a single force.
+    force_parameters = {}
+    for angle_idx in range(force.getNumAngles()):
+        atom1, atom2, atom3, theta0, k = force.getAngleParameters(angle_idx)
+
+        # Ignore angles with 0.0 spring constant that don't affect the energy.
+        if (k / k.unit) == 0.0:
+            continue
+
+        # Reorder the bond to have a canonical key.
+        angle_key = min(atom1, atom3), atom2, max(atom1, atom3)
+        force_parameters[angle_key] = _ParametersComparer(theta0=theta0, k=k)
+
+    return {'angle': force_parameters}
+
+
+@_get_force_parameters.register(openmm.NonbondedForce)
+def _get_nonbonded_force_parameters(force, _):
+    """Implementation of _get_force_parameters for NonbondedForces."""
+    # Build the dictionary of the particle parameters of the force.
+    particle_parameters = {}
+    for particle_idx in range(force.getNumParticles()):
+        charge, sigma, epsilon = force.getParticleParameters(particle_idx)
+
+        # Ignore sigma parameter if epsilon is 0.0.
+        particle_parameters[particle_idx] = _ParametersComparer(
+            charge=charge, epsilon=epsilon)
+        if (epsilon / epsilon.unit) != 0.0:
+            particle_parameters[particle_idx].parameters['sigma'] = sigma
+
+    # Build the dictionary representation of the particle exceptions.
+    exception_parameters = {}
+    for exception_idx in range(force.getNumExceptions()):
+        atom1, atom2, chargeprod, sigma, epsilon = force.getExceptionParameters(exception_idx)
+
+        # Reorder the atom indices to have a canonical key.
+        exception_key = tuple(sorted([atom1, atom2]))
+        exception_parameters[exception_key] = _ParametersComparer(
+            chargeprod=chargeprod, epsilon=epsilon, sigma=sigma)
+
+    return {'particle': particle_parameters, 'particle exception': exception_parameters}
+
+
+@_get_force_parameters.register(openmm.PeriodicTorsionForce)
+def _get_torsion_force_parameters(force, system):
+    """Implementation of _get_force_parameters for NonbondedForces."""
+    # Find all bonds. We'll use this to distinguish
+    # between proper and improper torsions.
+    bond_set = _find_all_bonds(system)
+
+    proper_parameters = {}
+    improper_parameters = {}
+    for torsion_idx in range(force.getNumTorsions()):
+        atom1, atom2, atom3, atom4, periodicity, phase, k = force.getTorsionParameters(torsion_idx)
+
+        # Ignore torsions that don't contribute to the energy.
+        if (k / k.unit) == 0.0:
+            continue
+
+        torsion_key = [atom1, atom2, atom3, atom4]
+        if len(set(torsion_key)) != 4:
+            raise ValueError('Torsion {} is defined on less than 4 atoms: {}'.format(torsion_key))
+
+        # Check if this is proper or not.
+        torsion_bonds = [(torsion_key[i], torsion_key[i+1]) for i in range(3)]
+        is_proper = all(bond in bond_set for bond in torsion_bonds)
+
+        # Determine the canonical order of the torsion key.
+        if is_proper:
+            torsion_key = _get_proper_torsion_canonical_order(*torsion_key)
+            force_parameters = proper_parameters
+        else:
+            torsion_key = _get_improper_torsion_canonical_order(bond_set, *torsion_key)
+            force_parameters = improper_parameters
+
+        # Update the dictionary representation.
+        parameters = _ParametersComparer(periodicity=periodicity, phase=phase, k=k)
+        # Each set of 4 atoms can have multiple torsion terms.
+        try:
+            force_parameters[torsion_key].parameters.append(parameters)
+        except KeyError:
+            force_parameters[torsion_key] = _TorsionParametersComparer(parameters)
+
+    return {'proper torsion': proper_parameters, 'improper torsion': improper_parameters}
+
+
+def _find_all_bonds(system):
+    """Find all bonds in the given system
+
+    Parameters
+    ----------
+    system : simtk.openmm.System
+        A System object containing a HarmonicBondForce from which the
+        bonds are inferred.
+
+    Returns
+    -------
+    bond_set : Set[Tuple[int]]
+        A set of pairs (atom_index1, atom_index2) associated to bonds.
+        For each bond two pairs are created with the atom indices in
+        inverse order.
+
+    """
+    # Find the force with information on the bonds.
+    bond_force = [f for f in system.getForces() if isinstance(f, openmm.HarmonicBondForce)]
+    assert len(bond_force) == 1
+    bond_force = bond_force[0]
+
+    # Create a set of all bonds.
+    bond_set = set()
+    for bond_idx in range(bond_force.getNumBonds()):
+        atom1, atom2, _, _ = bond_force.getBondParameters(bond_idx)
+        bond_set.add((atom1, atom2))
+        bond_set.add((atom2, atom1))
+
+    return bond_set
+
+
+def _get_proper_torsion_canonical_order(i0, i1, i2, i3):
+    """Create a unique order of the 4 atom indices of a proper torsion.
+
+    The atom indices of a proper torsion are reordered so that the
+    first atom is the smallest index.
+
+    Parameters
+    ----------
+    i0, i1, i2, i3 : int
+        Atom indices of the proper torsion.
+
+    Returns
+    -------
+    j0, j1, j2, j3 : int
+        Reordered atom indices of the proper torsion.
+
+    """
+    if i0 < i3:
+        return i0, i1, i2, i3
+    else:
+        return i3, i2, i1, i0
+
+
+def _get_improper_torsion_canonical_order(bond_set, i0, i1, i2, i3):
+    """Create a unique order of the 4 atom indices of an improper torsion.
+
+    Return j0, j1, j2, j3, where j0 is the central index and j1, j2, j3
+    are in sorted() order. The centrality is determined by the maximum
+    counts in the adjacency matrix.
+
+    Parameters
+    ----------
+    bond_set : set
+        The set of all bonds as determined by _find_all_bonds.
+    i0, i1, i2, i3 : int,
+        Atom indices of the improper torsion.
+
+    Returns
+    -------
+    j0, j1, j2, j3 : int
+        Reordered atom indices of the improper torsion, with j0 being
+        the central index.
+
+    """
+    connections = np.zeros((4, 4))
+
+    mapping = {i0: 0, i1: 1, i2: 2, i3: 3}
+    inv_mapping = dict([(val, key) for key, val in mapping.items()])
+
+    for (a, b) in itertools.combinations([i0, i1, i2, i3], 2):
+        if (a, b) in bond_set:
+            i, j = mapping[a], mapping[b]
+            connections[i, j] += 1.
+            connections[j, i] += 1.
+
+    central_ind = connections.sum(0).argmax()
+    central_ind = inv_mapping[central_ind]
+    other_ind = sorted([i0, i1, i2, i3])
+    other_ind.remove(central_ind)
+
+    return central_ind, other_ind[0], other_ind[1], other_ind[2]
+
+
+def compare_system_parameters(system1, system2):
+    """Check that two OpenMM systems have the same parameters.
+
+    Parameters
+    ----------
+    system1 : simtk.openmm.System
+        The first system to compare.
+    system2 : simtk.openmm.System
+        The second system to compare.
+
+    Raises
+    ------
+    FailedParameterComparisonError
+        If there are differences in the parameters of the two forces.
+        The exceptions exposes an attribute ``different_parameters``
+        with the different parameters.
+
+    """
+    # We need to perform some checks on the type and number of forces in the Systems.
+    force_names1 = collections.Counter(f.__class__.__name__ for f in system1.getForces())
+    force_names2 = collections.Counter(f.__class__.__name__ for f in system2.getForces())
+    err_msg = 'Only systems having 1 force per type are supported.'
+    assert set(force_names1.values()) == {1}, err_msg
+    assert set(force_names2.values()) == {1}, err_msg
+
+    # Check that the two systems have the same forces.
+    err_msg = 'The two Systems have different forces: system1 {}, system2 {}'
+    assert set(force_names1) == set(force_names2), err_msg.format(force_names1, force_names2)
+
+    # Find all the pair of forces to compare.
+    force_pairs = {force_name: [] for force_name in force_names1}
+    for system in [system1, system2]:
+        for force in system.getForces():
+            force_pairs[force.__class__.__name__].append(force)
+
+    # Compare all pairs of forces
+    for force_name, (force1, force2) in force_pairs.items():
+        parameters_force1 = _get_force_parameters(force1, system1)
+        parameters_force2 = _get_force_parameters(force2, system2)
+        for parameter_type, parameters1 in parameters_force1.items():
+            parameters2 = parameters_force2[parameter_type]
+            _compare_parameters(parameters1, parameters2,
+                                interaction_type=parameter_type)
+
+
+#=============================================================================================
+# Utility functions to compare SMIRNOFF and AMBER force fields.
+#=============================================================================================
+
+def compare_molecule_energies(prmtop_filepath, inpcrd_filepath, forcefield, molecule):
     """
     Compare energies for OpenMM Systems/topologies created from an AMBER prmtop
     and crd versus from a SMIRNOFF forcefield file and OEMol which should
     parameterize the same system with same parameters.
+
     Parameters
     ----------
-    prmtop_filename : str (filename)
-        Filename of input AMBER format prmtop file
-    crd_filename : str (filename)
-        Filename of input AMBER format crd file
+    prmtop_filepath : str (filename)
+        Path to the topology/parameter file in AMBER prmtop format
+    inpcrd_filepath : str (filename)
+        Path to the coordinates file in AMBER inpcrd or rst7 format
     forcefield : ForceField
         SMIRNOFF forcefield
-    mol : oechem.OEMol
-        Molecule to test
-    verbose (optional): Bool
-        Print out info. Default: True
-    skip_assert : bool
-        Skip assertion that energies must be equal within tolerance. Default, False.
-    skip_improper (optional) : bool
-        Skip detailed checking of force terms on impropers (helpful here if comparing with AMBER force fields using different definitions of impropers.) Default False.
+    molecule : topology.molecule.Molecule
+        The molecule object to test.
+
     Returns
-    --------
-        groups0 : dict
-            As returned by openmoltools.system_checker.check_energy_groups,
-            a dictionary with keys "bond", "angle", "nb", "torsion" and values
-            corresponding to the energies of these components for the first simulation object
-        groups1 : dict
-            As returned by openmoltools.system_checker.check_energy_groups,
-            a dictionary with keys "bond", "angle", "nb", "torsion" and values
-            corresponding to the energies of these components for the second simulation object
-        energy0 : simtk.unit.Quantity
-            Energy of first system
-        energy1 : simtk.unit.Quantity
-            Energy of second system
+    -------
+    amber_energies : Dict[str, Quantity]
+        The potential energy of the AMBER system for each force type.
+    forcefield_energies : simtk.unit.Quantity or Dict[str, Quantity]
+        The potential energy of the ForceField system for each force type.
+
+    Raises
+    ------
+    FailedEnergyComparisonError
+        If the potential energies of the two systems are different
+        or if the two Systems in the contexts have forces divided into
+        different force groups. The potential energies of the AMBER and
+        ForceField systems can be accessed in the Exception through the
+        attributes potential_energy1 and potential_energy2 respectively.
+
     """
+    from openforcefield.topology import Topology
 
-    ambertop, ambersys, amberpos = create_system_from_amber( prmtop, crd )
-    smirfftop, smirffsys, smirffpos = create_system_from_molecule(forcefield, mol, verbose = verbose)
+    # Create System from AMBER files. By default, contrarily to ForceField,
+    # systems from AMBER files are created with removeCMMotion=True
+    amber_system, openmm_topology, positions = create_system_from_amber(
+        prmtop_filepath, inpcrd_filepath, removeCMMotion=False)
+    box_vectors = amber_system.getDefaultPeriodicBoxVectors()
 
-    groups0, groups1, energy0, energy1 = compare_system_energies( ambertop,
-               smirfftop, ambersys, smirffsys, amberpos, verbose = verbose, skip_assert = skip_assert, skip_improper = skip_improper )
+    # Create System from forcefield.
+    openff_topology = Topology.from_openmm(openmm_topology, unique_molecules=[molecule])
+    ff_system = forcefield.create_openmm_system(openff_topology)
 
-    return groups0, groups1, energy0, energy1
+    # Test energies.
+    compare_system_energies(amber_system, ff_system, positions, box_vectors)
+    compare_system_parameters(amber_system, ff_system)

--- a/openforcefield/tests/utils.py
+++ b/openforcefield/tests/utils.py
@@ -30,26 +30,28 @@ from openforcefield.utils import get_data_filename
 # Shortcut functions to get file paths to test data.
 #=============================================================================================
 
-
-def get_amber_system(prefix='cyclohexane_ethanol_0.4_0.6'):
-    """Get AMBER prmtop and inpcrd test data filenames
+def get_amber_filepath(prefix):
+    """Get AMBER prmtop and inpcrd test data filepaths.
 
     Parameters
     ----------
-    prefix : str, optional, default='cyclohexane_ethanol_0.4_0.6'
-        The prefix of .prmtop and .inpcrd files to retrieve from testdata/systems/amber
+    prefix : str
+        The file name without extension of .prmtop and .inpcrd
+        files to retrieve from testdata/systems/amber.
 
     Returns
     -------
-    prmtop_filename : str
-        Absolute path to the AMBER prmtop filename in testdata/systems/amber
-    inpcrd_filename : str
-        Absolute path to the AMBER inpcrd filename in testdata/systems/amber
+    prmtop_filepath : str
+        Absolute path to the AMBER prmtop filepath in testdata/systems/amber
+    inpcrd_filepath : str
+        Absolute path to the AMBER inpcrd filepath in testdata/systems/amber
+
     """
     prefix = os.path.join('systems', 'amber', prefix)
-    prmtop_filename = get_data_filename(prefix+'.prmtop')
-    inpcrd_filename = get_data_filename(prefix+'.inpcrd')
-    return prmtop_filename, inpcrd_filename
+    prmtop_filepath = get_data_filename(prefix+'.prmtop')
+    inpcrd_filepath = get_data_filename(prefix+'.inpcrd')
+    return prmtop_filepath, inpcrd_filepath
+
 
 def get_packmol_pdbfile(prefix='cyclohexane_ethanol_0.4_0.6'):
     """Get PDB filename for a packmol-generated box
@@ -67,6 +69,7 @@ def get_packmol_pdbfile(prefix='cyclohexane_ethanol_0.4_0.6'):
     prefix = os.path.join('systems', 'packmol_boxes', prefix)
     pdb_filename = get_data_filename(prefix+'.pdb')
     return pdb_filename
+
 
 def get_monomer_mol2file(prefix='ethanol'):
     """Get absolute filepath for a mol2 file denoting a small molecule monomer in testdata


### PR DESCRIPTION
In this PR:
- Fixed unit specification of `cutoff` and `switch` in `Frosst_AlkEthOH_parmAtFrosst.offxml` according to the new specification.
- Reimplemented and renamed the function `openforcefield/tests/utils.py:compare_molecule_energies` to `compare_amber_smirnoff`.
- Fixed the syntax errors in the example `SMIRNOFF_comparison/compare_molecule_energies.py` and `SMIRNOFF_comparison/compare_set_energies.py`.

The old function `compare_molecule_energies()` used the [`SystemChecker`](https://github.com/choderalab/openmoltools/blob/master/openmoltools/system_checker.py) class in `openmoltools`, and we removed that dependency in the `topology` branch. Here, I've added a few functions to perform the same task. The implementation is hopefully a little more concise with less redundant code (there's a lot of new lines but about half of them are docstrings).

Currently `compare_molecule_energies.py` is successful while `compare_set_energies.py` still fails with the error
```
Traceback (most recent call last):
  File "compare_set_energies.py", line 39, in <module>
    results = compare_amber_smirnoff(prmtop_filepath, inpcrd_filepath, forcefield, molecule)
  File "/Users/andrea/miniconda/envs/openforcefield/lib/python3.6/site-packages/openforcefield-0.1+260.ge074487.dirty-py3.6.egg/openforcefield/tests/utils.py", line 918, in compare_amber_smirnoff
  File "/Users/andrea/miniconda/envs/openforcefield/lib/python3.6/site-packages/openforcefield-0.1+260.ge074487.dirty-py3.6.egg/openforcefield/topology/topology.py", line 1390, in from_openmm
Exception: No match found for molecule
```
I plan to look into it in a separate PR.