### PR TITLE
Improved RDKit stereo detection, fix Travis tests and warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,10 @@ install:
   - conda create -n test python=$PYTHON_VER pip pytest pytest-cov
   - source activate test
 
+  # TODO: Do we still need the beta version or can we do simply -c openeye openeye-toolkits?
   # Use beta version for partial bond orders
-  - if [[ "$OPENEYE" == true ]]; then conda install --yes -c openeye/label/Orion openeye-toolkits oeommtools && python -c "import openeye; print(openeye.__version__)"; fi
+  # TODO: Reactivate conda install instead of pip install once OpenEye is released for python 3.7 on conda-forge.
+  # - if [[ "$OPENEYE" == true ]]; then conda install --yes -c openeye/label/Orion openeye-toolkits oeommtools && python -c "import openeye; print(openeye.__version__)"; fi
 
   # Install RDKit
   - if [[ "$RDKIT" == true ]]; then conda install --yes -c rdkit rdkit; fi
@@ -78,6 +80,8 @@ install:
   # Install pip only modules
   - pip install codecov
   - pip install coverage==4.4
+  # TODO: Go back to conda install once OpenEye is released for python 3.7 on conda-forge.
+  - pip install -i https://pypi.anaconda.org/openeye/simple openeye-toolkits
 
   # Build and install package
   - conda build --python=$PYTHON_VER devtools/conda-recipe

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ install:
   - conda install --use-local openforcefield
 
 script:
-  - pytest -v -s --cov=openforcefield openforcefield/tests/
+  - pytest -v --cov=openforcefield openforcefield/tests/
 
 notifications:
     email: false

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -412,7 +412,7 @@ class TestForceField():
         assert serialized_1 == serialized_2
 
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.toolkit_is_available(), reason='Test requires OE toolkit')
+    @pytest.mark.skipif(not RDKitToolkitWrapper.toolkit_is_available(), reason='Test requires OE toolkit')
     def test_parameterize_ethanol_different_reference_ordering_rdkit(self):
         """
         Test parameterizing the same PDB, using reference mol2s that have different atom orderings.

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -602,6 +602,8 @@ def generate_alkethoh_parameters_assignment_cases():
     return fast_test_cases + slow_test_cases
 
 
+@pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(),
+                    reason='Test requires OE toolkit to read mol2 files')
 @pytest.mark.parametrize('alkethoh_id', generate_alkethoh_parameters_assignment_cases())
 def test_alkethoh_parameters_assignment(alkethoh_id):
     """Test that ForceField assign parameters correctly in the AlkEthOH set.
@@ -687,6 +689,8 @@ def generate_freesolv_parameters_assignment_cases():
     return fast_test_cases + slow_test_cases
 
 
+@pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(),
+                    reason='Test requires OE toolkit to read mol2 files')
 @pytest.mark.parametrize(('freesolv_id', 'forcefield_version', 'allow_undefined_stereo'),
                          generate_freesolv_parameters_assignment_cases())
 def test_freesolv_parameters_assignment(freesolv_id, forcefield_version, allow_undefined_stereo):

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -412,7 +412,7 @@ class TestForceField():
         assert serialized_1 == serialized_2
 
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.toolkit_is_available(), reason='Test requires OE toolkit')
+    @pytest.mark.skipif(not RDKitToolkitWrapper.toolkit_is_available(), reason='Test requires RDKit toolkit')
     def test_parameterize_ethanol_different_reference_ordering_rdkit(self):
         """
         Test parameterizing the same PDB, using reference mol2s that have different atom orderings.
@@ -427,7 +427,7 @@ class TestForceField():
         pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
 
         # Load the unique molecules with one atom ordering
-        molecules1 = [Molecule.from_file(get_data_filename('molecules/ethanol.mol2'))]
+        molecules1 = [Molecule.from_file(get_data_filename('molecules/ethanol.sdf'))]
         topology1 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules1,
                                          )
@@ -435,7 +435,7 @@ class TestForceField():
                                                       toolkit_registry=toolkit_registry)
 
         # Load the unique molecules with a different atom ordering
-        molecules2 = [Molecule.from_file(get_data_filename('molecules/ethanol_reordered.mol2'))]
+        molecules2 = [Molecule.from_file(get_data_filename('molecules/ethanol_reordered.sdf'))]
         topology2 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules2,
                                          )

--- a/openforcefield/tests/test_io.py
+++ b/openforcefield/tests/test_io.py
@@ -14,15 +14,7 @@ Test classes and function in module openforcefield.typing.engines.smirnoff.io.
 # GLOBAL IMPORTS
 #=============================================================================================
 
-import ast
-
 import pytest
-from simtk import unit
-
-from openforcefield.typing.engines.smirnoff.io import (
-    _ast_unit_eval,
-    _extract_attached_units,
-)
 
 
 #=============================================================================================
@@ -30,6 +22,7 @@ from openforcefield.typing.engines.smirnoff.io import (
 #=============================================================================================
 
 class TestXMLParameterIOHandler:
+
     def test_from_string(self):
         pass
 

--- a/openforcefield/tests/test_molecule.py
+++ b/openforcefield/tests/test_molecule.py
@@ -143,6 +143,12 @@ def mini_drug_bank(xfail_mols=None, wip_mols=None):
         to the failure reason.
 
     """
+    # We need OpenEye to parse the molecules, but pytest executes fixtures
+    # whether or not tests are skipped so if OE is not available we just
+    # return an empty list of test cases.
+    if not OpenEyeToolkitWrapper.is_available():
+        return []
+
     # If we have already loaded the data set, return the cached one.
     if mini_drug_bank.molecules is not None:
         molecules = mini_drug_bank.molecules

--- a/openforcefield/tests/test_molecule.py
+++ b/openforcefield/tests/test_molecule.py
@@ -892,7 +892,7 @@ class TestMolecule:
         molecule2 = Molecule.from_dict(molecule_dict)
         assert molecule.to_dict() == molecule2.to_dict()
 
-    @OpenEyeToolkitWrapper.requires_toolkit()
+    @requires_openeye
     def test_chemical_environment_matches_OE(self):
         """Test chemical environment matches"""
         # TODO: Move this to test_toolkits, test all available toolkits
@@ -934,7 +934,7 @@ class TestMolecule:
     # Potentially better OE stereo check: OEFlipper — Toolkits - - Python
     # https: // docs.eyesopen.com / toolkits / python / omegatk / OEConfGenFunctions / OEFlipper.html
 
-    @OpenEyeToolkitWrapper.requires_toolkit()
+    @requires_rdkit
     def test_chemical_environment_matches_RDKit(self):
         """Test chemical environment matches"""
         # Create chiral molecule

