### PR TITLE
Update SMIRNOFF spec and implement Electrostatics tag handler 

### DIFF
--- a/The-SMIRNOFF-force-field-format.md
+++ b/The-SMIRNOFF-force-field-format.md
@@ -212,7 +212,7 @@ For example, to ensure water molecules are assigned partial charges for [TIP3P](
 
 In keeping with the AMBER force field philosophy, especially as implemented in small molecule force fields such as [GAFF](http://ambermd.org/antechamber/gaff.html), [GAFF2](https://mulan.swmed.edu/group/gaff.php), and [parm@Frosst](http://www.ccl.net/cca/data/parm_at_Frosst/), partial charges for small molecules are usually assigned using a quantum chemical method (usually a semiempirical method such as [AM1](https://en.wikipedia.org/wiki/Austin_Model_1)) and a [partial charge determination scheme](https://en.wikipedia.org/wiki/Partial_charge) (such as [CM2](http://doi.org/10.1021/jp972682r) or [RESP](http://doi.org/10.1021/ja00074a030)), then subsequently corrected via charge increment rules, as in the highly successful [AM1-BCC](https://dx.doi.org/10.1002/jcc.10128) approach.
 
-Here is an example:
+Here is an example: 
 ```XML
 <ChargeIncrementModel number_of_conformers="10" quantum_chemical_method="AM1" partial_charge_method="CM2" increment_unit="elementary_charge">
   <!-- A fractional charge can be moved along a single bond -->
@@ -260,7 +260,7 @@ As an example of a complete SMIRNOFF force field specification, see the [AlkEthO
 
 van der Waals force parameters, which include repulsive forces arising from Pauli exclusion and attractive forces arising from dispersion, are specified via the `<vdW>` tag with sub-tags for individual `Atom` entries, such as:
 ```XML
-<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1.0" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstroms" long_range_dispersion="isotropic">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1.0" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="8.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstroms" long_range_dispersion="isotropic">
    <Atom smirks="[#1:1]" sigma="1.4870" epsilon="0.0157"/>
    <Atom smirks="[#1:1]-[#6]" sigma="1.4870" epsilon="0.0157"/>
    ...
@@ -271,8 +271,7 @@ The two are related by `r0 = 2^(1/6)*sigma` and conversion is done internally in
 Note that, if `rmin_half` is specified instead of `sigma`, `rmin_half_unit` should be specified; both can be used in the same block if desired.
 
 Attributes in the `<vdW>` tag specify the scaling terms applied to the energies of 1-2 (`scale12`, default: 0), 1-3 (`scale13`, default: 0), 1-4 (`scale14`, default: 0.5), and 1-5 (`scale15`, default: 1.0) interactions,
-as well as the distance at which a switching function is applied (`switch`, default: `"8.0"` angstroms), the cutoff (`cutoff`, default: `"9.0"` angstroms), and long-range dispersion treatment scheme (`long_range_dispersion`, default: `"isotropic"`).
-If Lennard-Jones PME is to be used, `switch` and `cutoff` are omitted and `long_range_dispersion="PME"` is used.
+as well as the distance at which a switching function is applied (`switch_width`, default: `"1.0"` angstroms), the cutoff (`cutoff`, default: `"9.0"` angstroms), and long-range dispersion treatment scheme (`long_range_dispersion`, default: `"isotropic"`).
 
 The `potential` attribute (default: `"none"`) specifies the potential energy function to use.
 Currently, only `potential="Lennard-Jones-12-6"` is supported:
@@ -284,7 +283,7 @@ Support for [other Lennard-Jones mixing schemes](https://en.wikipedia.org/wiki/C
 
 Later revisions will add support for additional potential types (e.g., `Buckingham-exp-6`), as well as the ability to support arbitrary algebraic functional forms using a scheme such as
 ```XML
-<vdW potential="4*epsilon*((sigma/r)^12-(sigma/r)^6)" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstrom" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+<vdW potential="4*epsilon*((sigma/r)^12-(sigma/r)^6)" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstrom" epsilon_unit="kilocalories_per_mole" switch_width="8.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
    <CombiningRules>
       <CombiningRule parameter="sigma" function="(sigma1+sigma2)/2"/>
       <CombiningRule parameter="epsilon" function="sqrt(epsilon1*epsilon2)"/>

--- a/The-SMIRNOFF-force-field-format.md
+++ b/The-SMIRNOFF-force-field-format.md
@@ -216,11 +216,11 @@ Here is an example:
 ```XML
 <ChargeIncrementModel number_of_conformers="10" quantum_chemical_method="AM1" partial_charge_method="CM2" increment_unit="elementary_charge">
   <!-- A fractional charge can be moved along a single bond -->
-  <ChargeIncrement smirks="[#6X4:1]-[#6X3a:2]" charge1increment="-0.0073" charge2increment="+0.0073"/>
-  <ChargeIncrement smirks="[#6X4:1]-[#6X3a:2]-[#7]" charge1increment="+0.0943" charge2increment="-0.0943"/>
-  <ChargeIncrement smirks="[#6X4:1]-[#8:2]" charge1increment="-0.0718" charge2increment="+0.0718"/>
+  <ChargeIncrement smirks="[#6X4:1]-[#6X3a:2]" chargeincrement1="-0.0073" chargeincrement2="+0.0073"/>
+  <ChargeIncrement smirks="[#6X4:1]-[#6X3a:2]-[#7]" chargeincrement1="+0.0943" chargeincrement2="-0.0943"/>
+  <ChargeIncrement smirks="[#6X4:1]-[#8:2]" chargeincrement1="-0.0718" chargeincrement2="+0.0718"/>
   <!--- Alternatively, factional charges can be redistributed among any number of bonded atoms -->
-  <ChargeIncrement smirks="[N:1](H:2)(H:3)" charge1increment="+0.02" charge2increment="-0.01" charge3increment="-0.01"/>
+  <ChargeIncrement smirks="[N:1](H:2)(H:3)" chargeincrement1="+0.02" chargeincrement2="-0.01" chargeincrement3="-0.01"/>
 </ChargeIncrementModel>
 ```
 The sum of formal charges for the molecule or fragment will be used to determine the total charge the molecule or fragment will possess.

--- a/The-SMIRNOFF-force-field-format.md
+++ b/The-SMIRNOFF-force-field-format.md
@@ -644,7 +644,7 @@ This is a backwards-incompatible overhaul of the SMIRNOFF 0.1 draft specificatio
     * `<BondChargeCorrections>` was renamed to `<ChargeIncrementModel>` and generalized to accommodate an arbitrary number of tagged atoms
     * `<GBSAForce>` was renamed to `<GBSA>`    
 * `<PeriodicTorsionForce>` was split into `<ProperTorsions>` and `<ImproperTorsions>`
-* `<vdW>` now specifies 1-2, 1-3, 1-4, and 1-5 scaling factors via `scale12` (default: 0), `scale13` (default: 0), and `scale14` (default: 0.5) attributes. Coulomb scaling parameters have been removed from `StericsForce`.
+* `<vdW>` now specifies 1-2, 1-3, 1-4, and 1-5 scaling factors via `scale12` (default: 0), `scale13` (default: 0), `scale14` (default: 0.5), and `scale15` (default 1.0) attributes. Coulomb scaling parameters have been removed from `StericsForce`.
 * Added the `<Electrostatics>` tag to separately specify 1-2, 1-3, 1-4, and 1-5 scaling factors for electrostatics, as well as the method used to compute electrostatics (`PME`, `reaction-field`, `Coulomb`) since this has a huge effect on the energetics of the system.
 * Made it clear that `<Constraint>` entries do not have to be between bonded atoms.
 * `<VirtualSites>` has been added, and the specification of charge increments harmonized with `<ChargeIncrementModel>`

--- a/The-SMIRNOFF-force-field-format.md
+++ b/The-SMIRNOFF-force-field-format.md
@@ -260,7 +260,7 @@ As an example of a complete SMIRNOFF force field specification, see the [AlkEthO
 
 van der Waals force parameters, which include repulsive forces arising from Pauli exclusion and attractive forces arising from dispersion, are specified via the `<vdW>` tag with sub-tags for individual `Atom` entries, such as:
 ```XML
-<vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0*angstroms" cutoff="9.0*angstroms" long_range_dispersion="isotropic">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1.0" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstroms" long_range_dispersion="isotropic">
    <Atom smirks="[#1:1]" sigma="1.4870" epsilon="0.0157"/>
    <Atom smirks="[#1:1]-[#6]" sigma="1.4870" epsilon="0.0157"/>
    ...
@@ -270,8 +270,8 @@ For standard Lennard-Jones 12-6 potentials (specified via `potential="Lennard-Jo
 The two are related by `r0 = 2^(1/6)*sigma` and conversion is done internally in `ForceField` into the `sigma` values used in OpenMM.
 Note that, if `rmin_half` is specified instead of `sigma`, `rmin_half_unit` should be specified; both can be used in the same block if desired.
 
-Attributes in the `<vdW>` tag specify the scaling terms applied to the energies of 1-2 (`scale12`, default: 0), 1-3 (`scale13`, default: 0), and 1-4 (`scale14`, default: 0.5) interactions, (`scale15`, default: 1.0),
-as well as the distance at which a switching function is applied (`switch`, default: `"8.0"`), the cutoff (`cutoff`, default: `"9.0"`), and long-range dispersion treatment scheme (`long_range_dispersion`, default: `"isotropic"`).
+Attributes in the `<vdW>` tag specify the scaling terms applied to the energies of 1-2 (`scale12`, default: 0), 1-3 (`scale13`, default: 0), 1-4 (`scale14`, default: 0.5), and 1-5 (`scale15`, default: 1.0) interactions,
+as well as the distance at which a switching function is applied (`switch`, default: `"8.0"` angstroms), the cutoff (`cutoff`, default: `"9.0"` angstroms), and long-range dispersion treatment scheme (`long_range_dispersion`, default: `"isotropic"`).
 If Lennard-Jones PME is to be used, `switch` and `cutoff` are omitted and `long_range_dispersion="PME"` is used.
 
 The `potential` attribute (default: `"none"`) specifies the potential energy function to use.
@@ -284,7 +284,7 @@ Support for [other Lennard-Jones mixing schemes](https://en.wikipedia.org/wiki/C
 
 Later revisions will add support for additional potential types (e.g., `Buckingham-exp-6`), as well as the ability to support arbitrary algebraic functional forms using a scheme such as
 ```XML
-<vdW potential="4*epsilon*((sigma/r)^12-(sigma/r)^6)" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" cutoff="9.0" long_range_dispersion="isotropic">
+<vdW potential="4*epsilon*((sigma/r)^12-(sigma/r)^6)" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstrom" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
    <CombiningRules>
       <CombiningRule parameter="sigma" function="(sigma1+sigma2)/2"/>
       <CombiningRule parameter="epsilon" function="sqrt(epsilon1*epsilon2)"/>
@@ -308,7 +308,7 @@ Later revisions will also provide support for special interactions using the `<A
 
 Electrostatic interactions are specified via the `<Electrostatics>` tag.
 ```XML
-<Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333"/>
+<Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0"/>
 ```
 The `method` attribute specifies the manner in which electrostatic interactions are to be computed:
 * `PME` - [particle mesh Ewald](http://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-particle-mesh-ewald) should be used (DEFAULT); can only apply to periodic systems
@@ -319,10 +319,11 @@ The interaction scaling parameters applied to atoms connected by a few bonds are
 * `scale12` (default: 0) specifies the scaling applied to 1-2 bonds
 * `scale13` (default: 0) specifies the scaling applied to 1-3 bonds
 * `scale14` (default: 0.833333) specifies the scaling applied to 1-4 bonds
+* `scale15` (default: 1.0) specifies the scaling applied to 1-5 bonds
 
 Currently, no child tags are used because the charge model is specified via different means (currently library charges or BCCs).
 
-For methods where the cutoff is not simply an implementation detail but determines the potential energy of the system (`reaction-field` and `Coulomb`), the `cutoff` distance must also be specified, and a `switch-width` if a switching function is to be used.
+For methods where the cutoff is not simply an implementation detail but determines the potential energy of the system (`reaction-field` and `Coulomb`), the `cutoff` distance must also be specified, and a `switch_width` if a switching function is to be used.
 
 ### `<Bonds>`
 
@@ -440,7 +441,7 @@ The *second* atom in an improper (in the example above, the trivalent carbon) is
 
 Generalized-Born surface area (GBSA) implicit solvent parameters are optionally specified via a `<GBSA>...</GBSA>` using `<Atom>` tags with GBSA model specific attributes:
 ```XML
- <GBSA gb_model="OBC1" solvent_dielectric="78.5" solute_dielectric="1" radius_units="nanometers" sa_model="ACE" surface_area_penalty="5.4*calories/mole/angstroms**2" solvent_radius="1.4*angstroms">
+ <GBSA gb_model="OBC1" solvent_dielectric="78.5" solute_dielectric="1" radius_unit="nanometers" sa_model="ACE" surface_area_penalty="5.4*calories/mole/angstroms**2" solvent_radius="1.4*angstroms">
    <Atom smirks="[#1:1]" radius="0.12" scale="0.85"/>
    <Atom smirks="[#1:1]~[#6]" radius="0.13" scale="0.85"/>
    <Atom smirks="[#1:1]~[#8]" radius="0.08" scale="0.85"/>
@@ -532,7 +533,7 @@ Currently we support the following different types or geometries of off-center c
 - `TrivalentLonePair`: This is suitable for planar or tetrahedral nitrogen lone pairs; a charge site `S` lies above  the central atom (e.g. nitrogen, blue) a distance `d` along the vector perpendicular to the plane of the three connected atoms (2,3,4). With positive values of `d` the site lies above the nitrogen and with negative values it lies below the nitrogen.
 <img src="figures/vsite_trivalent.jpg" width=500>
 
-Each virtual site receives charge which is transferred from the desired atoms specified in the SMIRKS pattern via a `charge#increment` parameter, e.g., if `charge1increment=+0.1` then the virtual site will receive a charge of -0.1 and the atom labeled `1` will have its charge adjusted upwards by +0.1.
+Each virtual site receives charge which is transferred from the desired atoms specified in the SMIRKS pattern via a `chargeincrement#` parameter, e.g., if `chargeincrement1=+0.1` then the virtual site will receive a charge of -0.1 and the atom labeled `1` will have its charge adjusted upwards by +0.1.
 N may index any indexed atom.
 Increments which are left unspecified default to zero.
 Additionally, each virtual site can bear Lennard-Jones parameters, specified by `sigma` and `epsilon` or `rmin_half` and `epsilon`.
@@ -543,23 +544,23 @@ In the SMIRNOFF format, these are encoded as:
 <VirtualSites distanceUnits="angstroms" angleUnits="degrees" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole">
     <!-- sigma hole for halogens: "distance" denotes distance along the 2->1 bond vector, measured from atom 2 -->
     <!-- Specify that 0.2 charge from atom 1 and 0.1 charge units from atom 2 are to be moved to the virtual site, and a small Lennard-Jones site is to be added (sigma = 0.1*angstroms, epsilon=0.05*kcal/mol) -->
-    <VirtualSite type="BondCharge" smirks="[Cl:1]-[C:2]" distance="0.30" charge1increment="+0.2" charge2increment="+0.1" sigma="0.1" epsilon="0.05" />
+    <VirtualSite type="BondCharge" smirks="[Cl:1]-[C:2]" distance="0.30" chargeincrement1="+0.2" chargeincrement2="+0.1" sigma="0.1" epsilon="0.05" />
     <!-- Charge increments can extend out to as many atoms as are labeled, e.g. with a third atom: -->
-    <VirtualSite type="BondCharge" smirks="[Cl:1]-[C:2]~[*:3]" distance="0.30" charge1increment="+0.1" charge2increment="+0.1" charge3increment="+0.05" sigma="0.1" epsilon="0.05" />
+    <VirtualSite type="BondCharge" smirks="[Cl:1]-[C:2]~[*:3]" distance="0.30" chargeincrement1="+0.1" chargeincrement2="+0.1" chargeincrement3="+0.05" sigma="0.1" epsilon="0.05" />
     <!-- monovalent lone pairs: carbonyl -->
     <!-- X denotes the charge site, and P denotes the projection of the charge site into the plane of 1 and 2. -->
     <!-- inPlaneAngle is angle point P makes with 1 and 2, i.e. P-1-2 -->
     <!-- outOfPlaneAngle is angle charge site (X) makes out of the plane of 2-1-3 (and P) measured from 1 -->
     <!-- Since unspecified here, sigma and epsilon for the virtual site default to zero -->
-    <VirtualSite type="MonovalentLonePair" smirks="[O:1]=[C:2]-[*:3]" distance="0.30" outOfPlaneAngle="0" inPlaneAngle="120" charge1increment="+0.2" />
+    <VirtualSite type="MonovalentLonePair" smirks="[O:1]=[C:2]-[*:3]" distance="0.30" outOfPlaneAngle="0" inPlaneAngle="120" chargeincrement1="+0.2" />
     <!-- divalent lone pair: pyrimidine, TIP4P, TIP5P -->
     <!-- The atoms 2-1-3 define the X-Y plane, with Z perpendicular. If outOfPlaneAngle is 0, the charge site is a specified distance along the in-plane vector which bisects the angle left by taking 360 degrees minus angle(2,1,3). If outOfPlaneAngle is nonzero, the charge sites lie out of the plane by the specified angle (at the specified distance) and their in-plane projection lines along the angle's bisector. -->
-    <VirtualSite type="DivalentLonePair" smirks="[*:2]~[#7X2:1]~[*:3]" distance="0.30" OfPlaneAngle="0.0" charge1increment="+0.1" />
+    <VirtualSite type="DivalentLonePair" smirks="[*:2]~[#7X2:1]~[*:3]" distance="0.30" OfPlaneAngle="0.0" chargeincrement1="+0.1" />
     <!-- trivalent nitrogen lone pair -->
     <!-- charge sites lie above and below the nitrogen at specified distances from the nitrogen, along the vector perpendicular to the plane of (2,3,4) that passes through the nitrogen. If the nitrogen is co-planar with the connected atom, charge sites are simply above and below the plane-->
     <!-- Positive and negative values refer to above or below the nitrogen as measured relative to the plane of (2,3,4), i.e. below the nitrogen means nearer the 2,3,4 plane unless they are co-planar -->
-    <VirtualSite type="TrivalentLonePair" smirks="[*:2]~[#7X3:1](~[*:4])~[*:3]" distance="0.30" charge1increment="+0.1"/>
-    <VirtualSite type="TrivalentLonePair" smirks="[*:2]~[#7X3:1](~[*:4])~[*:3]" distance="-0.30" charge1increment="+0.1"/>
+    <VirtualSite type="TrivalentLonePair" smirks="[*:2]~[#7X3:1](~[*:4])~[*:3]" distance="0.30" chargeincrement1="+0.1"/>
+    <VirtualSite type="TrivalentLonePair" smirks="[*:2]~[#7X3:1](~[*:4])~[*:3]" distance="-0.30" chargeincrement1="+0.1"/>
 </VirtualSites>
 ```
 
@@ -644,8 +645,8 @@ This is a backwards-incompatible overhaul of the SMIRNOFF 0.1 draft specificatio
     * `<BondChargeCorrections>` was renamed to `<ChargeIncrementModel>` and generalized to accommodate an arbitrary number of tagged atoms
     * `<GBSAForce>` was renamed to `<GBSA>`    
 * `<PeriodicTorsionForce>` was split into `<ProperTorsions>` and `<ImproperTorsions>`
-* `<vdW>` now specifies 1-2, 1-3, and 1-4 scaling factors via `scale12` (default: 0), `scale13` (default: 0), and `scale14` (default: 0.5) attributes. Coulomb scaling parameters have been removed from `StericsForce`.
-* Added the `<Electrostatics>` tag to separately specify 1-2, 1-3, and 1-4 scaling factors for electrostatics, as well as the method used to compute electrostatics (`PME`, `reaction-field`, `Coulomb`) since this has a huge effect on the energetics of the system.
+* `<vdW>` now specifies 1-2, 1-3, 1-4, and 1-5 scaling factors via `scale12` (default: 0), `scale13` (default: 0), and `scale14` (default: 0.5) attributes. Coulomb scaling parameters have been removed from `StericsForce`.
+* Added the `<Electrostatics>` tag to separately specify 1-2, 1-3, 1-4, and 1-5 scaling factors for electrostatics, as well as the method used to compute electrostatics (`PME`, `reaction-field`, `Coulomb`) since this has a huge effect on the energetics of the system.
 * Made it clear that `<Constraint>` entries do not have to be between bonded atoms.
 * `<VirtualSites>` has been added, and the specification of charge increments harmonized with `<ChargeIncrementModel>`
 * The `potential` attribute was added to most forces to allow flexibility in extending forces to additional functional forms (or algebraic expressions) in the future. `potential` defaults to the current recommended scheme if omitted.

--- a/openforcefield/data/forcefield/Frosst_AlkEthOH.offxml
+++ b/openforcefield/data/forcefield/Frosst_AlkEthOH.offxml
@@ -44,7 +44,7 @@
    <Improper smirks="[a,A:1]~[#6X3:2]([a,A:3])~[#8X1:4]" periodicity1="2" phase1="180.0" k1="10.5" id="i0001" parent_id="i0001"/> <!-- X -X -C -O  from frcmod.Frosst_AlkEthOH; none in set but here as format placeholder -->
 </ImproperTorsions>
 <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstroms" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
    <!-- sigma is in angstroms, epsilon is in kcal/mol -->
    <Atom smirks="[#1:1]" rmin_half="1.4870" epsilon="0.0157" id="n0001" parent_id="n0001"/> <!-- making HC the generic hydrogen -->
    <Atom smirks="[$([#1]-[#6]):1]" rmin_half="1.4870" epsilon="0.0157" id="n0002" parent_id="n0001"/> <!-- HC from frcmod.Frosst_AlkEthOH -->

--- a/openforcefield/data/forcefield/Frosst_AlkEthOH.offxml
+++ b/openforcefield/data/forcefield/Frosst_AlkEthOH.offxml
@@ -44,7 +44,7 @@
    <Improper smirks="[a,A:1]~[#6X3:2]([a,A:3])~[#8X1:4]" periodicity1="2" phase1="180.0" k1="10.5" id="i0001" parent_id="i0001"/> <!-- X -X -C -O  from frcmod.Frosst_AlkEthOH; none in set but here as format placeholder -->
 </ImproperTorsions>
 <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-<vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstroms" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstroms" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
    <!-- sigma is in angstroms, epsilon is in kcal/mol -->
    <Atom smirks="[#1:1]" rmin_half="1.4870" epsilon="0.0157" id="n0001" parent_id="n0001"/> <!-- making HC the generic hydrogen -->
    <Atom smirks="[$([#1]-[#6]):1]" rmin_half="1.4870" epsilon="0.0157" id="n0002" parent_id="n0001"/> <!-- HC from frcmod.Frosst_AlkEthOH -->

--- a/openforcefield/data/forcefield/Frosst_AlkEthOH.offxml
+++ b/openforcefield/data/forcefield/Frosst_AlkEthOH.offxml
@@ -44,7 +44,7 @@
    <Improper smirks="[a,A:1]~[#6X3:2]([a,A:3])~[#8X1:4]" periodicity1="2" phase1="180.0" k1="10.5" id="i0001" parent_id="i0001"/> <!-- X -X -C -O  from frcmod.Frosst_AlkEthOH; none in set but here as format placeholder -->
 </ImproperTorsions>
 <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
    <!-- sigma is in angstroms, epsilon is in kcal/mol -->
    <Atom smirks="[#1:1]" rmin_half="1.4870" epsilon="0.0157" id="n0001" parent_id="n0001"/> <!-- making HC the generic hydrogen -->
    <Atom smirks="[$([#1]-[#6]):1]" rmin_half="1.4870" epsilon="0.0157" id="n0002" parent_id="n0001"/> <!-- HC from frcmod.Frosst_AlkEthOH -->

--- a/openforcefield/data/forcefield/Frosst_AlkEthOH.offxml
+++ b/openforcefield/data/forcefield/Frosst_AlkEthOH.offxml
@@ -44,7 +44,7 @@
    <Improper smirks="[a,A:1]~[#6X3:2]([a,A:3])~[#8X1:4]" periodicity1="2" phase1="180.0" k1="10.5" id="i0001" parent_id="i0001"/> <!-- X -X -C -O  from frcmod.Frosst_AlkEthOH; none in set but here as format placeholder -->
 </ImproperTorsions>
 <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" method="cutoff">
    <!-- sigma is in angstroms, epsilon is in kcal/mol -->
    <Atom smirks="[#1:1]" rmin_half="1.4870" epsilon="0.0157" id="n0001" parent_id="n0001"/> <!-- making HC the generic hydrogen -->
    <Atom smirks="[$([#1]-[#6]):1]" rmin_half="1.4870" epsilon="0.0157" id="n0002" parent_id="n0001"/> <!-- HC from frcmod.Frosst_AlkEthOH -->

--- a/openforcefield/data/forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml
+++ b/openforcefield/data/forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml
@@ -47,7 +47,7 @@
    <Improper smirks="[a,A:1]~[#6X3:2]([a,A:3])~[OX1:4]" periodicity1="2" phase1="180.0" k1="10.5" id="i0001" parent_id="i0001"/> <!-- X -X -C -O  from frcmod.Frosst_AlkEthOH; none in set but here as format placeholder -->
 </ImproperTorsions>
 <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-<vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstroms" cutoff="9.0" cutoff_unit="angstroms" long_range_dispersion="isotropic">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstroms" cutoff="9.0" cutoff_unit="angstroms" long_range_dispersion="isotropic">
    <!-- rmin_half is in angstroms, epsilon is in kcal/mol -->
    <Atom smirks="[#1:1]" rmin_half="1.4870" epsilon="0.0157" id="n0001" parent_id="n0001"/> <!-- making HC the generic hydrogen -->
    <Atom smirks="[$([#1]-C):1]" rmin_half="1.4870" epsilon="0.0157" id="n0002" parent_id="n0001"/> <!-- HC from frcmod.Frosst_AlkEthOH -->

--- a/openforcefield/data/forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml
+++ b/openforcefield/data/forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml
@@ -47,7 +47,7 @@
    <Improper smirks="[a,A:1]~[#6X3:2]([a,A:3])~[OX1:4]" periodicity1="2" phase1="180.0" k1="10.5" id="i0001" parent_id="i0001"/> <!-- X -X -C -O  from frcmod.Frosst_AlkEthOH; none in set but here as format placeholder -->
 </ImproperTorsions>
 <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstroms" cutoff="9.0" cutoff_unit="angstroms" long_range_dispersion="isotropic">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
    <!-- rmin_half is in angstroms, epsilon is in kcal/mol -->
    <Atom smirks="[#1:1]" rmin_half="1.4870" epsilon="0.0157" id="n0001" parent_id="n0001"/> <!-- making HC the generic hydrogen -->
    <Atom smirks="[$([#1]-C):1]" rmin_half="1.4870" epsilon="0.0157" id="n0002" parent_id="n0001"/> <!-- HC from frcmod.Frosst_AlkEthOH -->

--- a/openforcefield/data/forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml
+++ b/openforcefield/data/forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml
@@ -47,7 +47,7 @@
    <Improper smirks="[a,A:1]~[#6X3:2]([a,A:3])~[OX1:4]" periodicity1="2" phase1="180.0" k1="10.5" id="i0001" parent_id="i0001"/> <!-- X -X -C -O  from frcmod.Frosst_AlkEthOH; none in set but here as format placeholder -->
 </ImproperTorsions>
 <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
    <!-- rmin_half is in angstroms, epsilon is in kcal/mol -->
    <Atom smirks="[#1:1]" rmin_half="1.4870" epsilon="0.0157" id="n0001" parent_id="n0001"/> <!-- making HC the generic hydrogen -->
    <Atom smirks="[$([#1]-C):1]" rmin_half="1.4870" epsilon="0.0157" id="n0002" parent_id="n0001"/> <!-- HC from frcmod.Frosst_AlkEthOH -->
@@ -61,5 +61,4 @@
    <Atom smirks="[#8X2:1]" rmin_half="1.6837" epsilon="0.1700" id="n0010" parent_id="n0009"/> <!-- OS from frcmod.Frosst_AlkEthOH -->
    <Atom smirks="[#8X2+0$(*-[#1]):1]" rmin_half="1.7210" epsilon="0.2104" id="n0011" parent_id="n0009"/> <!-- OH from frcmod.Frosst_AlkEthOH -->
 </vdW>
-
 </SMIRNOFF>

--- a/openforcefield/data/forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml
+++ b/openforcefield/data/forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml
@@ -47,7 +47,7 @@
    <Improper smirks="[a,A:1]~[#6X3:2]([a,A:3])~[OX1:4]" periodicity1="2" phase1="180.0" k1="10.5" id="i0001" parent_id="i0001"/> <!-- X -X -C -O  from frcmod.Frosst_AlkEthOH; none in set but here as format placeholder -->
 </ImproperTorsions>
 <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" method="cutoff">
    <!-- rmin_half is in angstroms, epsilon is in kcal/mol -->
    <Atom smirks="[#1:1]" rmin_half="1.4870" epsilon="0.0157" id="n0001" parent_id="n0001"/> <!-- making HC the generic hydrogen -->
    <Atom smirks="[$([#1]-C):1]" rmin_half="1.4870" epsilon="0.0157" id="n0002" parent_id="n0001"/> <!-- HC from frcmod.Frosst_AlkEthOH -->

--- a/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_2.offxml
+++ b/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_2.offxml
@@ -306,7 +306,7 @@
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
   <!-- Old tag: NonbondedForce coulomb14scale="0.833333" lj14scale="0.5" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" method="cutoff">
     <Atom smirks="[*:1]" epsilon="0.25" id="n1" rmin_half="4."/>
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n2" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n3" rmin_half="1.4870"/>

--- a/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_2.offxml
+++ b/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_2.offxml
@@ -306,7 +306,7 @@
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
   <!-- Old tag: NonbondedForce coulomb14scale="0.833333" lj14scale="0.5" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
     <Atom smirks="[*:1]" epsilon="0.25" id="n1" rmin_half="4."/>
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n2" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n3" rmin_half="1.4870"/>

--- a/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_2.offxml
+++ b/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_2.offxml
@@ -306,7 +306,7 @@
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
   <!-- Old tag: NonbondedForce coulomb14scale="0.833333" lj14scale="0.5" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[*:1]" epsilon="0.25" id="n1" rmin_half="4."/>
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n2" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n3" rmin_half="1.4870"/>

--- a/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_2.offxml
+++ b/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_2.offxml
@@ -306,7 +306,7 @@
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
   <!-- Old tag: NonbondedForce coulomb14scale="0.833333" lj14scale="0.5" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[*:1]" epsilon="0.25" id="n1" rmin_half="4."/>
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n2" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n3" rmin_half="1.4870"/>

--- a/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_4.offxml
+++ b/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_4.offxml
@@ -306,7 +306,7 @@
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
   <!-- Old tag: NonbondedForce coulomb14scale="0.833333" lj14scale="0.5" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" method="cutoff">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
     <Atom smirks="[#1:1]-[#6X4]-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157" id="n3" rmin_half="1.3870"/>

--- a/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_4.offxml
+++ b/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_4.offxml
@@ -306,7 +306,7 @@
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
   <!-- Old tag: NonbondedForce coulomb14scale="0.833333" lj14scale="0.5" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
     <Atom smirks="[#1:1]-[#6X4]-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157" id="n3" rmin_half="1.3870"/>

--- a/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_4_fixed.offxml
+++ b/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_4_fixed.offxml
@@ -307,7 +307,7 @@
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
   <!-- Old tag: NonbondedForce coulomb14scale="0.833333" lj14scale="0.5" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
     <Atom smirks="[#1:1]-[#6X4]-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157" id="n3" rmin_half="1.3870"/>

--- a/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_4_fixed.offxml
+++ b/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_4_fixed.offxml
@@ -307,7 +307,7 @@
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
   <!-- Old tag: NonbondedForce coulomb14scale="0.833333" lj14scale="0.5" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" method="cutoff">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
     <Atom smirks="[#1:1]-[#6X4]-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157" id="n3" rmin_half="1.3870"/>

--- a/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_4_fixed.offxml
+++ b/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_4_fixed.offxml
@@ -307,7 +307,7 @@
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
   <!-- Old tag: NonbondedForce coulomb14scale="0.833333" lj14scale="0.5" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
     <Atom smirks="[#1:1]-[#6X4]-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157" id="n3" rmin_half="1.3870"/>

--- a/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_4_fixed.offxml
+++ b/openforcefield/data/forcefield/old/smirnoff99Frosst_0_0_4_fixed.offxml
@@ -307,7 +307,7 @@
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
   <!-- Old tag: NonbondedForce coulomb14scale="0.833333" lj14scale="0.5" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
     <Atom smirks="[#1:1]-[#6X4]-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157" id="n3" rmin_half="1.3870"/>

--- a/openforcefield/data/forcefield/smirnoff99Frosst.offxml
+++ b/openforcefield/data/forcefield/smirnoff99Frosst.offxml
@@ -304,7 +304,7 @@
     <Improper smirks="[*:1]~[#6X3:2](=[#7X2,#7X3+1:3])~[#7:4]" id="i4" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="8.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
     <Atom smirks="[#1:1]-[#6X4]-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157" id="n3" rmin_half="1.3870"/>

--- a/openforcefield/data/forcefield/smirnoff99Frosst.offxml
+++ b/openforcefield/data/forcefield/smirnoff99Frosst.offxml
@@ -304,7 +304,7 @@
     <Improper smirks="[*:1]~[#6X3:2](=[#7X2,#7X3+1:3])~[#7:4]" id="i4" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" method="cutoff">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
     <Atom smirks="[#1:1]-[#6X4]-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157" id="n3" rmin_half="1.3870"/>
@@ -341,7 +341,7 @@
     <Atom smirks="[#35X0-1:1]" epsilon="0.0586554" id="n34" rmin_half="2.608"/>
     <Atom smirks="[#53X0-1:1]" epsilon="0.0536816" id="n35" rmin_half="2.860"/>
   </vdW>
-  <Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333"/>
+  <Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0" cutoff_unit="angstrom" />
   <ToolkitAM1BCC/>
   <!-- Note that the AM1-BCC charge model is not yet encoded as a ChargeIncrementModel -->
 </SMIRNOFF>

--- a/openforcefield/data/forcefield/smirnoff99Frosst.offxml
+++ b/openforcefield/data/forcefield/smirnoff99Frosst.offxml
@@ -304,7 +304,7 @@
     <Improper smirks="[*:1]~[#6X3:2](=[#7X2,#7X3+1:3])~[#7:4]" id="i4" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
     <Atom smirks="[#1:1]-[#6X4]-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157" id="n3" rmin_half="1.3870"/>
@@ -341,7 +341,7 @@
     <Atom smirks="[#35X0-1:1]" epsilon="0.0586554" id="n34" rmin_half="2.608"/>
     <Atom smirks="[#53X0-1:1]" epsilon="0.0536816" id="n35" rmin_half="2.860"/>
   </vdW>
-  <Electrostatics method="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333"/>
+  <Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333"/>
   <ToolkitAM1BCC/>
   <!-- Note that the AM1-BCC charge model is not yet encoded as a ChargeIncrementModel -->
 </SMIRNOFF>

--- a/openforcefield/data/forcefield/smirnoff99Frosst.offxml
+++ b/openforcefield/data/forcefield/smirnoff99Frosst.offxml
@@ -304,7 +304,7 @@
     <Improper smirks="[*:1]~[#6X3:2](=[#7X2,#7X3+1:3])~[#7:4]" id="i4" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="8.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
     <Atom smirks="[#1:1]-[#6X4]-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157" id="n3" rmin_half="1.3870"/>
@@ -341,7 +341,7 @@
     <Atom smirks="[#35X0-1:1]" epsilon="0.0586554" id="n34" rmin_half="2.608"/>
     <Atom smirks="[#53X0-1:1]" epsilon="0.0536816" id="n35" rmin_half="2.860"/>
   </vdW>
-  <Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333"/>
+  <Electrostatics method="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333"/>
   <ToolkitAM1BCC/>
   <!-- Note that the AM1-BCC charge model is not yet encoded as a ChargeIncrementModel -->
 </SMIRNOFF>

--- a/openforcefield/data/forcefield/smirnoff99Frosst.offxml
+++ b/openforcefield/data/forcefield/smirnoff99Frosst.offxml
@@ -304,7 +304,7 @@
     <Improper smirks="[*:1]~[#6X3:2](=[#7X2,#7X3+1:3])~[#7:4]" id="i4" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
     <Atom smirks="[#1:1]-[#6X4]-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157" id="n3" rmin_half="1.3870"/>
@@ -341,7 +341,7 @@
     <Atom smirks="[#35X0-1:1]" epsilon="0.0586554" id="n34" rmin_half="2.608"/>
     <Atom smirks="[#53X0-1:1]" epsilon="0.0536816" id="n35" rmin_half="2.860"/>
   </vdW>
+  <Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333"/>
   <ToolkitAM1BCC/>
-
   <!-- Note that the AM1-BCC charge model is not yet encoded as a ChargeIncrementModel -->
 </SMIRNOFF>

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -358,6 +358,18 @@ class TestForceField():
 
         omm_system = forcefield.create_openmm_system(topology)
 
+    @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
+    def test_parameterize_no_matching_reference(self, toolkit_registry, registry_description):
+        from simtk.openmm import app
+        from openforcefield.topology import Topology
+        forcefield = ForceField('smirnoff99Frosst.offxml')
+        pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
+        # toolkit_wrapper = RDKitToolkitWrapper()
+        molecules = []
+        molecules.append(Molecule.from_smiles('CC'))
+        with pytest.raises(ValueError, match='No match found for molecule'):
+            topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
+
     @pytest.mark.slow
     @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
     @pytest.mark.parametrize("box", ['ethanol_water.pdb',

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -227,20 +227,20 @@ nonbonded_resolution_matrix = [
     {'vdw_method': 'cutoff', 'electrostatics_method': 'PME', 'has_periodic_box': True,
      'omm_force': openmm.NonbondedForce.PME, 'exception': None, 'exception_match': ''},
     {'vdw_method': 'cutoff', 'electrostatics_method': 'PME', 'has_periodic_box': False,
-     'omm_force': None, 'exception': IncompatibleParameterError, 'exception_match': ''},
+     'omm_force': openmm.NonbondedForce.NoCutoff, 'exception': None, 'exception_match': ''},
 
     {'vdw_method': 'PME', 'electrostatics_method': 'Coulomb', 'has_periodic_box': True,
      'omm_force': None, 'exception': IncompatibleParameterError, 'exception_match': ''},
     {'vdw_method': 'PME', 'electrostatics_method': 'Coulomb', 'has_periodic_box': False,
-     'omm_force': None, 'exception': SMIRNOFFSpecError, 'exception_match': ''},
+     'omm_force': openmm.NonbondedForce.NoCutoff, 'exception': None, 'exception_match': ''},
     {'vdw_method': 'PME', 'electrostatics_method': 'reaction-field', 'has_periodic_box': True,
      'omm_force': None, 'exception': IncompatibleParameterError, 'exception_match': ''},
     {'vdw_method': 'PME', 'electrostatics_method': 'reaction-field', 'has_periodic_box': False,
-     'omm_force': None, 'exception': SMIRNOFFSpecError, 'exception_match': ''},
+     'omm_force': None, 'exception': IncompatibleParameterError, 'exception_match': ''},
     {'vdw_method': 'PME', 'electrostatics_method': 'PME', 'has_periodic_box': True,
      'omm_force': openmm.NonbondedForce.LJPME, 'exception': None, 'exception_match': ''},
     {'vdw_method': 'PME', 'electrostatics_method': 'PME', 'has_periodic_box': False,
-     'omm_force': None, 'exception': SMIRNOFFSpecError, 'exception_match': ''},
+     'omm_force': openmm.NonbondedForce.NoCutoff, 'exception': None, 'exception_match': ''},
      ]
 
 
@@ -404,8 +404,8 @@ class TestForceField():
         #                                                                      'molecules/cyclohexane.mol2')]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         topology.box_vectors = None
-        forcefield.get_handler("Electrostatics", {})._method = "Coulomb"
-        forcefield.get_handler("vdW", {})._method = "cutoff"
+        #forcefield.get_handler("Electrostatics", {})._method = "Coulomb"
+        #forcefield.get_handler("vdW", {})._method = "cutoff"
 
         omm_system = forcefield.create_openmm_system(topology)
 
@@ -628,12 +628,6 @@ class TestForceField():
     @pytest.mark.parametrize("inputs", nonbonded_resolution_matrix)
     def test_nonbonded_method_resolution(self,
                                          inputs
-                                         # vdw_method=None,
-                                         # electrostatics_method=None,
-                                         # has_periodic_box=None,
-                                         # omm_force=None,
-                                         # exception=None,
-                                         # exception_match=None
                                          ):
         """Test predefined permutations of input options to ensure nonbonded handling is correctly resolved"""
         from simtk.openmm import app

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -360,11 +360,9 @@ class TestForceField():
 
     @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
     def test_parameterize_1_cyclohexane_1_ethanol_vacuum(self, toolkit_registry, registry_description):
-        # TODO: Need to load a SMIRNOFF data source with vdw = isotropic and es = PME
         from simtk.openmm import app
         from openforcefield.topology import Topology
         forcefield = ForceField('smirnoff99Frosst.offxml')
-        forcefield.configure_vacuum()
         pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
         # toolkit_wrapper = RDKitToolkitWrapper()
         molecules = []
@@ -374,6 +372,8 @@ class TestForceField():
         #                                                                      'molecules/cyclohexane.mol2')]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         topology.box_vectors = None
+        forcefield.get_handler("Electrostatics", {})._method = "Coulomb"
+        forcefield.get_handler("vdW", {})._long_range_dispersion = "None"
 
         omm_system = forcefield.create_openmm_system(topology)
 
@@ -667,7 +667,6 @@ def test_alkethoh_parameters_assignment(alkethoh_id):
 
     # Load forcefield
     forcefield = ForceField('Frosst_AlkEthOH_parmAtFrosst.offxml')
-    forcefield.configure_vacuum()
 
     # Compare parameters. Skip the energy checks as the parameter check should be
     # sufficient. We test both energies and parameters in the slow test.
@@ -745,7 +744,6 @@ def test_freesolv_parameters_assignment(freesolv_id, forcefield_version, allow_u
     # Create OpenFF System with the current toolkit.
     forcefield_file_path = 'old/smirnoff99Frosst_' + forcefield_version + '.offxml'
     ff = ForceField(forcefield_file_path, 'old/hbonds.offxml')
-    ff.configure_vacuum()
     ff_system = ff.create_openmm_system(molecule.to_topology())
 
     # Load OpenMM System created with the 0.1 version of the toolkit.

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -386,6 +386,24 @@ class TestForceField():
         omm_system = forcefield.create_openmm_system(topology)
 
     @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
+    def test_parameterize_1_cyclohexane_1_ethanol_periodic(self, toolkit_registry, registry_description):
+        raise NotImplementedError
+        # TODO: Need to load a SMIRNOFF data source with vdw = isotropic and es = PME
+        from simtk.openmm import app
+        from openforcefield.topology import Topology
+        forcefield = ForceField('smirnoff99Frosst.offxml')
+        pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
+        # toolkit_wrapper = RDKitToolkitWrapper()
+        molecules = []
+        molecules.append(Molecule.from_smiles('CCO'))
+        molecules.append(Molecule.from_smiles('C1CCCCC1'))
+        # molecules = [Molecule.from_file(get_data_filename(name)) for name in ('molecules/ethanol.mol2',
+        #                                                                      'molecules/cyclohexane.mol2')]
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
+
+        omm_system = forcefield.create_openmm_system(topology)
+
+    @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
     def test_parameterize_no_matching_reference(self, toolkit_registry, registry_description):
         from simtk.openmm import app
         from openforcefield.topology import Topology

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -50,10 +50,11 @@ simple_xml_ff = str.encode('''<?xml version='1.0' encoding='ASCII'?>
     <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
     <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
   </vdW>
+  <Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333"/>
   <ToolkitAM1BCC/>
 </SMIRNOFF>
 ''')
@@ -82,10 +83,11 @@ xml_ff_w_comments = '''<?xml version='1.0' encoding='ASCII'?>
     <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
     <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
   </vdW>
+  <Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333"/>
   <ToolkitAM1BCC/>
 </SMIRNOFF>
 '''
@@ -114,12 +116,12 @@ xml_ff_w_cosmetic_elements = '''<?xml version='1.0' encoding='ASCII'?>
     <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
     <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
   </vdW>
-    <ToolkitAM1BCC/>
-
+  <Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333"/>
+  <ToolkitAM1BCC/>
 </SMIRNOFF>
 '''
 

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -50,7 +50,34 @@ simple_xml_ff = str.encode('''<?xml version='1.0' encoding='ASCII'?>
     <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
     <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="8.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
+    <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
+    <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
+  </vdW>
+  <Electrostatics method="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333"/>
+  <ToolkitAM1BCC/>
+</SMIRNOFF>
+''')
+
+simple_xml_ff_periodic = str.encode('''<?xml version='1.0' encoding='ASCII'?>
+<SMIRNOFF version="1.0" aromaticity_model="OEAroModel_MDL">
+  <Bonds length_unit="angstroms" k_unit="kilocalories_per_mole/angstrom**2">
+    <Bond smirks="[#6X4:1]-[#6X4:2]" id="b1" k="620.0" length="1.526"/>
+    <Bond smirks="[#6X4:1]-[#6X3:2]" id="b2" k="634.0" length="1.51"/>
+  </Bonds>
+  <Angles angle_unit="degrees" k_unit="kilocalories_per_mole/radian**2">
+    <Angle smirks="[*:1]~[#6X4:2]-[*:3]" angle="109.5" id="a1" k="100.0"/>
+    <Angle smirks="[#1:1]-[#6X4:2]-[#1:3]" angle="109.5" id="a2" k="70.0"/>
+  </Angles>
+  <ProperTorsions potential="charmm" phase_unit="degrees" k_unit="kilocalories_per_mole">
+    <Proper smirks="[*:1]-[#6X4:2]-[#6X4:3]-[*:4]" id="t1" idivf1="1" k1="0.156" periodicity1="3" phase1="0.0"/>
+    <Proper smirks="[#6X4:1]-[#6X4:2]-[#6X4:3]-[#6X4:4]" id="t2" idivf1="1" k1="0.180" periodicity1="3" phase1="0.0" periodicity2="2" phase2="180.0" idivf2="1" k2="0.250" periodicity3="1" phase3="180.0" idivf3="1" k3="0.200"/>
+  </ProperTorsions>
+  <ImproperTorsions potential="charmm" phase_unit="degrees" k_unit="kilocalories_per_mole">
+    <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
+    <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
+  </ImproperTorsions>
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole"  switch_width="8.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
   </vdW>
@@ -83,11 +110,11 @@ xml_ff_w_comments = '''<?xml version='1.0' encoding='ASCII'?>
     <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
     <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="8.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
   </vdW>
-  <Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333"/>
+  <Electrostatics method="isotropic" scale12="0.0" scale13="0.0" scale14="0.833333"/>
   <ToolkitAM1BCC/>
 </SMIRNOFF>
 '''
@@ -116,11 +143,11 @@ xml_ff_w_cosmetic_elements = '''<?xml version='1.0' encoding='ASCII'?>
     <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
     <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="8.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole"   long_range_dispersion="None">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
   </vdW>
-  <Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333"/>
+  <Electrostatics method="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333"/>
   <ToolkitAM1BCC/>
 </SMIRNOFF>
 '''

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -338,7 +338,7 @@ class TestForceField():
         pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
         molecules = []
         molecules.append(Molecule.from_smiles('CCO'))
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, load_box_vectors=True)
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, )
 
         omm_system = forcefield.create_openmm_system(topology, toolkit_registry=toolkit_registry)
 
@@ -354,7 +354,7 @@ class TestForceField():
         molecules.append(Molecule.from_smiles('C1CCCCC1'))
         # molecules = [Molecule.from_file(get_data_filename(name)) for name in ('molecules/ethanol.mol2',
         #                                                                      'molecules/cyclohexane.mol2')]
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, load_box_vectors=True)
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, )
 
         omm_system = forcefield.create_openmm_system(topology)
 
@@ -373,10 +373,10 @@ class TestForceField():
         # molecules = [Molecule.from_file(get_data_filename(name)) for name in ('molecules/ethanol.mol2',
         #                                                                      'molecules/cyclohexane.mol2')]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
+        topology.box_vectors = None
 
         omm_system = forcefield.create_openmm_system(topology)
 
-        assert omm_system.getNonbonded
 
     @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
     def test_parameterize_no_matching_reference(self, toolkit_registry, registry_description):
@@ -405,7 +405,7 @@ class TestForceField():
         mol_names = ['water', 'cyclohexane', 'ethanol', 'propane', 'methane', 'butanol']
         sdf_files = [get_data_filename(os.path.join('systems', 'monomers', name+'.sdf')) for name in mol_names]
         molecules = [Molecule.from_file(sdf_file) for sdf_file in sdf_files]
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, load_box_vectors=True)
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, )
 
         omm_system = forcefield.create_openmm_system(topology, toolkit_registry=toolkit_registry)
         # TODO: Add check to ensure system energy is finite
@@ -426,7 +426,6 @@ class TestForceField():
         molecules1 = [Molecule.from_file(get_data_filename('molecules/ethanol.sdf'))]
         topology1 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules1,
-                                         load_box_vectors = True
                                          )
         omm_system1 = forcefield.create_openmm_system(topology1,
                                                       toolkit_registry=toolkit_registry)
@@ -434,7 +433,6 @@ class TestForceField():
         molecules2 = [Molecule.from_file(get_data_filename('molecules/ethanol_reordered.sdf'))]
         topology2 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules2,
-                                         load_box_vectors=True
                                          )
         omm_system2 = forcefield.create_openmm_system(topology2,
                                                       toolkit_registry=toolkit_registry)
@@ -466,7 +464,7 @@ class TestForceField():
         molecules1 = [Molecule.from_file(get_data_filename('molecules/ethanol.sdf'))]
         topology1 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules1,
-                                         load_box_vectors=True
+                                         
                                          )
         omm_system1 = forcefield.create_openmm_system(topology1,
                                                       toolkit_registry=toolkit_registry)
@@ -475,7 +473,6 @@ class TestForceField():
         molecules2 = [Molecule.from_file(get_data_filename('molecules/ethanol_reordered.sdf'))]
         topology2 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules2,
-                                         load_box_vectors = True
                                          )
         omm_system2 = forcefield.create_openmm_system(topology2,
                                                       toolkit_registry=toolkit_registry)
@@ -514,7 +511,7 @@ class TestForceField():
         filename = get_data_filename('forcefield/smirnoff99Frosst.offxml')
         forcefield = ForceField(filename)
         pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, load_box_vectors = True)
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         omm_system = forcefield.create_openmm_system(topology, charge_from_molecules=molecules,
                                                      toolkit_registry=toolkit_registry)
         nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
@@ -529,7 +526,7 @@ class TestForceField():
         # In 1_ethanol_reordered.pdb, the first three atoms go O-C-C instead of C-C-O. This part of the test ensures
         # that the charges are correctly mapped according to this PDB in the resulting system.
         pdbfile2 = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol_reordered.pdb'))
-        topology2 = Topology.from_openmm(pdbfile2.topology, unique_molecules=molecules, load_box_vectors=True)
+        topology2 = Topology.from_openmm(pdbfile2.topology, unique_molecules=molecules, )
 
         omm_system2 = forcefield.create_openmm_system(topology2, charge_from_molecules=molecules,
                                                       toolkit_registry=toolkit_registry)
@@ -558,7 +555,7 @@ class TestForceField():
         filename = get_data_filename('forcefield/smirnoff99Frosst.offxml')
         forcefield = ForceField(filename)
         pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, load_box_vectors=True)
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, )
 
         omm_system = forcefield.create_openmm_system(topology,
                                                      charge_from_molecules=[ethanol],
@@ -589,7 +586,7 @@ class TestForceField():
         pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
         molecules = []
         molecules.append(Molecule.from_smiles('CCO'))
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, load_box_vectors=True)
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, )
 
         with pytest.raises(ValueError, match=".* not used by any registered force Handler: {'invalid_kwarg'}.*") as e:
             omm_system = forcefield.create_openmm_system(topology, invalid_kwarg='aaa', toolkit_registry=toolkit_registry)

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -50,7 +50,7 @@ simple_xml_ff = str.encode('''<?xml version='1.0' encoding='ASCII'?>
     <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
     <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="8.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
   </vdW>
@@ -83,7 +83,7 @@ xml_ff_w_comments = '''<?xml version='1.0' encoding='ASCII'?>
     <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
     <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="8.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
   </vdW>
@@ -116,7 +116,7 @@ xml_ff_w_cosmetic_elements = '''<?xml version='1.0' encoding='ASCII'?>
     <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
     <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0" switch_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="8.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
   </vdW>
@@ -352,7 +352,7 @@ class TestForceField():
         molecules = []
         molecules.append(Molecule.from_smiles('CCO'))
         molecules.append(Molecule.from_smiles('C1CCCCC1'))
-        #molecules = [Molecule.from_file(get_data_filename(name)) for name in ('molecules/ethanol.mol2',
+        # molecules = [Molecule.from_file(get_data_filename(name)) for name in ('molecules/ethanol.mol2',
         #                                                                      'molecules/cyclohexane.mol2')]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -50,34 +50,7 @@ simple_xml_ff = str.encode('''<?xml version='1.0' encoding='ASCII'?>
     <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
     <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
-    <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
-    <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
-  </vdW>
-  <Electrostatics method="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333"/>
-  <ToolkitAM1BCC/>
-</SMIRNOFF>
-''')
-
-simple_xml_ff_periodic = str.encode('''<?xml version='1.0' encoding='ASCII'?>
-<SMIRNOFF version="1.0" aromaticity_model="OEAroModel_MDL">
-  <Bonds length_unit="angstroms" k_unit="kilocalories_per_mole/angstrom**2">
-    <Bond smirks="[#6X4:1]-[#6X4:2]" id="b1" k="620.0" length="1.526"/>
-    <Bond smirks="[#6X4:1]-[#6X3:2]" id="b2" k="634.0" length="1.51"/>
-  </Bonds>
-  <Angles angle_unit="degrees" k_unit="kilocalories_per_mole/radian**2">
-    <Angle smirks="[*:1]~[#6X4:2]-[*:3]" angle="109.5" id="a1" k="100.0"/>
-    <Angle smirks="[#1:1]-[#6X4:2]-[#1:3]" angle="109.5" id="a2" k="70.0"/>
-  </Angles>
-  <ProperTorsions potential="charmm" phase_unit="degrees" k_unit="kilocalories_per_mole">
-    <Proper smirks="[*:1]-[#6X4:2]-[#6X4:3]-[*:4]" id="t1" idivf1="1" k1="0.156" periodicity1="3" phase1="0.0"/>
-    <Proper smirks="[#6X4:1]-[#6X4:2]-[#6X4:3]-[#6X4:4]" id="t2" idivf1="1" k1="0.180" periodicity1="3" phase1="0.0" periodicity2="2" phase2="180.0" idivf2="1" k2="0.250" periodicity3="1" phase3="180.0" idivf3="1" k3="0.200"/>
-  </ProperTorsions>
-  <ImproperTorsions potential="charmm" phase_unit="degrees" k_unit="kilocalories_per_mole">
-    <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
-    <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
-  </ImproperTorsions>
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole"  switch_width="8.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
   </vdW>
@@ -110,11 +83,11 @@ xml_ff_w_comments = '''<?xml version='1.0' encoding='ASCII'?>
     <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
     <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" long_range_dispersion="None">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
   </vdW>
-  <Electrostatics method="isotropic" scale12="0.0" scale13="0.0" scale14="0.833333"/>
+  <Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333"/>
   <ToolkitAM1BCC/>
 </SMIRNOFF>
 '''
@@ -143,11 +116,11 @@ xml_ff_w_cosmetic_elements = '''<?xml version='1.0' encoding='ASCII'?>
     <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
     <Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" id="i2" k1="10.5" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole"   long_range_dispersion="None">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" rmin_half_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="8.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157" id="n2" rmin_half="1.4870"/>
   </vdW>
-  <Electrostatics method="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333"/>
+  <Electrostatics method="PME" scale12="0.0" scale13="0.0" scale14="0.833333"/>
   <ToolkitAM1BCC/>
 </SMIRNOFF>
 '''
@@ -365,7 +338,7 @@ class TestForceField():
         pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
         molecules = []
         molecules.append(Molecule.from_smiles('CCO'))
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, load_box_vectors=True)
 
         omm_system = forcefield.create_openmm_system(topology, toolkit_registry=toolkit_registry)
 
@@ -381,17 +354,17 @@ class TestForceField():
         molecules.append(Molecule.from_smiles('C1CCCCC1'))
         # molecules = [Molecule.from_file(get_data_filename(name)) for name in ('molecules/ethanol.mol2',
         #                                                                      'molecules/cyclohexane.mol2')]
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, load_box_vectors=True)
 
         omm_system = forcefield.create_openmm_system(topology)
 
     @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
-    def test_parameterize_1_cyclohexane_1_ethanol_periodic(self, toolkit_registry, registry_description):
-        raise NotImplementedError
+    def test_parameterize_1_cyclohexane_1_ethanol_vacuum(self, toolkit_registry, registry_description):
         # TODO: Need to load a SMIRNOFF data source with vdw = isotropic and es = PME
         from simtk.openmm import app
         from openforcefield.topology import Topology
         forcefield = ForceField('smirnoff99Frosst.offxml')
+        forcefield.configure_vacuum()
         pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
         # toolkit_wrapper = RDKitToolkitWrapper()
         molecules = []
@@ -402,6 +375,8 @@ class TestForceField():
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 
         omm_system = forcefield.create_openmm_system(topology)
+
+        assert omm_system.getNonbonded
 
     @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
     def test_parameterize_no_matching_reference(self, toolkit_registry, registry_description):
@@ -430,7 +405,7 @@ class TestForceField():
         mol_names = ['water', 'cyclohexane', 'ethanol', 'propane', 'methane', 'butanol']
         sdf_files = [get_data_filename(os.path.join('systems', 'monomers', name+'.sdf')) for name in mol_names]
         molecules = [Molecule.from_file(sdf_file) for sdf_file in sdf_files]
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, load_box_vectors=True)
 
         omm_system = forcefield.create_openmm_system(topology, toolkit_registry=toolkit_registry)
         # TODO: Add check to ensure system energy is finite
@@ -451,6 +426,7 @@ class TestForceField():
         molecules1 = [Molecule.from_file(get_data_filename('molecules/ethanol.sdf'))]
         topology1 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules1,
+                                         load_box_vectors = True
                                          )
         omm_system1 = forcefield.create_openmm_system(topology1,
                                                       toolkit_registry=toolkit_registry)
@@ -458,6 +434,7 @@ class TestForceField():
         molecules2 = [Molecule.from_file(get_data_filename('molecules/ethanol_reordered.sdf'))]
         topology2 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules2,
+                                         load_box_vectors=True
                                          )
         omm_system2 = forcefield.create_openmm_system(topology2,
                                                       toolkit_registry=toolkit_registry)
@@ -489,6 +466,7 @@ class TestForceField():
         molecules1 = [Molecule.from_file(get_data_filename('molecules/ethanol.sdf'))]
         topology1 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules1,
+                                         load_box_vectors=True
                                          )
         omm_system1 = forcefield.create_openmm_system(topology1,
                                                       toolkit_registry=toolkit_registry)
@@ -497,6 +475,7 @@ class TestForceField():
         molecules2 = [Molecule.from_file(get_data_filename('molecules/ethanol_reordered.sdf'))]
         topology2 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules2,
+                                         load_box_vectors = True
                                          )
         omm_system2 = forcefield.create_openmm_system(topology2,
                                                       toolkit_registry=toolkit_registry)
@@ -535,7 +514,7 @@ class TestForceField():
         filename = get_data_filename('forcefield/smirnoff99Frosst.offxml')
         forcefield = ForceField(filename)
         pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, load_box_vectors = True)
         omm_system = forcefield.create_openmm_system(topology, charge_from_molecules=molecules,
                                                      toolkit_registry=toolkit_registry)
         nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
@@ -550,7 +529,7 @@ class TestForceField():
         # In 1_ethanol_reordered.pdb, the first three atoms go O-C-C instead of C-C-O. This part of the test ensures
         # that the charges are correctly mapped according to this PDB in the resulting system.
         pdbfile2 = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol_reordered.pdb'))
-        topology2 = Topology.from_openmm(pdbfile2.topology, unique_molecules=molecules)
+        topology2 = Topology.from_openmm(pdbfile2.topology, unique_molecules=molecules, load_box_vectors=True)
 
         omm_system2 = forcefield.create_openmm_system(topology2, charge_from_molecules=molecules,
                                                       toolkit_registry=toolkit_registry)
@@ -579,7 +558,7 @@ class TestForceField():
         filename = get_data_filename('forcefield/smirnoff99Frosst.offxml')
         forcefield = ForceField(filename)
         pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, load_box_vectors=True)
 
         omm_system = forcefield.create_openmm_system(topology,
                                                      charge_from_molecules=[ethanol],
@@ -610,7 +589,7 @@ class TestForceField():
         pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
         molecules = []
         molecules.append(Molecule.from_smiles('CCO'))
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, load_box_vectors=True)
 
         with pytest.raises(ValueError, match=".* not used by any registered force Handler: {'invalid_kwarg'}.*") as e:
             omm_system = forcefield.create_openmm_system(topology, invalid_kwarg='aaa', toolkit_registry=toolkit_registry)
@@ -691,6 +670,7 @@ def test_alkethoh_parameters_assignment(alkethoh_id):
 
     # Load forcefield
     forcefield = ForceField('Frosst_AlkEthOH_parmAtFrosst.offxml')
+    forcefield.configure_vacuum()
 
     # Compare parameters. Skip the energy checks as the parameter check should be
     # sufficient. We test both energies and parameters in the slow test.
@@ -768,6 +748,7 @@ def test_freesolv_parameters_assignment(freesolv_id, forcefield_version, allow_u
     # Create OpenFF System with the current toolkit.
     forcefield_file_path = 'old/smirnoff99Frosst_' + forcefield_version + '.offxml'
     ff = ForceField(forcefield_file_path, 'old/hbonds.offxml')
+    ff.configure_vacuum()
     ff_system = ff.create_openmm_system(molecule.to_topology())
 
     # Load OpenMM System created with the 0.1 version of the toolkit.

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -460,6 +460,10 @@ class TestParameterType:
                                                         )
 
 
+
+# TODO: test_nonbonded_settings (ensure that choices in Electrostatics and vdW tags resolve
+#                                to correct openmm.NonbondedForce subtypes, that setting different cutoffs raises
+#                                exceptions, etc)
 # TODO: test_(all attributes of all ParameterTypes)
 # TODO: test_add_parameter_fractional_bondorder
 # TODO: test_get_indexed_attrib

--- a/openforcefield/tests/test_topology.py
+++ b/openforcefield/tests/test_topology.py
@@ -102,7 +102,8 @@ class TestTopology(TestCase):
         assert topology.n_topology_virtual_sites == 0
         assert topology.box_vectors is None
         assert len(topology.constrained_atom_pairs.items()) == 0
-        assert topology.is_periodic == False
+        assert topology.is_vacuum == True
+        assert topology.is_condensed == False
 
     def test_box_vectors(self):
         """Test the getter and setter for box_vectors"""
@@ -111,12 +112,14 @@ class TestTopology(TestCase):
         bad_box_vectors = np.array([10,20,30]) # They're bad because they're unitless
         assert topology.box_vectors is None
 
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(ValueError) as context:
             topology.box_vectors = bad_box_vectors
         assert topology.box_vectors is None
 
         topology.box_vectors = good_box_vectors
         assert (topology.box_vectors == good_box_vectors).all()
+        assert topology.is_vacuum == False
+        assert topology.is_condensed == True
 
 
     def test_from_smiles(self):
@@ -131,7 +134,7 @@ class TestTopology(TestCase):
         assert topology.n_topology_virtual_sites == 0
         assert topology.box_vectors is None
         assert len(topology.constrained_atom_pairs.items()) == 0
-        assert topology.is_periodic == False
+        assert topology.is_condensed == False
 
         topology.add_molecule(self.ethane_from_smiles)
 
@@ -143,7 +146,7 @@ class TestTopology(TestCase):
         assert topology.n_topology_virtual_sites == 0
         assert topology.box_vectors is None
         assert len(topology.constrained_atom_pairs.items()) == 0
-        assert topology.is_periodic == False
+        assert topology.is_condensed == False
 
     def test_from_smiles_unique_mols(self):
         """Test the addition of two different molecules to a topology"""

--- a/openforcefield/tests/test_topology.py
+++ b/openforcefield/tests/test_topology.py
@@ -102,8 +102,6 @@ class TestTopology(TestCase):
         assert topology.n_topology_virtual_sites == 0
         assert topology.box_vectors is None
         assert len(topology.constrained_atom_pairs.items()) == 0
-        assert topology.is_vacuum == True
-        assert topology.is_condensed == False
 
     def test_box_vectors(self):
         """Test the getter and setter for box_vectors"""
@@ -118,8 +116,6 @@ class TestTopology(TestCase):
 
         topology.box_vectors = good_box_vectors
         assert (topology.box_vectors == good_box_vectors).all()
-        assert topology.is_vacuum == False
-        assert topology.is_condensed == True
 
 
     def test_from_smiles(self):
@@ -134,7 +130,6 @@ class TestTopology(TestCase):
         assert topology.n_topology_virtual_sites == 0
         assert topology.box_vectors is None
         assert len(topology.constrained_atom_pairs.items()) == 0
-        assert topology.is_condensed == False
 
         topology.add_molecule(self.ethane_from_smiles)
 
@@ -146,7 +141,6 @@ class TestTopology(TestCase):
         assert topology.n_topology_virtual_sites == 0
         assert topology.box_vectors is None
         assert len(topology.constrained_atom_pairs.items()) == 0
-        assert topology.is_condensed == False
 
     def test_from_smiles_unique_mols(self):
         """Test the addition of two different molecules to a topology"""

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -833,6 +833,8 @@ class Topology(Serializable):
     """
     A Topology is a chemical representation of a system containing one or more molecules appearing in a specified order.
 
+    # TODO: Update list of attributes
+
     Attributes
     ----------
     molecules : list of Molecule
@@ -843,6 +845,8 @@ class Topology(Serializable):
         Number of molecules in the topology
     n_unique_molecules : int
         Number of unique molecules in the topology
+    box_vectors : iterable of simtk.unit.Quantity
+        The box vectors for a periodic system. If box_vectors=None, the system is assumed to be vacuum.
 
     Examples
     --------

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -2102,16 +2102,3 @@ class Topology(Serializable):
 
         pass
 
-    @property
-    def is_condensed(self):
-        """
-        ``True`` if the topology represents a condensed/periodic system; ``False`` otherwise
-        """
-        return self._box_vectors is not None
-
-    @property
-    def is_vacuum(self):
-        """
-        ``True`` if the topology represents a vacuum/nonperiodic system; ``False`` otherwise
-        """
-        return self._box_vectors is None

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -1371,7 +1371,7 @@ class Topology(Serializable):
         raise NotImplementedError()  # TODO
 
     @classmethod
-    def from_openmm(cls, openmm_topology, unique_molecules=None, load_box_vectors=False):
+    def from_openmm(cls, openmm_topology, unique_molecules=None):
         """
         Construct an openforcefield Topology object from an OpenMM Topology object.
 
@@ -1386,9 +1386,6 @@ class Topology(Serializable):
             OpenMM ``Topology``, these will be used in matching as well.
             If all bonds have bond orders assigned in ``mdtraj_topology``, these bond orders will be used to attempt to construct
             the list of unique Molecules if the ``unique_molecules`` argument is omitted.
-        load_box_vectors : bool. Default=False
-            Whether to load the box vectors from the openMM topology into the Open Force Field topology. Note that, if
-            box vectors are loaded into the OFF topology, the system is assumed to be condensed-phase
 
         Returns
         -------
@@ -1478,8 +1475,7 @@ class Topology(Serializable):
                 graph_to_unq_mol[unq_mol_G],
                 local_topology_to_reference_index=local_top_to_ref_index)
 
-        if load_box_vectors:
-            topology.box_vectors = openmm_topology.getPeriodicBoxVectors()
+        topology.box_vectors = openmm_topology.getPeriodicBoxVectors()
         # TODO: How can we preserve metadata from the openMM topology when creating the OFF topology?
         return topology
 

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -1050,7 +1050,11 @@ class Topology(Serializable):
             raise ValueError(
                 "Attempting to set box vectors in units that are incompatible with simtk.unit.Angstrom"
             )
-        assert box_vectors.shape == (3, )
+
+        if hasattr(box_vectors, 'shape'):
+            assert box_vectors.shape == (3, )
+        else:
+            assert len(box_vectors) == 3
         self._box_vectors = box_vectors
 
     @property
@@ -1363,7 +1367,7 @@ class Topology(Serializable):
         raise NotImplementedError()  # TODO
 
     @classmethod
-    def from_openmm(cls, openmm_topology, unique_molecules=None):
+    def from_openmm(cls, openmm_topology, unique_molecules=None, load_box_vectors=False):
         """
         Construct an openforcefield Topology object from an OpenMM Topology object.
 
@@ -1378,6 +1382,9 @@ class Topology(Serializable):
             OpenMM ``Topology``, these will be used in matching as well.
             If all bonds have bond orders assigned in ``mdtraj_topology``, these bond orders will be used to attempt to construct
             the list of unique Molecules if the ``unique_molecules`` argument is omitted.
+        load_box_vectors : bool. Default=False
+            Whether to load the box vectors from the openMM topology into the Open Force Field topology. Note that, if
+            box vectors are loaded into the OFF topology, the system is assumed to be condensed-phase
 
         Returns
         -------
@@ -1467,6 +1474,8 @@ class Topology(Serializable):
                 graph_to_unq_mol[unq_mol_G],
                 local_topology_to_reference_index=local_top_to_ref_index)
 
+        if load_box_vectors:
+            topology.box_vectors = openmm_topology.getPeriodicBoxVectors()
         # TODO: How can we preserve metadata from the openMM topology when creating the OFF topology?
         return topology
 

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -793,12 +793,6 @@ class ForceField(object):
     # TODO: Should we also accept a Molecule as an alternative to a Topology?
 
 
-    def configure_vacuum(self):
-        """
-        A convenience function which calls the `convert_vacuum` function in each ofthis ForceField's ParameterHandlers.
-        """
-        for tag in self._parameter_handlers:
-            self._parameter_handlers[tag].configure_vacuum()
 
     def create_openmm_system(self,
                              topology,

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -792,6 +792,14 @@ class ForceField(object):
     # TODO: How do we know if the system is periodic or not?
     # TODO: Should we also accept a Molecule as an alternative to a Topology?
 
+
+    def configure_vacuum(self):
+        """
+        A convenience function which calls the `convert_vacuum` function in each ofthis ForceField's ParameterHandlers.
+        """
+        for tag in self._parameter_handlers:
+            self._parameter_handlers[tag].configure_vacuum()
+
     def create_openmm_system(self,
                              topology,
                              default_box_vectors=None,

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -1437,10 +1437,11 @@ class vdWHandler(ParameterHandler):
             force.setNonbondedMethod(openmm.NonbondedForce.PME)
             force.setCutoffDistance(self._cutoff)
             if hasattr(self, '_switch_width'):
-                force.setUseSwitchingFunction(False)
-            else:
                 force.setUseSwitchingFunction(True)
                 force.setSwitchingDistance(self._cutoff - self._switch_width)
+            else:
+                force.setUseSwitchingFunction(False)
+
         elif self._long_range_dispersion == "None":
             force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
 

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -1432,15 +1432,15 @@ class vdWHandler(ParameterHandler):
         # If we're using PME, then the only possible openMM Nonbonded type is LJPME
         if self._long_range_dispersion == 'LJPME':
             force.setNonbondedMethod(openmm.NonbondedForce.LJPME)
-            force.setCutoffDistance(self._cutoff.in_units_of(unit.nanometer))
+            force.setCutoffDistance(self._cutoff)
         elif self._long_range_dispersion == 'isotropic':
             force.setNonbondedMethod(openmm.NonbondedForce.PME)
-            force.setCutoffDistance(self._cutoff.in_units_of(unit.nanometer))
+            force.setCutoffDistance(self._cutoff)
             if hasattr(self, '_switch_width'):
                 force.setUseSwitchingFunction(False)
             else:
                 force.setUseSwitchingFunction(True)
-                force.setSwitchingDistance((self._cutoff - self._switch_width).in_units_of(unit.nanometer))
+                force.setSwitchingDistance(self._cutoff - self._switch_width)
         elif self._long_range_dispersion == "None":
             force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
 

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -1280,7 +1280,7 @@ class vdWHandler(ParameterHandler):
         'scale13': 0.0,
         'scale14': 0.5,
         'scale15': 1.0,
-        'switch': 8.0 * unit.angstroms,
+        'switch_width': 1.0 * unit.angstroms,
         'cutoff': 9.0 * unit.angstroms,
         'long_range_dispersion': 'isotropic',
         'nonbonded_method': NonbondedMethod.NoCutoff
@@ -1299,8 +1299,6 @@ class vdWHandler(ParameterHandler):
 
         super().__init__(**kwargs)
 
-
-
         if self._scale12 != 0.0:
             raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale12 values other than 0.0. "
                                     "Specified 1-2 scaling was {}".format(self._scale12))
@@ -1311,19 +1309,27 @@ class vdWHandler(ParameterHandler):
             raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale15 values other than 1.0. "
                                     "Specified 1-5 scaling was {}".format(self._scale15))
 
-        if self._long_range_dispersion == 'isotropic':
-            if self._cutoff == None:
+
+        supported_long_range_dispersions = [None, 'isotropic', 'LJPME']
+        if self._long_range_dispersion not in supported_long_range_dispersions:
+            raise SMIRNOFFSpecError("The Open Force Field toolkit currently only supports vdW long_range_dispersion"
+                                    "values of {}. Received unsupported value "
+                                    "{}".format(supported_long_range_dispersions, self._long_range_dispersion))
+
+        if self._long_range_dispersion is None:
+            if self._cutoff is not None:
+                raise SMIRNOFFSpecError("If vdW long_range_dispersion is None, a cutoff distance"
+                                        "must NOT be provided")
+
+        elif self._long_range_dispersion == 'isotropic':
+            if self._cutoff is None:
                 raise SMIRNOFFSpecError("If vdW long_range_dispersion is isotropic, a cutoff distance"
                                         "must be provided")
-            if self._switch == None:
-                raise SMIRNOFFSpecError("If vdW long_range_dispersion is isotropic, a switch distance"
+
+        elif self._long_range_dispersion == 'LJPME':
+            if self._cutoff == None:
+                raise SMIRNOFFSpecError("If vdW long_range_dispersion is LJPME, a cutoff distance"
                                         "must be provided")
-        elif self._long_range_dispersion == 'PME':
-            pass
-        else:
-            raise SMIRNOFFSpecError("The Open Force Field toolkit currently only supports vdW long_range_dispersion"
-                                    "values of 'isotropic' (default) and 'PME'. Received unsupported value "
-                                    "{}".format(self._long_range_dispersion))
 
         if self._potential != "Lennard-Jones-12-6":
             raise SMIRNOFFSpecError("vdW potential set to {}. Only 'Lennard-Jones-12-6' is currently"
@@ -1343,23 +1349,23 @@ class vdWHandler(ParameterHandler):
                                     handler_kwargs,
                                     assume_missing_is_default=True):
         """
-               Checks if a set of kwargs used to create a ParameterHandler are compatible with this ParameterHandler. This is
-               called if a second handler is attempted to be initialized for the same tag. If no value is given for a field, it
-               will be assumed to expect the ParameterHandler class default.
+        Checks if a set of kwargs used to create a ParameterHandler are compatible with this ParameterHandler. This is
+        called if a second handler is attempted to be initialized for the same tag. If no value is given for a field, it
+        will be assumed to expect the ParameterHandler class default.
 
-               Parameters
-               ----------
-               handler_kwargs : dict
-                   The kwargs that would be used to construct a ParameterHandler
-               assume_missing_is_default : bool
-                   If True, will assume that parameters not specified in handler_kwargs would have been set to the default.
-                   Therefore, an exception is raised if the ParameterHandler is incompatible with the default value for a
-                   unspecified field.
+        Parameters
+        ----------
+        handler_kwargs : dict
+            The kwargs that would be used to construct a ParameterHandler
+        assume_missing_is_default : bool
+            If True, will assume that parameters not specified in handler_kwargs would have been set to the default.
+            Therefore, an exception is raised if the ParameterHandler is incompatible with the default value for a
+            unspecified field.
 
-               Raises
-               ------
-               IncompatibleParameterError if handler_kwargs are incompatible with existing parameters.
-               """
+        Raises
+        ------
+        IncompatibleParameterError if handler_kwargs are incompatible with existing parameters.
+        """
         compare_attr_to_kwargs = {
             self._scale12: 'scale12',
             self._scale13: 'scale13',
@@ -1385,21 +1391,30 @@ class vdWHandler(ParameterHandler):
         #}
 
     def create_force(self, system, topology, **kwargs):
+        if (self._long_range_dispersion is None) and (not topology.is_vacuum):
+            raise SMIRNOFFSpecError("If vdW long_range_dispersion is None, a vacuum/nonperiodic Topology "
+                                    "must be provided")
+        if (self._long_range_dispersion is not None) and (not topology.is_condensed):
+            raise SMIRNOFFSpecError("If vdW long_range_dispersion is isotropic or LJPME, a condensed/periodic Topology "
+                                    "must be provided")
+
+
         force = openmm.NonbondedForce()
         # If we're using PME, then the only possible openMM Nonbonded type is LJPME
-        if self._long_range_dispersion == 'PME':
+        if self._long_range_dispersion == 'LJPME':
             force.setNonbondedMethod(openmm.NonbondedForce.LJPME)
-        else:
-            #nonbonded_method = self._NONBOND_METHOD_MAP[self._nonbonded_method]
-            #force.setNonbondedMethod(nonbonded_method)
-            force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
             force.setCutoffDistance(self._cutoff.in_units_of(unit.nanometer))
-            force.setSwitchingDistance(self._switch.in_units_of(unit.nanometer))
-        if 'ewaldErrorTolerance' in kwargs:
-            force.setEwaldErrorTolerance(kwargs['ewaldErrorTolerance'])
-        if 'useDispersionCorrection' in kwargs:
-            force.setUseDispersionCorrection(
-                bool(kwargs['useDispersionCorrection']))
+        elif self._long_range_dispersion == 'isotropic':
+            force.setNonbondedMethod(openmm.NonbondedForce.PME)
+            force.setCutoffDistance(self._cutoff.in_units_of(unit.nanometer))
+            if self._switch_width is None:
+                force.setUseSwitchingFunction(False)
+            else:
+                force.setUseSwitchingFunction(True)
+                force.setSwitchingDistance((self._cutoff - self._switch_width).in_units_of(unit.nanometer))
+        elif self._long_range_dispersion is None:
+            force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
+
         system.addForce(force)
 
         # Iterate over all defined Lennard-Jones types, allowing later matches to override earlier ones.
@@ -1455,7 +1470,8 @@ class ElectrostaticsHandler(ParameterHandler):
         'scale13': 0.0,
         'scale14': 0.833333,
         'scale15': 1.0,
-        'switch_width': 8.0 * unit.angstrom,
+        #'switch_width': 8.0 * unit.angstrom, # OpenMM can't support an electrostatics switch
+        'switch_width': None,
         'cutoff': 9.0 * unit.angstrom
     }
     _ATTRIBS_TO_TYPE = {'scale12': float,
@@ -1464,17 +1480,8 @@ class ElectrostaticsHandler(ParameterHandler):
                         'scale15': float
                         }
 
-    _OPTIONAL_SPEC_ATTRIBS = ['cutoff', 'switch-width']
+    _OPTIONAL_SPEC_ATTRIBS = ['cutoff', 'switch_width']
 
-
-    # _NONBOND_METHOD_MAP = {
-    #     NonbondedMethod.NoCutoff: openmm.NonbondedForce.NoCutoff,
-    #     NonbondedMethod.CutoffPeriodic: openmm.NonbondedForce.CutoffPeriodic,
-    #     NonbondedMethod.CutoffNonPeriodic: openmm.NonbondedForce.CutoffNonPeriodic,
-    #     NonbondedMethod.Ewald: openmm.NonbondedForce.Ewald,
-    #     NonbondedMethod.PME: openmm.NonbondedForce.PME
-    #     NonbondedMethod.LJPME: openmm.NonbondedForce.LJPME
-    # }
 
     # NOTE: In theory, this can have a different cutoff than the vdWHandler. However, we can't currently specify
     #       different values for these in the OpenMM system.
@@ -1492,18 +1499,25 @@ class ElectrostaticsHandler(ParameterHandler):
             raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale15 values other than 1.0. "
                                     "Specified 1-5 scaling was {}".format(self._scale15))
 
-        supported_methods = ['PME', 'reaction-field', 'Coulomb']
+        supported_methods = ['PME', 'Coulomb'] # 'reaction-field'
+        if self._method == 'reaction-field':
+            raise SMIRNOFFSpecError('The Open Force Field toolkit does not currently support reaction-field '
+                                    'electrostatics. There are lingering issues in the implementation of reaction-field'
+                                    'in OpenMM.')
         if not self._method in supported_methods:
             raise SMIRNOFFSpecError("'method' parameter in Electrostatics tag {} is not a supported"
                                     "option. Valid methods are {}".format(self._method, supported_methods))
 
 
-        if self._method == 'reaction-field' or self._method == 'Coulomb':
+        if self._method == 'reaction-field' or self._method == 'PME':
             if self._cutoff == None:
-                raise SMIRNOFFSpecError("If Electrostatics method is 'reaction-field' or 'Coulomb', then 'cutoff' must"
+                raise SMIRNOFFSpecError("If Electrostatics method is 'reaction-field' or 'PME', then 'cutoff' must"
                                         "also be specified")
 
-
+        if self._switch_width is not None:
+            raise SMIRNOFFSpecError("The current implementation of the Open Force Field toolkit can not support"
+                                    "an electrostatic switching width. Currently only `None` is supported"
+                                    "(SMIRNOFF data specified {})".format(self._switch_width))
 
 
 
@@ -1515,16 +1529,16 @@ class ElectrostaticsHandler(ParameterHandler):
         force = existing[0]
 
         # Set the nonbonded method
-
-        if 'usePbc' in kwargs:
-            usePbc = bool(kwargs['usePbc'])
+        if topology.is_vacuum:
+            usePbc = False
         else:
             usePbc = True
 
         settings_matched = False
 
 
-        # First, check whether the vdWHandler set it to LJPME, because that means that electrostatics also has to be PME
+        # First, check whether the vdWHandler set the nonbonded method to LJPME, because that means
+        # that electrostatics also has to be PME
         current_nb_method = force.getNonbondedMethod()
         if current_nb_method == openmm.NonbondedForce.LJPME:
             if not self._method == 'PME':
@@ -1534,9 +1548,9 @@ class ElectrostaticsHandler(ParameterHandler):
             settings_matched = True
 
         settings_tuples = (({'method': 'Coulomb', 'usePbc': False}, openmm.NonbondedForce.NoCutoff),
-                           ({'method': 'reaction-field', 'usePbc': True}, openmm.NonbondedForce.CutoffPeriodic),
-                           ({'method': 'reaction-field', 'usePbc': False}, openmm.NonbondedForce.CutoffNonPeriodic),
-                           ({'method': 'Coulomb', 'usePbc': True}, openmm.NonbondedForce.Ewald),
+                           #({'method': 'reaction-field', 'usePbc': True}, openmm.NonbondedForce.CutoffPeriodic),
+                           #({'method': 'reaction-field', 'usePbc': False}, openmm.NonbondedForce.CutoffNonPeriodic),
+                           #({'method': 'Coulomb', 'usePbc': True}, openmm.NonbondedForce.Ewald),
                            ({'method': 'PME', 'usePbc': True}, openmm.NonbondedForce.PME),
                            )
 
@@ -1551,8 +1565,17 @@ class ElectrostaticsHandler(ParameterHandler):
                                     '(electrostatics method={}, usePbc={})'.format(self._method,
                                                                                    usePbc))
 
+        # Our current tie-in with OpenMM doesn't support having different cutoffs for vdW and electrostatic interactions
+        if self._method == 'PME':
+            vdw_cutoff = force.getCutoffDistance()
+            if self._cutoff != vdw_cutoff:
+                raise SMIRNOFFSpecError("Current Open Force Field toolkit implementation only supports equal cutoff"
+                                        "distances between vdW and Electrostatics tags. Current vdW cutoff is"
+                                        "{} and electrostatic cutoff is {}.".format(vdw_cutoff, self._cutoff))
 
-        # TODO: Check that the same cutoffs have been set for both this and vdWHandler
+
+
+
 
 
 class ToolkitAM1BCCHandler(ParameterHandler):

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -554,11 +554,15 @@ class ParameterHandler(object):
                                                                                self._REQUIRE_UNITS[key])
                     raise SMIRNOFFSpecError(msg)
 
+        element_name = None
+        if self._INFOTYPE is not None:
+            element_name = self._INFOTYPE._ELEMENT_NAME
+
         for key, val in smirnoff_data.items():
             # If we're reading the parameter list, iterate through and attach units to
             # each parameter_dict, then use it to initialize a ParameterType
             #if key == self._TAGNAME:
-            if key == self._INFOTYPE._ELEMENT_NAME:
+            if key == element_name:
                 # If there are multiple parameters, this will be a list. If there's just one, make it a list
                 if not(isinstance(val, list)):
                     val = [val]
@@ -1264,12 +1268,14 @@ class vdWHandler(ParameterHandler):
     _TAGNAME = 'vdW'  # SMIRNOFF tag name to process
     _INFOTYPE = vdWType  # info type to store
     _OPENMMTYPE = openmm.NonbondedForce  # OpenMM force class to create
-    _KWARGS = ['ewaldErrorTolerance', 'useDispersionCorrection'] # Kwargs to catch when create_force is called
+    _KWARGS = ['ewaldErrorTolerance',
+               'useDispersionCorrection',
+               'usePbc'] # Kwargs to catch when create_force is called
     _REQUIRE_UNITS = {'switch': unit.angstrom,
                       'cutoff': unit.angstrom}
     _DEFAULT_SPEC_ATTRIBS = {
         'potential': 'Lennard-Jones-12-6',
-        'combining_rules': 'Loentz-Berthelot',
+        'combining_rules': 'Lorentz-Berthelot',
         'scale12': 0.0,
         'scale13': 0.0,
         'scale14': 0.5,
@@ -1288,70 +1294,48 @@ class vdWHandler(ParameterHandler):
     # TODO: Is this necessary? It's used in check_compatibility but could be hard-coded.
     _SCALETOL = 1e-5
 
-    _NONBOND_METHOD_MAP = {
-        NonbondedMethod.NoCutoff: openmm.NonbondedForce.NoCutoff,
-        NonbondedMethod.CutoffPeriodic: openmm.NonbondedForce.CutoffPeriodic,
-        NonbondedMethod.CutoffNonPeriodic: openmm.NonbondedForce.CutoffNonPeriodic,
-        NonbondedMethod.Ewald: openmm.NonbondedForce.Ewald,
-        NonbondedMethod.PME: openmm.NonbondedForce.PME
-    }
 
     def __init__(self, **kwargs):
 
         super().__init__(**kwargs)
-        if self.scale12 != 0.0:
-            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale12 values other than 0.0. "
-                                    "Specified 1-2 scaling was {}".format(self.scale12))
-        if self.scale13 != 0.0:
-            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale13 values other than 0.0. "
-                                    "Specified 1-3 scaling was {}".format(self.scale13))
-        if self.scale15 != 1.0:
-            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale15 values other than 1.0. "
-                                    "Specified 1-5 scaling was {}".format(self.scale15))
 
-        if self.long_range_dispersion == 'isotropic':
-            if self.cutoff == None:
+
+
+        if self._scale12 != 0.0:
+            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale12 values other than 0.0. "
+                                    "Specified 1-2 scaling was {}".format(self._scale12))
+        if self._scale13 != 0.0:
+            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale13 values other than 0.0. "
+                                    "Specified 1-3 scaling was {}".format(self._scale13))
+        if self._scale15 != 1.0:
+            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale15 values other than 1.0. "
+                                    "Specified 1-5 scaling was {}".format(self._scale15))
+
+        if self._long_range_dispersion == 'isotropic':
+            if self._cutoff == None:
                 raise SMIRNOFFSpecError("If vdW long_range_dispersion is isotropic, a cutoff distance"
                                         "must be provided")
-            if self.switch == None:
+            if self._switch == None:
                 raise SMIRNOFFSpecError("If vdW long_range_dispersion is isotropic, a switch distance"
                                         "must be provided")
-        elif self.long_range_dispersion == 'PME':
+        elif self._long_range_dispersion == 'PME':
             pass
         else:
             raise SMIRNOFFSpecError("The Open Force Field toolkit currently only supports vdW long_range_dispersion"
                                     "values of 'isotropic' (default) and 'PME'. Received unsupported value "
-                                    "{}".format(self.long_range_dispersion))
+                                    "{}".format(self._long_range_dispersion))
 
-        if self.potential != "Lennard-Jones-12-6":
-            raise SMIRNOFFSpecError("vdW potential set to {}. Only Lennard-Jones-12-6 is currently"
-                                    "supported".format(self.potential))
+        if self._potential != "Lennard-Jones-12-6":
+            raise SMIRNOFFSpecError("vdW potential set to {}. Only 'Lennard-Jones-12-6' is currently"
+                                    "supported".format(self._potential))
 
 
-        if self.combining_rules != "Lorentz-Berthelot":
+        if self._combining_rules != "Lorentz-Berthelot":
             raise SMIRNOFFSpecError("vdW combining_rules set to {}. Only 'Lorentz-Berthelot' is currently "
-                                    "supported".format(self.combining_rules))
+                                    "supported".format(self._combining_rules))
         # TODO: Find a better way to set defaults
         # TODO: Validate these values against the supported output types (openMM force kwargs?)
         # TODO: Add conditional logic to assign NonbondedMethod and check compatibility
-
-        # # Set the nonbonded method
-        # if nonbonded_method is None:
-        #     self._nonbonded_method = NonbondedMethod.NoCutoff
-        # else:
-        #     # If it's a string that's the name of a nonbonded method
-        #     if type(nonbonded_method) is str:
-        #         self._nonbonded_method = NonbondedMethod[nonbonded_method]
-        #
-        #     # If it's an enum'ed value of NonbondedMethod
-        #     elif nonbonded_method in NonbondedMethod:
-        #         self._nonbonded_method = nonbonded_method
-        #     # If it's an openMM nonbonded method, reverse it back to a package-independent enum
-        #     elif nonbonded_method in self._NONBOND_METHOD_MAP.values():
-        #         for key, val in self._NONBOND_METHOD_MAP.items():
-        #             if nonbonded_method == val:
-        #                 self._nonbonded_method = key
-        #                 break
 
 
 
@@ -1400,13 +1384,17 @@ class vdWHandler(ParameterHandler):
         #self._long_range_dispersion:'long_range_dispersion'
         #}
 
-    # TODO: nonbondedMethod and nonbondedCutoff should now be specified by StericsForce attributes
     def create_force(self, system, topology, **kwargs):
-
         force = openmm.NonbondedForce()
-        nonbonded_method = self._NONBOND_METHOD_MAP[self._nonbonded_method]
-        force.setNonbondedMethod(nonbonded_method)
-        force.setCutoffDistance(self._cutoff.in_units_of(unit.nanometer))
+        # If we're using PME, then the only possible openMM Nonbonded type is LJPME
+        if self._long_range_dispersion == 'PME':
+            force.setNonbondedMethod(openmm.NonbondedForce.LJPME)
+        else:
+            #nonbonded_method = self._NONBOND_METHOD_MAP[self._nonbonded_method]
+            #force.setNonbondedMethod(nonbonded_method)
+            force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
+            force.setCutoffDistance(self._cutoff.in_units_of(unit.nanometer))
+            force.setSwitchingDistance(self._switch.in_units_of(unit.nanometer))
         if 'ewaldErrorTolerance' in kwargs:
             force.setEwaldErrorTolerance(kwargs['ewaldErrorTolerance'])
         if 'useDispersionCorrection' in kwargs:
@@ -1463,10 +1451,12 @@ class ElectrostaticsHandler(ParameterHandler):
     _DEPENDENCIES = [vdWHandler]
     _DEFAULT_SPEC_ATTRIBS = {
         'method': 'PME',
-        'scale12': '0.0',
-        'scale13': '0.0',
-        'scale14': '0.833333',
-        'scale15': '1.0',
+        'scale12': 0.0,
+        'scale13': 0.0,
+        'scale14': 0.833333,
+        'scale15': 1.0,
+        'switch_width': 8.0 * unit.angstrom,
+        'cutoff': 9.0 * unit.angstrom
     }
     _ATTRIBS_TO_TYPE = {'scale12': float,
                         'scale13': float,
@@ -1474,24 +1464,95 @@ class ElectrostaticsHandler(ParameterHandler):
                         'scale15': float
                         }
 
-    _OPTIONAL_SPEC_ATTRIBS = {
-        'switch_width': 8.0 * unit.angstrom,
-        'cutoff': 9.0 * unit.angstrom
-    }
+    _OPTIONAL_SPEC_ATTRIBS = ['cutoff', 'switch-width']
 
-    # TODO: Can this have a distinct cutoff and switch value from vdW?
+
+    # _NONBOND_METHOD_MAP = {
+    #     NonbondedMethod.NoCutoff: openmm.NonbondedForce.NoCutoff,
+    #     NonbondedMethod.CutoffPeriodic: openmm.NonbondedForce.CutoffPeriodic,
+    #     NonbondedMethod.CutoffNonPeriodic: openmm.NonbondedForce.CutoffNonPeriodic,
+    #     NonbondedMethod.Ewald: openmm.NonbondedForce.Ewald,
+    #     NonbondedMethod.PME: openmm.NonbondedForce.PME
+    #     NonbondedMethod.LJPME: openmm.NonbondedForce.LJPME
+    # }
+
+    # NOTE: In theory, this can have a different cutoff than the vdWHandler. However, we can't currently specify
+    #       different values for these in the OpenMM system.
     def __init__(self, **kwargs):
-        if self.scale12 != 0.0:
-            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale12 values other than 0.0. "
-                                    "Specified 1-2 scaling was {}".format(self.scale12))
-        if self.scale13 != 0.0:
-            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale13 values other than 0.0. "
-                                    "Specified 1-3 scaling was {}".format(self.scale13))
-        if self.scale15 != 1.0:
-            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale15 values other than 1.0. "
-                                    "Specified 1-5 scaling was {}".format(self.scale15))
 
         super().__init__(**kwargs)
+
+        if self._scale12 != 0.0:
+            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale12 values other than 0.0. "
+                                    "Specified 1-2 scaling was {}".format(self._scale12))
+        if self._scale13 != 0.0:
+            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale13 values other than 0.0. "
+                                    "Specified 1-3 scaling was {}".format(self._scale13))
+        if self._scale15 != 1.0:
+            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale15 values other than 1.0. "
+                                    "Specified 1-5 scaling was {}".format(self._scale15))
+
+        supported_methods = ['PME', 'reaction-field', 'Coulomb']
+        if not self._method in supported_methods:
+            raise SMIRNOFFSpecError("'method' parameter in Electrostatics tag {} is not a supported"
+                                    "option. Valid methods are {}".format(self._method, supported_methods))
+
+
+        if self._method == 'reaction-field' or self._method == 'Coulomb':
+            if self._cutoff == None:
+                raise SMIRNOFFSpecError("If Electrostatics method is 'reaction-field' or 'Coulomb', then 'cutoff' must"
+                                        "also be specified")
+
+
+
+
+
+    def create_force(self, system, topology, **kwargs):
+        existing = [system.getForce(i) for i in range(system.getNumForces())]
+        existing = [
+            f for f in existing if type(f) == openmm.NonbondedForce
+        ]
+        force = existing[0]
+
+        # Set the nonbonded method
+
+        if 'usePbc' in kwargs:
+            usePbc = bool(kwargs['usePbc'])
+        else:
+            usePbc = True
+
+        settings_matched = False
+
+
+        # First, check whether the vdWHandler set it to LJPME, because that means that electrostatics also has to be PME
+        current_nb_method = force.getNonbondedMethod()
+        if current_nb_method == openmm.NonbondedForce.LJPME:
+            if not self._method == 'PME':
+                raise SMIRNOFFSpecError("vdW long_range_dispersion set to PME, but electrostatics set "
+                                        "to {}. Current Open Force Field implementation only supports"
+                                        " PME electrostatics for this vdW setting.".format(self._method))
+            settings_matched = True
+
+        settings_tuples = (({'method': 'Coulomb', 'usePbc': False}, openmm.NonbondedForce.NoCutoff),
+                           ({'method': 'reaction-field', 'usePbc': True}, openmm.NonbondedForce.CutoffPeriodic),
+                           ({'method': 'reaction-field', 'usePbc': False}, openmm.NonbondedForce.CutoffNonPeriodic),
+                           ({'method': 'Coulomb', 'usePbc': True}, openmm.NonbondedForce.Ewald),
+                           ({'method': 'PME', 'usePbc': True}, openmm.NonbondedForce.PME),
+                           )
+
+        for setting_dict, nonbond_method in settings_tuples:
+            if self._method == setting_dict['method'] and usePbc == setting_dict['usePbc']:
+                settings_matched = True
+                force.setNonbondedMethod(nonbond_method)
+                break
+
+        if not(settings_matched):
+            raise SMIRNOFFSpecError('Unable to find an OpenMM NonbondedForce for the provided settings'
+                                    '(electrostatics method={}, usePbc={})'.format(self._method,
+                                                                                   usePbc))
+
+
+        # TODO: Check that the same cutoffs have been set for both this and vdWHandler
 
 
 class ToolkitAM1BCCHandler(ParameterHandler):

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -1455,6 +1455,45 @@ class vdWHandler(ParameterHandler):
                                                 self._scale14)
                 #force.createExceptionsFromBonds(bond_particle_indices, self.coulomb14scale, self._scale14)
 
+
+class ElectrostaticsHandler(ParameterHandler):
+    """Handles SMIRNOFF <Electrostatics> tags."""
+    _TAGNAME = 'Electrostatics'
+    _OPENMMTYPE = openmm.NonbondedForce
+    _DEPENDENCIES = [vdWHandler]
+    _DEFAULT_SPEC_ATTRIBS = {
+        'method': 'PME',
+        'scale12': '0.0',
+        'scale13': '0.0',
+        'scale14': '0.833333',
+        'scale15': '1.0',
+    }
+    _ATTRIBS_TO_TYPE = {'scale12': float,
+                        'scale13': float,
+                        'scale14': float,
+                        'scale15': float
+                        }
+
+    _OPTIONAL_SPEC_ATTRIBS = {
+        'switch_width': 8.0 * unit.angstrom,
+        'cutoff': 9.0 * unit.angstrom
+    }
+
+    # TODO: Can this have a distinct cutoff and switch value from vdW?
+    def __init__(self, **kwargs):
+        if self.scale12 != 0.0:
+            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale12 values other than 0.0. "
+                                    "Specified 1-2 scaling was {}".format(self.scale12))
+        if self.scale13 != 0.0:
+            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale13 values other than 0.0. "
+                                    "Specified 1-3 scaling was {}".format(self.scale13))
+        if self.scale15 != 1.0:
+            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale15 values other than 1.0. "
+                                    "Specified 1-5 scaling was {}".format(self.scale15))
+
+        super().__init__(**kwargs)
+
+
 class ToolkitAM1BCCHandler(ParameterHandler):
     """Handle SMIRNOFF ``<ToolkitAM1BCC>`` tags"""
 

--- a/openforcefield/utils/structure.py
+++ b/openforcefield/utils/structure.py
@@ -45,6 +45,11 @@ def generateSMIRNOFFStructure(oemol):
 
     # Create OpenMM System and Topology.
     omm_top = generateTopologyFromOEMol(oemol)
+
+    # If it's a nonperiodic box, then we can't use default (PME) settings
+    if omm_top.getPeriodicBoxVectors() is None:
+        mol_ff.get_handler("Electrostatics", {})._method = 'Coulomb'
+
     system = mol_ff.create_openmm_system(off_top)
 
     # Convert to ParmEd structure.


### PR DESCRIPTION
This PR 
* Updates the SMIRNOFF spec with recent updates, closing #191 
* Corrects a long-running typo in our vdW tags (`Loentz-Berthelot` --> `Lo_r_entz-Berthelot`)
* ~Adds optional `load_box_vectors` param to `Topology.from_openmm()`, thus allowing retrieval of periodic box vectors during Topology initialization.~
* Implements `ElectrostaticsHandler`, thus adding support for the `Electrostatics` OFFXML tag
* Implements `_validate_parameters` functions for `vdWHandler` and `ElectrostaticsHandler` which ensure that their settings map to an OpenMM `NonbondedMethod` that we currently support.
* Implements checks during system creation that ensure `vdWHandler` and `ElectrostaticsHandler` are configured in a way compatible with the presence/absence of a periodic box in the `Topology` object.
* ~Implements the `ForceField.configure_vacuum()` function, which recursively calls `configure_vacuum` on all of the ForceField's ParameterHandlers. These functions have the ParameterHandlers switch to default non-periodic/vacuum phase settings.~ 
    * ~This makes it easier to "just run" a vacuum simulation. It will be useful because all of our  `smirnoff99Frosst.offxml` files have condensed-phase-specific vdW and Electrostatics parameters specified. Thankfully, we currently only support one configuration for vacuum, so switching to "vacuum settings" is currently unambiguous. We will need to refactor this later, however.~
* Exposes 1-5 scaling parameters
* Removes vdW `long_range_dispersion` attribute, and replaces it with vdw `method`, which can be set to either `cutoff` (default) or `PME`.
* Adds logic to resolve inputs to OpenMM system types specified [on slide 15 here](https://docs.google.com/presentation/d/1U1ZnB-kaAA1s-lFjTQSI1hHx5kntbOw-H4HlGdV4KCo/edit#slide=id.g554019e4c3_0_13)