### PR TITLE
Fix ConstraintHandler

### DIFF
--- a/openforcefield/tests/utils.py
+++ b/openforcefield/tests/utils.py
@@ -1009,6 +1009,12 @@ def _find_all_bonds(system):
         bond_set.add((atom1, atom2))
         bond_set.add((atom2, atom1))
 
+    # Find all the constrained bonds, which do not have a HarmonicBondForce term.
+    for constraint_idx in range(system.getNumConstraints()):
+        atom1, atom2, distance = system.getConstraintParameters(constraint_idx)
+        bond_set.add((atom1, atom2))
+        bond_set.add((atom2, atom1))
+
     return bond_set
 
 

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -289,7 +289,7 @@ class ForceField(object):
             #tagname = subclass._TAGNAME
             tagname = parameter_handler_class._TAGNAME
             if tagname is not None:
-                if tagname in self._parameter_handler_classes.keys():
+                if tagname in self._parameter_handler_classes:
                     raise Exception(
                         "ParameterHandler {} provides a parser for tag '{}', but ParameterHandler {} has "
                         "already been registered to handle that tag.".format(
@@ -491,11 +491,11 @@ class ForceField(object):
         KeyError if there is no ParameterHandler for the given tagname
         """
         handler = None
-        if tagname in self._parameter_handlers.keys():
+        if tagname in self._parameter_handlers:
             # If handler already exists, make sure it is compatible
             handler = self._parameter_handlers[tagname]
             handler.check_handler_compatibility(handler_kwargs)
-        elif tagname in self._parameter_handler_classes.keys():
+        elif tagname in self._parameter_handler_classes:
             new_ph_class = self._parameter_handler_classes[tagname]
             handler = self.register_parameter_handler(new_ph_class,
                                                       handler_kwargs)

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -399,17 +399,12 @@ class ConstraintHandler(ParameterHandler):
     class ConstraintType(ParameterType):
         """A SMIRNOFF constraint type"""
 
-        def __init__(self, node, parent):
-            super(ConstraintType, self).__init__(
-                **kwargs)  # Base class handles ``smirks`` and ``id`` fields
-            if 'distance' in node.attrib:
-                self.distance = _extract_quantity_from_xml_element(
-                    node, parent, 'distance'
-                )  # Constraint with specified distance will be added by ConstraintHandler
-            else:
-                self.distance = True  # Constraint to equilibrium bond length will be added by HarmonicBondHandler
+        def __init__(self, distance=True, **kwargs):
+            # Base class handles ``smirks`` and ``id`` fields
+            super().__init__(**kwargs)
+            self.distance = distance
 
-    _TAGNAME = 'Constraint'
+    _TAGNAME = 'Constraints'
     _VALENCE_TYPE = 'Bond'  # ChemicalEnvironment valence type expected for SMARTS # TODO: Do we support more exotic types as well?
     _INFOTYPE = ConstraintType
     _OPENMMTYPE = None  # don't create a corresponding OpenMM Force class
@@ -860,7 +855,7 @@ class ImproperTorsionHandler(ParameterHandler):
                     force.addTorsion(atom_indices[1], p[0], p[1], p[2],
                                      improper_periodicity, improper_phase, improper_k)
         logger.info(
-            '{} impropers added, each applied in a six-fold trefoil'.format(
+            '{} impropers added, each applied in a three-fold trefoil'.format(
                 len(impropers)))
 
         # Check that no topological torsions are missing force parameters


### PR DESCRIPTION
This resuscitates the `ConstraintHandler` and fixes a bug related to constraints and improper torsions in the code comparing the parameters of two `System`s.

I was going to use this PR to add the FreeSolv tests, but I encountered a lot of problems that I will summarize in #175, and I think will require some time to address. In the meantime, these changes are independent and can be merged into `topology`.