--- a/openforcefield/tests/test_molecule.py
+++ b/openforcefield/tests/test_molecule.py
@@ -43,7 +43,7 @@ from openforcefield.utils.toolkits import OpenEyeToolkitWrapper, RDKitToolkitWra
 
 requires_openeye = pytest.mark.skipif(not OpenEyeToolkitWrapper.toolkit_is_available(),
                                       reason='Test requires OE toolkit')
-requires_rdkit = pytest.mark.skipif(not OpenEyeToolkitWrapper.toolkit_is_available(),
+requires_rdkit = pytest.mark.skipif(not RDKitToolkitWrapper.toolkit_is_available(),
                                     reason='Test requires RDKit')
 
 

--- a/openforcefield/tests/test_molecule.py
+++ b/openforcefield/tests/test_molecule.py
@@ -303,12 +303,7 @@ class TestMolecule:
         graph = molecule.to_networkx()
 
     @requires_rdkit
-    @pytest.mark.parametrize('molecule', mini_drug_bank(
-        xfail_mols={
-            'DrugBank_2684': 'The RDKit round-trip assign incorrect info for the bond stereo',
-            'DrugBank_4346': 'The RDKit round-trip assign incorrect info for the bond stereo'
-        }
-    ))
+    @pytest.mark.parametrize('molecule', mini_drug_bank())
     def test_to_from_rdkit(self, molecule):
         """Test that conversion/creation of a molecule to and from an RDKit rdmol is consistent."""
         from openforcefield.utils.toolkits import UndefinedStereochemistryError
@@ -323,7 +318,8 @@ class TestMolecule:
             allow_undefined_stereo = True
         else:
             allow_undefined_stereo = False
-        molecule_copies.append(Molecule.from_rdkit(rdmol, allow_undefined_stereo=allow_undefined_stereo))
+        molecule_copies.append(Molecule.from_rdkit(
+            rdmol, allow_undefined_stereo=allow_undefined_stereo))
 
         for molecule_copy in molecule_copies:
             assert molecule == molecule_copy

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -74,6 +74,8 @@ class TestParameterList:
         p2 = ParameterType(smirks='[#1:1]')
         parameters = ParameterList([p1, p2])
 
+    @pytest.mark.wip(reason="Until ChemicalEnvironment won't be refactored to use the ToolkitRegistry "
+                            "API, the smirks assignment will fail with RDKit.")
     def test_getitem(self):
         """Test ParameterList __getitem__ overloading.
         """

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -62,25 +62,6 @@ class TestParameterHandler:
         assert abs(bh_dict['Bond'][0]['length'] - 100.) < 1.e-8
         assert abs(bh_dict['Bond'][1]['length'] - 200.) < 1.e-8
 
-    def test_to_dict_del_last_param(self):
-        """Test ParameterHandler.to_dict(), when the last-added parameter is deleted. The proper behavior is to
-        convert all unit-bearing attribs to the last-read unit, _even if that parameter was deleted_.
-        """
-        from simtk import unit
-        bh = BondHandler()
-        bh.add_parameter({'smirks': '[*:1]-[*:2]',
-                          'length': 1*unit.angstrom,
-                          'k': 10*unit.kilocalorie_per_mole/unit.angstrom**2})
-        bh.add_parameter({'smirks': '[*:1]=[*:2]',
-                          'length': 0.2*unit.nanometer,
-                          'k': 0.4*unit.kilojoule_per_mole/unit.nanometer**2})
-        del bh._parameters[1]
-        bh_dict = bh.to_dict()
-        assert ('length_unit', 'nanometer') in bh_dict.items()
-        assert ('k_unit', 'nanometer**-2 * mole**-1 * kilojoule') in bh_dict.items()
-        assert bh_dict['Bond'][0]['length'] == 0.1
-
-
 
 class TestParameterList:
     """Test capabilities of ParameterList for accessing and manipulating SMIRNOFF parameter definitions.
@@ -124,7 +105,7 @@ class TestParameterList:
         assert parameters.index('[*:1]') == 0
         assert parameters.index('[#1:1]') == 1
         assert parameters.index('[#7:1]') == 2
-        with pytest.raises(IndexError, match='SMIRKS \[#2:1\] not found in ParameterList') as excinfo:
+        with pytest.raises(IndexError, match=r'SMIRKS \[#2:1\] not found in ParameterList') as excinfo:
             parameters.index('[#2:1]')
 
         p4 = ParameterType(smirks='[#2:1]')
@@ -156,7 +137,7 @@ class TestParameterList:
 
         with pytest.raises(IndexError, match='list assignment index out of range'):
             del parameters[4]
-        with pytest.raises(IndexError, match='SMIRKS \[#6:1\] not found in ParameterList'):
+        with pytest.raises(IndexError, match=r'SMIRKS \[#6:1\] not found in ParameterList'):
             del parameters['[#6:1]']
 
         # Test that original list deletion behavior is preserved.
@@ -184,12 +165,10 @@ class TestParameterList:
         param_list.append(p1)
         assert len(param_list) == 1
         assert '[*:1]-[*:2]' in param_list
-        assert param_list.last_added_parameter == p1
         param_list.append(p2)
         assert len(param_list) == 2
         assert '[*:1]=[*:2]' in param_list
-        assert param_list.last_added_parameter == p2
-
+        assert param_list[-1] == p2
 
     def test_insert(self):
         """
@@ -201,7 +180,6 @@ class TestParameterList:
         p3 = ParameterType(smirks='[*:1]#[*:2]')
         param_list = ParameterList([p1, p2])
         param_list.insert(1, p3)
-        assert param_list.last_added_parameter == p3
         assert param_list[1] == p3
 
     def test_extend(self):
@@ -218,9 +196,7 @@ class TestParameterList:
         assert len(param_list1) == 2
         assert '[*:1]-[*:2]' in param_list1
         assert '[*:1]=[*:2]' in param_list1
-        assert param_list1.last_added_parameter == p2
-
-
+        assert param_list1[-1] == p2
 
     def test_to_list(self):
         """Test basic ParameterList.to_list() function, ensuring units are preserved"""
@@ -241,7 +217,6 @@ class TestParameterList:
         ser_param_list = parameter_list.to_list()
         assert len(ser_param_list) == 3
         assert ser_param_list[0]['length'] == 1.01 * unit.angstrom
-
 
     def test_round_trip(self):
         """Test basic ParameterList.to_list() function and constructor"""
@@ -265,9 +240,6 @@ class TestParameterList:
             new_parameter = BondHandler.BondType(**param_dict)
             parameter_list_2.append(new_parameter)
         assert parameter_list.to_list() == parameter_list_2.to_list()
-
-
-
 
 
 class TestParameterType:

--- a/openforcefield/tests/test_utils_serialization.py
+++ b/openforcefield/tests/test_utils_serialization.py
@@ -13,7 +13,8 @@ Tests for utility methods for serialization
 # GLOBAL IMPORTS
 #=============================================================================================
 
-from unittest import TestCase
+import pytest
+
 
 #=============================================================================================
 # TESTS
@@ -22,6 +23,7 @@ from unittest import TestCase
 from openforcefield.utils.serialization import Serializable
 
 class Thing(Serializable):
+
     def __init__(self, description, mylist):
         self.description = description
         self.mylist = mylist
@@ -30,18 +32,18 @@ class Thing(Serializable):
         return {
             'description' : self.description,
             'mylist' : self.mylist
-            }
+        }
 
-    @staticmethod
-    def from_dict(d):
-        return Thing(d['description'], d['mylist'])
+    @classmethod
+    def from_dict(cls, d):
+        return cls(d['description'], d['mylist'])
 
     def __eq__(self, other):
         """Comparator for asserting object field equality."""
-        equality = True
-        equality == equality and (self.description == other.description)
-        equality == equality and (self.mylist == other.mylist)
+        equality = self.description == other.description
+        equality &= self.mylist == other.mylist
         return equality
+
 
 # DEBUG
 def write(filename, contents):
@@ -54,62 +56,62 @@ def write(filename, contents):
     with open(filename, mode) as outfile:
         outfile.write(contents)
 
-class TestUtilsSerialization(TestCase):
+
+class TestUtilsSerialization:
     """Test serialization and deserialization of a simple class."""
 
-    def setUp(self):
-        # Create an example object
-        self.thing = Thing('blorb', [1,2,3])
-        self.thing_class = Thing
+    @classmethod
+    def setup_class(cls):
+        cls.thing = Thing('blorb', [1, 2, 3])
 
     def test_json(self):
         """Test JSON serialization"""
         json_thing = self.thing.to_json()
-        write('out.json', json_thing) # DEBUG
-        thing_from_json = self.thing_class.from_json(json_thing)
+        thing_from_json = self.thing.__class__.from_json(json_thing)
         assert self.thing == thing_from_json
 
     def test_yaml(self):
         """Test YAML serialization"""
         yaml_thing = self.thing.to_yaml()
-        write('out.yaml', yaml_thing) # DEBUG
-        thing_from_yaml = self.thing_class.from_yaml(yaml_thing)
+        thing_from_yaml = self.thing.__class__.from_yaml(yaml_thing)
         assert self.thing == thing_from_yaml
 
     def test_bson(self):
         """Test BSON serialization"""
         bson_thing = self.thing.to_bson()
-        write('out.bson', bson_thing) # DEBUG
-        thing_from_bson = self.thing_class.from_bson(bson_thing)
+        thing_from_bson = self.thing.__class__.from_bson(bson_thing)
         assert self.thing == thing_from_bson
 
+    @pytest.mark.wip(reason=("the current implementation of to_toml cannot handle dict "
+                             "keys associated to None (e.g. the ToolkitAM1BCC tag in the "
+                             "TestUtilsSMIRNOFFSerialization suite)."))
     def test_toml(self):
         """Test TOML serialization"""
         toml_thing = self.thing.to_toml()
-        write('out.toml', toml_thing) # DEBUG
-        thing_from_toml = self.thing_class.from_toml(toml_thing)
+        thing_from_toml = self.thing.__class__.from_toml(toml_thing)
         assert self.thing == thing_from_toml
 
     def test_messagepack(self):
         """Test MessagePack serialization"""
         messagepack_thing = self.thing.to_messagepack()
-        write('out.messagepack', messagepack_thing) # DEBUG
-        thing_from_messagepack = self.thing_class.from_messagepack(messagepack_thing)
+        thing_from_messagepack = self.thing.__class__.from_messagepack(messagepack_thing)
         assert self.thing == thing_from_messagepack
 
+    @pytest.mark.wip(reason='from/to_xml is not implemented yet. This test fails '
+                            'because the list of integers is saved in the XML as '
+                            'a list of numeric strings.')
     def test_xml(self):
         """Test XML serialization"""
         xml_thing = self.thing.to_xml()
-        write('out.xml', xml_thing) # DEBUG
-        thing_from_xml = self.thing_class.from_xml(xml_thing)
+        thing_from_xml = self.thing.__class__.from_xml(xml_thing)
         assert self.thing == thing_from_xml
 
     def test_pickle(self):
         """Test pickle serialization"""
         pkl_thing = self.thing.to_pickle()
-        write('out.pkl', pkl_thing) # DEBUG
-        thing_from_pkl = self.thing_class.from_pickle(pkl_thing)
+        thing_from_pkl = self.thing.__class__.from_pickle(pkl_thing)
         assert self.thing == thing_from_pkl
+
 
 class DictionaryContainer(Serializable):
     def __init__(self, dictionary):
@@ -127,10 +129,13 @@ class DictionaryContainer(Serializable):
         """Comparator for asserting object field equality."""
         return self.dictionary == other.dictionary
 
+
 class TestUtilsSMIRNOFFSerialization(TestUtilsSerialization):
     """Test serialization and deserialization of smirnoff99Frosst."""
 
-    def setUp(self):
+    @classmethod
+    def setup_class(cls):
+        cls.thing = Thing('blorb', [1, 2, 3])
         # Create an example object holding the SMIRNOFF xmltodict dictionary representation
         import xmltodict
         from openforcefield.utils import get_data_filename
@@ -138,5 +143,4 @@ class TestUtilsSMIRNOFFSerialization(TestUtilsSerialization):
         with open(filename, 'r') as f:
             xml = f.read()
             dictionary = xmltodict.parse(xml)
-            self.thing = DictionaryContainer(dictionary)
-            self.thing_class = DictionaryContainer
+            cls.thing = DictionaryContainer(dictionary)

--- a/openforcefield/tests/test_utils_structure.py
+++ b/openforcefield/tests/test_utils_structure.py
@@ -13,42 +13,47 @@ Tests for utility methods that involve parmed Structure manipulation
 # GLOBAL IMPORTS
 #=============================================================================================
 
-from functools import partial
-from unittest import TestCase
 import parmed
+
 from openforcefield import utils
+import openforcefield.utils.structure as structure
+
 
 #=============================================================================================
 # TESTS
 #=============================================================================================
 
-class TestUtils(TestCase):
+class TestUtilsStructure:
+
     def test_read_molecules(self):
-        molecules = utils.read_molecules('zinc-subset-tripos.mol2.gz', verbose=False)
+        molecules = structure.read_molecules('zinc-subset-tripos.mol2.gz', verbose=False)
+
     def test_positions(self):
         """Test ability to extract and set positions."""
-        molecules = utils.read_molecules('zinc-subset-tripos.mol2.gz', verbose=False)
-        positions = utils.extractPositionsFromOEMol(molecules[0])
-        utils.setPositionsInOEMol(molecules[0], positions)
+        molecules = structure.read_molecules('zinc-subset-tripos.mol2.gz', verbose=False)
+        positions = structure.extractPositionsFromOEMol(molecules[0])
+        structure.setPositionsInOEMol(molecules[0], positions)
+
     def test_smirnoff_structure(self):
-       """Test function that generates the SMIRNOFF parmed.Structure."""
-       molecule = utils.read_molecules('toluene.pdb', verbose=False)[0]
-       molecule_structure = utils.generateSMIRNOFFStructure(molecule)
-       self.assertIsInstance(molecule_structure, parmed.structure.Structure)
+        """Test function that generates the SMIRNOFF parmed.Structure."""
+        molecule = structure.read_molecules('toluene.pdb', verbose=False)[0]
+        molecule_structure = structure.generateSMIRNOFFStructure(molecule)
+        assert isinstance(molecule_structure, parmed.structure.Structure)
+
     def test_protein_structure(self):
         from simtk.openmm import app
         pdbfile = utils.get_data_filename('proteins/T4-protein.pdb')
         proteinpdb = app.PDBFile(pdbfile)
-        protein_structure = utils.generateProteinStructure(proteinpdb)
-        self.assertIsInstance(protein_structure, parmed.structure.Structure)
+        protein_structure = structure.generateProteinStructure(proteinpdb)
+        assert isinstance(protein_structure, parmed.structure.Structure)
+
 
 def test_merge_system():
     """Test merging of a system created from AMBER and another created from SMIRNOFF."""
 
     # Create System from AMBER
-    # TODO: Add create_system_from_amber convenience function
-    from openforcefield.typing.engines.smirnoff import create_system_from_amber
-    prmtop_filename, inpcrd_filename = get_amber_filepaths('cyclohexane_ethanol_0.4_0.6')
+    from .utils import create_system_from_amber, get_amber_filepath
+    prmtop_filename, inpcrd_filename = get_amber_filepath('cyclohexane_ethanol_0.4_0.6')
     topology0, system0, positions0 = create_system_from_amber(prmtop_filename, inpcrd_filename)
 
     # TODO:
@@ -66,6 +71,7 @@ def test_merge_system():
     topology1, system1, positions1 = create_system_from_molecule(forcefield, mol)
 
     merge_system( topology0, topology1, system0, system1, positions0, positions1, verbose=True )
+
 
 def test_component_combination():
     """Test that a system still yields the same energy after rebuilding it out of its components

--- a/openforcefield/tests/test_utils_structure.py
+++ b/openforcefield/tests/test_utils_structure.py
@@ -13,8 +13,13 @@ Tests for utility methods that involve parmed Structure manipulation
 # GLOBAL IMPORTS
 #=============================================================================================
 
-import parmed
+import os
 
+import parmed
+import pytest
+
+from openforcefield.typing.engines.smirnoff import ForceField
+from openforcefield.topology import Molecule, Topology
 from openforcefield import utils
 import openforcefield.utils.structure as structure
 
@@ -23,17 +28,23 @@ import openforcefield.utils.structure as structure
 # TESTS
 #=============================================================================================
 
+requires_openeye_mol2 = pytest.mark.skipif(not utils.OpenEyeToolkitWrapper.is_available(),
+                                               reason='OpenEye is required to parse mol2 files')
+
 class TestUtilsStructure:
 
+    @requires_openeye_mol2
     def test_read_molecules(self):
         molecules = structure.read_molecules('zinc-subset-tripos.mol2.gz', verbose=False)
 
+    @requires_openeye_mol2
     def test_positions(self):
         """Test ability to extract and set positions."""
         molecules = structure.read_molecules('zinc-subset-tripos.mol2.gz', verbose=False)
         positions = structure.extractPositionsFromOEMol(molecules[0])
         structure.setPositionsInOEMol(molecules[0], positions)
 
+    @requires_openeye_mol2
     def test_smirnoff_structure(self):
         """Test function that generates the SMIRNOFF parmed.Structure."""
         molecule = structure.read_molecules('toluene.pdb', verbose=False)[0]
@@ -48,45 +59,61 @@ class TestUtilsStructure:
         assert isinstance(protein_structure, parmed.structure.Structure)
 
 
+@requires_openeye_mol2
 def test_merge_system():
     """Test merging of a system created from AMBER and another created from SMIRNOFF."""
+    from .utils import create_system_from_amber, get_amber_filepath, get_alkethoh_filepath
 
     # Create System from AMBER
-    from .utils import create_system_from_amber, get_amber_filepath
     prmtop_filename, inpcrd_filename = get_amber_filepath('cyclohexane_ethanol_0.4_0.6')
-    topology0, system0, positions0 = create_system_from_amber(prmtop_filename, inpcrd_filename)
+    system0, topology0, positions0 = create_system_from_amber(prmtop_filename, inpcrd_filename)
 
     # TODO:
     from openeye import oechem
     # Load simple OEMol
-    ifs = oechem.oemolistream(get_testdata_filename('molecules/AlkEthOH_c100.mol2'))
+    alkethoh_mol2_filepath = get_alkethoh_filepath('AlkEthOH_c100')[0]
+    ifs = oechem.oemolistream(alkethoh_mol2_filepath)
     mol = oechem.OEMol()
     flavor = oechem.OEIFlavor_Generic_Default | oechem.OEIFlavor_MOL2_Default | oechem.OEIFlavor_MOL2_Forcefield
-    ifs.SetFlavor( oechem.OEFormat_MOL2, flavor)
+    ifs.SetFlavor(oechem.OEFormat_MOL2, flavor)
     oechem.OEReadMolecule(ifs, mol)
     oechem.OETriposAtomNames(mol)
 
-    # Load forcefield file
+    # Load forcefield file.
+    AlkEthOH_offxml_filename = utils.get_data_filename('forcefield/Frosst_AlkEthOH.offxml')
     forcefield = ForceField(AlkEthOH_offxml_filename)
-    topology1, system1, positions1 = create_system_from_molecule(forcefield, mol)
 
-    merge_system( topology0, topology1, system0, system1, positions0, positions1, verbose=True )
+    # Create OpenMM System and Topology.
+    off_mol = Molecule.from_openeye(mol, allow_undefined_stereo=True)
+    off_top = Topology.from_molecules([off_mol])
+    system1 = forcefield.create_openmm_system(off_top)
+    topology1 = structure.generateTopologyFromOEMol(mol)
+    positions1 = structure.extractPositionsFromOEMol(mol)
+
+    structure.merge_system(topology0, topology1, system0, system1, positions0, positions1, verbose=True)
 
 
+@pytest.mark.slow
+@requires_openeye_mol2
 def test_component_combination():
     """Test that a system still yields the same energy after rebuilding it out of its components
     """
+    from simtk import openmm
+    from .utils import compare_system_energies, get_packmol_pdbfile
 
     # We've had issues where subsequent instances of a molecule might have zero charges
     # Here we'll try to catch this (and also explicitly check the charges) by re-building
     # a system out of its components
 
-    # Create an OpenMM System from a PDB file containing a cyclohexane-ethanol mixture
+    # Create an OpenMM System from mol2 files containing a cyclohexane-ethanol mixture.
+    AlkEthOH_offxml_filename = utils.get_data_filename('forcefield/Frosst_AlkEthOH.offxml')
     forcefield = ForceField(AlkEthOH_offxml_filename)
-    pdbfile = app.PDBFile(get_packmol_pdbfile('cyclohexane_ethanol_0.4_0.6.pdb'))
-    molecules = [ Molecule.from_file(get_monomer_mol2file(name)) for name in ('ethanol', 'cyclohexane') ]
+    pdbfile = openmm.app.PDBFile(get_packmol_pdbfile('cyclohexane_ethanol_0.4_0.6'))
+    sdf_file_paths = [utils.get_data_filename(os.path.join('systems', 'monomers', name+'.sdf'))
+                      for name in ('ethanol', 'cyclohexane')]
+    molecules = [Molecule.from_file(file_path) for file_path in sdf_file_paths]
     topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
-    system = forcefield.createSystem(topology)
+    system = forcefield.create_openmm_system(topology)
 
     # Convert System to a ParmEd Structure
     structure = parmed.openmm.topsystem.load_topology(topology.to_openmm(), system, pdbfile.positions)
@@ -97,7 +124,7 @@ def test_component_combination():
     for s, n in tmp:
         strs.append(s)
         nums.append(n)
-    nums = [ len(n) for n in nums ]
+    nums = [len(n) for n in nums]
 
     # Re-compose Structure from components
     new_structure = strs[0]*nums[0]
@@ -107,13 +134,13 @@ def test_component_combination():
     new_structure.positions = structure.positions
 
     # Create System
-    newsys = new_structure.createSystem(nonbondedMethod= app.NoCutoff, constraints=None, implicitSolvent=None)
+    newsys = new_structure.createSystem(nonbondedMethod=openmm.app.NoCutoff, constraints=None, implicitSolvent=None)
 
     # Cross check energies
     groups0, groups1, energy0, energy1 = compare_system_energies(pdbfile.topology, pdbfile.topology, system, newsys, pdbfile.positions, verbose = False)
 
     # Also check that that the number of components is equal to the number I expect
-    if not len(nums)==2:
+    if not len(nums) == 2:
         print("Error: Test system has incorrect number of components.")
         raise Exception('Incorrect number of components in cyclohexane/ethanol test system.')
 

--- a/openforcefield/tests/utils.py
+++ b/openforcefield/tests/utils.py
@@ -85,8 +85,9 @@ def get_monomer_mol2file(prefix='ethanol'):
     mol2_filename : str
         Absolute path to the mol2 file
     """
+    # TODO: The mol2 files in this folder are not tripos mol2 files. Delete or convert them.
     prefix = os.path.join('systems', 'monomers', prefix)
-    mol2_filename = get_data_filename(prefix+'.pdb')
+    mol2_filename = get_data_filename(prefix + '.mol2')
     return mol2_filename
 
 

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -149,6 +149,17 @@ class Particle(Serializable):
         """
         return self._name
 
+    def to_dict(self):
+        """Convert to dictionary representation."""
+        # Implement abstract method Serializable.to_dict()
+        raise NotImplementedError()  # TODO
+
+    @classmethod
+    def from_dict(cls, d):
+        """Static constructor from dictionary representation."""
+        # Implement abstract method Serializable.to_dict()
+        raise NotImplementedError()  # TODO
+
 
 #=============================================================================================
 # Atom

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -242,7 +242,8 @@ class Atom(Particle):
         self._bonds = list()
         self._virtual_sites = list()
 
-    # TODO: Change this to add_bond(Bond) to improve encapsulation and extensibility?
+    # TODO: We can probably avoid an explicit call and determine this dynamically
+    #   from self._molecule (maybe caching the result) to get rid of some bookkeeping.
     def add_bond(self, bond):
         """Adds a bond that this atom is involved in
         .. todo :: Is this how we want to keep records?

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -1516,15 +1516,13 @@ class FrozenMolecule(Serializable):
                 self.__setstate__(other)
                 loaded = True
             # Check through the toolkit registry to find a compatible wrapper for loading
-            if not (loaded):
-                for toolkit_wrapper in toolkit_registry.registered_toolkits:
-                    if not (hasattr(toolkit_wrapper, 'from_object')):
-                        continue
-                    load_attempt = toolkit_wrapper.from_object(other)
-                    # TODO: Come up with a better check for load failure
-                    if type(load_attempt) is bool:
-                        continue
-                    self._copy_initializer(load_attempt)
+            if not loaded:
+                try:
+                    result = toolkit_registry.call('from_object', other)
+                except NotImplementedError:
+                    pass
+                else:
+                    self._copy_initializer(result)
                     loaded = True
             # TODO: Make this compatible with file-like objects (I couldn't figure out how to make an oemolistream
             # from a fileIO object)

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -56,10 +56,16 @@ class NotBondedError(MessageException):
 # PRIVATE SUBROUTINES
 #=============================================================================================
 
-
 class _TransformedDict(MutableMapping):
-    """A dictionary that applies an arbitrary key-altering
-       function before accessing the keys"""
+    """A dictionary that transform and sort keys.
+
+    The function __keytransform__ can be inherited to apply an arbitrary
+    key-altering function before accessing the keys.
+
+    The function __sortfunc__ can be inherited to specify a particular
+    order over which to iterate over the dictionary.
+
+    """
 
     def __init__(self, *args, **kwargs):
         self.store = OrderedDict()
@@ -75,7 +81,7 @@ class _TransformedDict(MutableMapping):
         del self.store[self.__keytransform__(key)]
 
     def __iter__(self):
-        return iter(self.store)
+        return iter(sorted(self.store, key=self.__sortfunc__))
 
     def __len__(self):
         return len(self.store)
@@ -83,9 +89,13 @@ class _TransformedDict(MutableMapping):
     def __keytransform__(self, key):
         return key
 
+    @staticmethod
+    def __sortfunc__(key):
+        return key
+
 
 class ValenceDict(_TransformedDict):
-    """Enforce uniqueness in atom indices"""
+    """Enforce uniqueness in atom indices."""
 
     def __keytransform__(self, key):
         """Reverse tuple if first element is larger than last element."""
@@ -98,7 +108,7 @@ class ValenceDict(_TransformedDict):
 
 
 class ImproperDict(_TransformedDict):
-    """Symmetrize improper torsions"""
+    """Symmetrize improper torsions."""
 
     def __keytransform__(self, key):
         """Reorder tuple in numerical order except for element[1] which is the central atom; it retains its position."""

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -245,6 +245,17 @@ class TopologyAtom(Serializable):
         return "TopologyAtom {} with reference atom {} and parent TopologyMolecule {}".format(
             self.topology_atom_index, self._atom, self._topology_molecule)
 
+    def to_dict(self):
+        """Convert to dictionary representation."""
+        # Implement abstract method Serializable.to_dict()
+        raise NotImplementedError()  # TODO
+
+    @classmethod
+    def from_dict(cls, d):
+        """Static constructor from dictionary representation."""
+        # Implement abstract method Serializable.to_dict()
+        raise NotImplementedError()  # TODO
+
     #@property
     #def bonds(self):
     #    """
@@ -351,6 +362,17 @@ class TopologyBond(Serializable):
         """
         for ref_atom in self._bond.atoms:
             yield TopologyAtom(ref_atom, self._topology_molecule)
+
+    def to_dict(self):
+        """Convert to dictionary representation."""
+        # Implement abstract method Serializable.to_dict()
+        raise NotImplementedError()  # TODO
+
+    @classmethod
+    def from_dict(cls, d):
+        """Static constructor from dictionary representation."""
+        # Implement abstract method Serializable.to_dict()
+        raise NotImplementedError()  # TODO
 
 
 #=============================================================================================
@@ -481,6 +503,17 @@ class TopologyVirtualSite(Serializable):
     def __eq__(self, other):
         return ((self._virtual_site == other._virtual_site)
                 and (self._topology_molecule == other._topology_molecule))
+
+    def to_dict(self):
+        """Convert to dictionary representation."""
+        # Implement abstract method Serializable.to_dict()
+        raise NotImplementedError()  # TODO
+
+    @classmethod
+    def from_dict(cls, d):
+        """Static constructor from dictionary representation."""
+        # Implement abstract method Serializable.to_dict()
+        raise NotImplementedError()  # TODO
 
 
 # =============================================================================================
@@ -765,6 +798,17 @@ class TopologyMolecule:
                 return virtual_site_start_topology_index
             virtual_site_start_topology_index += topology_molecule.n_virtual_sites
 
+    def to_dict(self):
+        """Convert to dictionary representation."""
+        # Implement abstract method Serializable.to_dict()
+        raise NotImplementedError()  # TODO
+
+    @classmethod
+    def from_dict(cls, d):
+        """Static constructor from dictionary representation."""
+        # Implement abstract method Serializable.to_dict()
+        raise NotImplementedError()  # TODO
+
 
 # TODO: pick back up figuring out how we want TopologyMolecules to know their starting TopologyParticle indices
 
@@ -892,8 +936,8 @@ class Topology(Serializable):
         for ref_mol in self._reference_molecule_to_topology_molecules.keys():
             yield ref_mol
 
-    @staticmethod
-    def from_molecules(molecules):
+    @classmethod
+    def from_molecules(cls, molecules):
         """
         Create a new Topology object containing one copy of each of the specified molecule(s).
 
@@ -915,7 +959,7 @@ class Topology(Serializable):
             molecules = [molecules]
 
         # Create Topology and populate it with specified molecules
-        topology = Topology()
+        topology = cls()
         for molecule in molecules:
             topology.add_molecule(molecule)
 
@@ -1301,6 +1345,17 @@ class Topology(Serializable):
                     matches.append(match)
 
         return matches
+
+    def to_dict(self):
+        """Convert to dictionary representation."""
+        # Implement abstract method Serializable.to_dict()
+        raise NotImplementedError()  # TODO
+
+    @classmethod
+    def from_dict(cls, d):
+        """Static constructor from dictionary representation."""
+        # Implement abstract method Serializable.to_dict()
+        raise NotImplementedError()  # TODO
 
     @classmethod
     def from_openmm(cls, openmm_topology, unique_molecules=None):

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -1367,7 +1367,8 @@ class Topology(Serializable):
 
         # For each connected subgraph (molecule) in the topology, find its match in unique_molecules
         topology_molecules_to_add = list()
-        for omm_mol_G in nx.connected_component_subgraphs(omm_topology_G):
+        for omm_mol_G in (omm_topology_G.subgraph(c).copy()
+                          for c in nx.connected_components(omm_topology_G)):
             match_found = False
             for unq_mol_G in graph_to_unq_mol.keys():
                 if nx.is_isomorphic(

--- a/openforcefield/typing/chemistry/environment.py
+++ b/openforcefield/typing/chemistry/environment.py
@@ -25,12 +25,14 @@ and David Mobley, UC Irvine.
 # GLOBAL IMPORTS
 #==============================================================================
 
-import networkx as nx
 import re
 import copy
 
-import openforcefield.utils
+import networkx as nx
 from numpy import random
+
+import openforcefield.utils
+
 
 #==============================================================================
 # Functions
@@ -452,20 +454,14 @@ class ChemicalEnvironment(object):
         replacements = list of lists, optional,
             [substitution, smarts] form for parsing SMIRKS
         """
-        if toolkit.lower() == 'openeye':
-            try:
-                from openeye import oechem
-                self.toolkit = 'openeye'
-            except:
-                raise Exception("Could not import openeye.oechem")
-        elif toolkit.lower() == 'rdkit':
-            try:
-                from rdkit import Chem
-                self.toolkit = 'rdkit'
-            except:
-                raise Exception("Could not import rdkit.Chem")
+        # TODO: Refactor all this class to use the ToolkitRegistry API.
+        if toolkit.lower() == 'openeye' and openforcefield.utils.OpenEyeToolkitWrapper.is_available():
+            self.toolkit = 'openeye'
+        elif toolkit.lower() == 'rdkit' and openforcefield.utils.RDKitToolkitWrapper.is_available():
+            self.toolkit = 'rdkit'
         else:
-            raise Exception("Toolkit %s was not recognized, please use openeye or rdkit" % toolkit)
+            raise ValueError("Could not find toolkit {}, please use/install "
+                             "openeye or rdkit.".format(toolkit))
 
         # Define the regular expressions used for all SMIRKS decorators
         # There are a limited number of descriptors for smirks string they are:

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -87,8 +87,7 @@ class NonbondedMethod(Enum):
 # the dictionary key's SMIRKS to be out of sync.
 class ParameterList(list):
     """
-    Parameter list that also supports accessing items by SMARTS string. Remembers the
-    most recent parameter that was added.
+    Parameter list that also supports accessing items by SMARTS string.
     """
 
     # TODO: Make this faster by caching SMARTS -> index lookup?
@@ -110,15 +109,10 @@ class ParameterList(list):
         """
         super().__init__()
 
-        # We keep track of the last parameter added as this will be
-        # used to set output units during serialization
-        self._last_added_param = None
         input_parameter_list = input_parameter_list or []
         # TODO: Should a ParameterList only contain a single kind of ParameterType?
         for input_parameter in input_parameter_list:
             self.append(input_parameter)
-            self._last_added_param = input_parameter_list
-
 
     def append(self, parameter):
         """
@@ -131,7 +125,6 @@ class ParameterList(list):
         """
         # TODO: Ensure that newly added parameter is the same type as existing?
         super().append(parameter)
-        self._last_added_param = parameter
 
     def extend(self, other):
         """
@@ -148,9 +141,6 @@ class ParameterList(list):
             raise TypeError(msg)
         # TODO: Check if other ParameterList contains the same ParameterTypes?
         super().extend(other)
-        if len(other) > 0:
-            self._last_added_param = other[-1]
-
 
     def index(self, item):
         """
@@ -173,8 +163,7 @@ class ParameterList(list):
             for parameter in self:
                 if parameter.smirks == item:
                     return self.index(parameter)
-            raise IndexError(f'SMIRKS {item} not found in ParameterList')
-
+            raise IndexError('SMIRKS {item} not found in ParameterList'.format(item=item))
 
     def insert(self, index, parameter):
         """
@@ -188,9 +177,7 @@ class ParameterList(list):
             The parameter to insert
         """
         # TODO: Ensure that newly added parameter is the same type as existing?
-
         super().insert(index, parameter)
-        self._last_added_param = parameter
 
     def __delitem__(self, item):
         """
@@ -207,7 +194,6 @@ class ParameterList(list):
             # Try to find by SMIRKS
             index = self.index(item)
         super().__delitem__(index)
-
 
     def __getitem__(self, item):
         """
@@ -236,7 +222,7 @@ class ParameterList(list):
         item : str
             SMIRKS of item in this ParameterList
         """
-        if type(item) == str:
+        if isinstance(item, str):
             # Special case for SMIRKS strings
             if item in [result.smirks for result in self]:
                 return True
@@ -762,8 +748,9 @@ class ParameterHandler(object):
         # Set default output units to those from the last parameter added to the ParameterList
         if (output_units is None):
             output_units = dict()
-        if (self._parameters.last_added_parameter is not None):
-            _, last_added_output_units = detach_units(self._parameters.last_added_parameter.to_dict())
+        # TODO: What if self._parameters is an empty list?
+        if len(self._parameters) > 0:
+            _, last_added_output_units = detach_units(self._parameters[-1].to_dict())
             # Overwrite key_value pairs in last_added_output_units with those specified by user in output_units
             last_added_output_units.update(output_units)
             output_units = last_added_output_units

--- a/openforcefield/utils/serialization.py
+++ b/openforcefield/utils/serialization.py
@@ -13,12 +13,15 @@ Serialization mix-in
 # GLOBAL IMPORTS
 #=============================================================================================
 
+import abc
+
+
 #=============================================================================================
 # SERIALIZATION MIX-IN
 #=============================================================================================
 
 
-class Serializable(object):
+class Serializable(abc.ABC):
     """Mix-in to add serialization and deserialization support via JSON, YAML, BSON, TOML, MessagePack, and XML.
 
     For more information on these formats, see: `JSON <https://www.json.org/>`_, `BSON <http://bsonspec.org/>`_, `YAML <http://yaml.org/>`_, `TOML <https://github.com/toml-lang/toml>`_, `MessagePack <https://msgpack.org/index.html>`_, and `XML <https://www.w3.org/XML/>`_.
@@ -44,9 +47,9 @@ class Serializable(object):
     ...     def to_dict(self):
     ...         return { 'description' : self.description }
     ...
-    ...     @staticmethod
-    ...     def from_dict(d):
-    ...         return Thing(d['description'])
+    ...     @classmethod
+    ...     def from_dict(cls, d):
+    ...         return cls(d['description'])
     ...
     ... # Create an example object
     ... thing = Thing('blorb')
@@ -101,11 +104,14 @@ class Serializable(object):
 
     """
 
+    @abc.abstractmethod
     def to_dict(self):
-        raise NotImplementedError
+        pass
 
-    def from_dict(self):
-        raise NotImplementedError
+    @classmethod
+    @abc.abstractmethod
+    def from_dict(cls, d):
+        pass
 
     def to_json(self, indent=None):
         """
@@ -200,6 +206,9 @@ class Serializable(object):
             A TOML serialized representation of the object
 
         """
+        raise NotImplementedError()
+        # TODO: This implementation currently discards dict keys associated to the None value.
+        #   See test_utils_serialization::TestUtilsSMIRNOFFSerialization::test_toml.
         import toml
         d = self.to_dict()
         return toml.dumps(d)
@@ -385,6 +394,9 @@ class Serializable(object):
             Instantiated object.
 
         """
+        raise NotImplementedError()
+        # TODO: This implementation currently loads numbers as strings.
+        #   See test_utils_serialization::TestUtilsSerialization::test_xml.
         import xmltodict
         d = xmltodict.parse(serialized)
         root_name = cls.__name__

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -354,18 +354,22 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         ----------
         object : A molecule-like object
             An object to by type-checked.
+
         Returns
         -------
-        Molecule or False
-            An openforcefield.topology.molecule Molecule, or False if loading was unsuccessful
+        Molecule
+            An openforcefield.topology.molecule Molecule.
+
+        Raises
+        ------
+        NotImplementedError
+            If the object could not be converted into a Molecule.
         """
         # TODO: Add tests for the from_object functions
         from openeye import oechem
         if isinstance(object, oechem.OEMolBase):
-            mol = self.from_openeye(object)
-            return mol
-        else:
-            return False
+            return self.from_openeye(object)
+        raise NotImplementedError('Cannot create Molecule from {} object'.format(type(object)))
 
     def from_file(self,
                   filename,
@@ -1446,15 +1450,18 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         Returns
         -------
         Molecule or False
-            An openforcefield.topology.molecule Molecule, or False if loading was unsuccessful
+            An openforcefield.topology.molecule Molecule.
+
+        Raises
+        ------
+        NotImplementedError
+            If the object could not be converted into a Molecule.
         """
         # TODO: Add tests for the from_object functions
         from rdkit import Chem
         if isinstance(object, Chem.rdchem.Mol):
-            mol = self.from_rdkit(object)
-            return mol
-        else:
-            return False
+            return self.from_rdkit(object)
+        raise NotImplementedError('Cannot create Molecule from {} object'.format(type(object)))
 
     def from_file(self,
                   filename,
@@ -2890,10 +2897,9 @@ class ToolkitRegistry(object):
         for toolkit in self._toolkits:
             if hasattr(toolkit, method_name):
                 method = getattr(toolkit, method_name)
-                #return method(*args, **kwargs)
                 try:
                     return method(*args, **kwargs)
-                except NotImplementedError as e:
+                except NotImplementedError:
                     pass
                 except ValueError as value_error:
                     value_errors.append((toolkit, value_error))

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -2495,14 +2495,15 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
                            "AmberToolsToolkitWrapper.compute_partial_charges_am1bcc()"))
 
         if len(molecule._conformers) == 0:
-            raise Exception(
+            raise ValueError(
                 "No conformers present in molecule submitted for partial charge calculation. Consider "
                 "loading the molecule from a file with geometry already present or running "
                 "molecule.generate_conformers() before calling molecule.compute_partial_charges"
             )
         if len(molecule._conformers) > 1:
-            logger.warn("In AmberToolsToolkitwrapper.computer_partial_charges_am1bcc: Molecule '{}' has more than one "
-                        "conformer, but this function will only generate charges for the first one.".format(molecule.name))
+            logger.warning("In AmberToolsToolkitwrapper.computer_partial_charges_am1bcc: "
+                           "Molecule '{}' has more than one conformer, but this function "
+                           "will only generate charges for the first one.".format(molecule.name))
 
 
         # Compute charges

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -2778,6 +2778,7 @@ class ToolkitRegistry(object):
                 raise ToolkitUnavailableException(msg)
             else:
                 logger.warning(msg)
+            return
 
         # Add toolkit to the registry.
         self._toolkits.append(toolkit_wrapper)

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -1682,9 +1682,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             An openforcefield-style molecule.
         """
         from openforcefield.topology.molecule import Molecule
-        # inherits base class docstring
         from rdkit import Chem
-        from rdkit.Chem import EnumerateStereoisomers
 
         rdmol = Chem.MolFromSmiles(smiles, sanitize=False)
         rdmol.UpdatePropertyCache(strict=False)

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -1784,6 +1784,9 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         from rdkit import Chem
         from openforcefield.topology.molecule import Molecule
 
+        # Make a copy of the RDKit Mol as we'll need to change it (e.g. assign stereo).
+        rdmol = Chem.Mol(rdmol)
+
         # Sanitize the molecule. We handle aromaticity and chirality manually.
         Chem.SanitizeMol(rdmol, (Chem.SANITIZE_ALL ^ Chem.SANITIZE_SETAROMATICITY ^
                                  Chem.SANITIZE_ADJUSTHS ^ Chem.SANITIZE_CLEANUPCHIRALITY))
@@ -2086,7 +2089,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             for conformer in molecule._conformers:
                 rdmol_conformer = Chem.Conformer()
                 for atom_idx in range(molecule.n_atoms):
-                    (x, y, z) = conformer[atom_idx, :] / unit.angstrom
+                    x, y, z = conformer[atom_idx, :].value_in_unit(unit.angstrom)
                     rdmol_conformer.SetAtomPosition(atom_idx,
                                                     Geometry.Point3D(x, y, z))
                 rdmol.AddConformer(rdmol_conformer)
@@ -2096,7 +2099,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
             rdk_indexed_charges = np.zeros((molecule.n_atoms), dtype=np.float)
             for atom_idx, charge in enumerate(molecule._partial_charges):
-                charge_unitless = charge / unit.elementary_charge
+                charge_unitless = charge.value_in_unit(unit.elementary_charge)
                 rdk_indexed_charges[atom_idx] = charge_unitless
             for atom_idx, rdk_atom in enumerate(rdmol.GetAtoms()):
                 rdk_atom.SetDoubleProp('partial_charge',

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -2747,7 +2747,7 @@ class ToolkitRegistry(object):
         return list(self._toolkits)
 
     def register_toolkit(self,
-                         toolkit_wrapper_class,
+                         toolkit_wrapper,
                          exception_if_unavailable=True):
         """
         Register the provided toolkit wrapper class, instantiating an object of it.
@@ -2761,22 +2761,26 @@ class ToolkitRegistry(object):
 
         Parameters
         ----------
-        toolkit_wrapper_class : subclass of ToolkitWrapper
-            The class of the toolkit wrapper to register.
+        toolkit_wrapper : instance or subclass of ToolkitWrapper
+            The toolkit wrapper to register or its class.
         exception_if_unavailable : bool, optional, default=True
             If True, an exception will be raised if the toolkit is unavailable
 
         """
-        # TODO: Instantiate class if class, or just add if already instantiated.
-        try:
-            toolkit_wrapper = toolkit_wrapper_class()
-            if not(toolkit_wrapper.is_available()):
-                raise ToolkitUnavailableException()
-            self._toolkits.append(toolkit_wrapper)
-        except ToolkitUnavailableException as e:
+        # Instantiate class if class, or just add if already instantiated.
+        if isinstance(toolkit_wrapper, type):
+            toolkit_wrapper = toolkit_wrapper()
+
+        # Raise exception if not available.
+        if not toolkit_wrapper.is_available():
+            msg = "Unable to load toolkit {}.".format(toolkit_wrapper)
             if exception_if_unavailable:
-                raise e
-            print("Unable to load toolkit {}.".format(toolkit_wrapper))
+                raise ToolkitUnavailableException(msg)
+            else:
+                logger.warning(msg)
+
+        # Add toolkit to the registry.
+        self._toolkits.append(toolkit_wrapper)
 
     def add_toolkit(self, toolkit_wrapper):
         """


### PR DESCRIPTION
This should be the last PR to bring back Travis tests.

Besides a bunch of fixes, there are only two notable changes in the actual code:
- I made some changes to the stereochemistry detection in the RDKit toolkit because it wasn't working for SMILES. The new implementation should be equivalent to the old one enumerating stereo configurations, but faster and with better error messages.
- I've changed `ParameterHandler` to use the units in the `parameter_list[-1]` parameter type, which should be identical to the old behavior in the 95% of the use cases, but simplify the code and bookkeeping greatly.