### PR TITLE
Reactivate atoms and bonds valence checks

### DIFF
--- a/openforcefield/tests/test_topology.py
+++ b/openforcefield/tests/test_topology.py
@@ -13,25 +13,57 @@ Tests for Topology
 # GLOBAL IMPORTS
 #=============================================================================================
 
-import pickle
-from functools import partial
 from unittest import TestCase
 
-from openforcefield import utils, topology
-
 import pytest
-import copy
 import numpy as np
 from simtk import unit
-from openforcefield.utils import BASIC_CHEMINFORMATICS_TOOLKITS, RDKIT_AVAILABLE, OPENEYE_AVAILABLE, AMBERTOOLS_AVAILABLE, RDKitToolkitWrapper, OpenEyeToolkitWrapper, AmberToolsToolkitWrapper
+from openforcefield.utils import (BASIC_CHEMINFORMATICS_TOOLKITS, RDKIT_AVAILABLE, OPENEYE_AVAILABLE,
+                                  RDKitToolkitWrapper, OpenEyeToolkitWrapper)
 from openforcefield.tests.utils import get_data_filename
-from openforcefield.topology import Topology, TopologyAtom, TopologyBond, TopologyMolecule, TopologyVirtualSite, DuplicateUniqueMoleculeError
+from openforcefield.topology import Topology, ValenceDict, ImproperDict, DuplicateUniqueMoleculeError
 from openforcefield.topology import Molecule
+
+
+#=============================================================================================
+# UTILITY FUNCTIONS
+#=============================================================================================
+
+def assert_tuple_of_atoms_equal(atom_tuples1, atom_tuples2, transformed_dict_cls=ValenceDict):
+    """Check that two lists of atoms are the same.
+
+    The function compares that the parent molecules are isomorphic and
+    that the molecule index is the same.
+    """
+    assert len(atom_tuples1) == len(atom_tuples2)
+
+    # They are atoms of isomorphic molecules. We assume here that all
+    # atoms in the same list of tuples belong to the same molecule so
+    # that we can perform the check only once.
+    molecule1 = atom_tuples1[0][0]._molecule
+    molecule2 = atom_tuples2[0][0]._molecule
+    assert molecule1 == molecule2
+    for atom_tuple in atom_tuples1:
+        for a in atom_tuple:
+            assert a._molecule is molecule1
+    for atom_tuple in atom_tuples2:
+        for a in atom_tuple:
+            assert a._molecule is molecule2
+
+    # All atoms are equal. Use ValenceDict for this
+    atom_indices = []
+    for atom_tuples in [atom_tuples1, atom_tuples2]:
+        valence_dict = transformed_dict_cls()
+        for atom_tuple in atom_tuples:
+            key = tuple(a.molecule_atom_index for a in atom_tuple)
+            valence_dict[key] = atom_tuple
+        atom_indices.append(valence_dict)
+    assert set(atom_indices[0]) == set(atom_indices[1])
+
 
 #=============================================================================================
 # TESTS
 #=============================================================================================
-
 
 # IF we've done our jobs right, it shouldn't matter which toolkit the tests for Topology run using (both's behaviors
 # should be indistinguishable)
@@ -44,7 +76,6 @@ def test_cheminformatics_toolkit_is_installed():
 
 
 class TestTopology(TestCase):
-    from openforcefield.topology import Topology
 
     def setUp(self):
         self.empty_molecule = Molecule()
@@ -265,6 +296,97 @@ class TestTopology(TestCase):
         topology.assert_bonded(0,4)
         with self.assertRaises(Exception) as context:
             topology.assert_bonded(0, 2)
+
+    def test_angles(self):
+        """Topology.angles should return image angles of all topology molecules."""
+        molecule1 = self.ethane_from_smiles
+        molecule2 = self.propane_from_smiles
+
+        # Create topology.
+        topology = Topology()
+        topology.add_molecule(molecule1)
+        topology.add_molecule(molecule1)
+        topology.add_molecule(molecule2)
+
+        # The topology should have the correct number of angles.
+        topology_angles = list(topology.angles)
+        assert len(topology_angles) == topology.n_angles
+        assert topology.n_angles == 2*molecule1.n_angles + molecule2.n_angles
+
+        # Check that the topology angles are the correct ones.
+        mol_angle_atoms1 = list(molecule1.angles)
+        mol_angle_atoms2 = list(molecule2.angles)
+        top_angle_atoms1 = [tuple(a._atom for a in atoms)
+                            for atoms in topology_angles[:molecule1.n_angles]]
+        top_angle_atoms2 = [tuple(a._atom for a in atoms)
+                            for atoms in topology_angles[molecule1.n_angles:2*molecule1.n_angles]]
+        top_angle_atoms3 = [tuple(a._atom for a in atoms)
+                            for atoms in topology_angles[2*molecule1.n_angles:]]
+
+        assert_tuple_of_atoms_equal(top_angle_atoms1, mol_angle_atoms1)
+        assert_tuple_of_atoms_equal(top_angle_atoms2, mol_angle_atoms1)
+        assert_tuple_of_atoms_equal(top_angle_atoms3, mol_angle_atoms2)
+
+    def test_propers(self):
+        """Topology.propers should return image propers torsions of all topology molecules."""
+        molecule1 = self.ethane_from_smiles
+        molecule2 = self.propane_from_smiles
+
+        # Create topology.
+        topology = Topology()
+        topology.add_molecule(molecule1)
+        topology.add_molecule(molecule1)
+        topology.add_molecule(molecule2)
+
+        # The topology should have the correct number of propers.
+        topology_propers = list(topology.propers)
+        assert len(topology_propers) == topology.n_propers
+        assert topology.n_propers == 2*molecule1.n_propers + molecule2.n_propers
+
+        # Check that the topology propers are the correct ones.
+        mol_proper_atoms1 = list(molecule1.propers)
+        mol_proper_atoms2 = list(molecule2.propers)
+        top_proper_atoms1 = [tuple(a._atom for a in atoms)
+                            for atoms in topology_propers[:molecule1.n_propers]]
+        top_proper_atoms2 = [tuple(a._atom for a in atoms)
+                            for atoms in topology_propers[molecule1.n_propers:2*molecule1.n_propers]]
+        top_proper_atoms3 = [tuple(a._atom for a in atoms)
+                            for atoms in topology_propers[2*molecule1.n_propers:]]
+
+        assert_tuple_of_atoms_equal(top_proper_atoms1, mol_proper_atoms1)
+        assert_tuple_of_atoms_equal(top_proper_atoms2, mol_proper_atoms1)
+        assert_tuple_of_atoms_equal(top_proper_atoms3, mol_proper_atoms2)
+
+    def test_impropers(self):
+        """Topology.impropers should return image impropers torsions of all topology molecules."""
+        molecule1 = self.ethane_from_smiles
+        molecule2 = self.propane_from_smiles
+
+        # Create topology.
+        topology = Topology()
+        topology.add_molecule(molecule1)
+        topology.add_molecule(molecule1)
+        topology.add_molecule(molecule2)
+
+        # The topology should have the correct number of impropers.
+        topology_impropers = list(topology.impropers)
+        assert len(topology_impropers) == topology.n_impropers
+        assert topology.n_impropers == 2*molecule1.n_impropers + molecule2.n_impropers
+
+        # Check that the topology impropers are the correct ones.
+        mol_improper_atoms1 = list(molecule1.impropers)
+        mol_improper_atoms2 = list(molecule2.impropers)
+        top_improper_atoms1 = [tuple(a._atom for a in atoms)
+                            for atoms in topology_impropers[:molecule1.n_impropers]]
+        top_improper_atoms2 = [tuple(a._atom for a in atoms)
+                            for atoms in topology_impropers[molecule1.n_impropers:2*molecule1.n_impropers]]
+        top_improper_atoms3 = [tuple(a._atom for a in atoms)
+                            for atoms in topology_impropers[2*molecule1.n_impropers:]]
+
+        assert_tuple_of_atoms_equal(top_improper_atoms1, mol_improper_atoms1)
+        assert_tuple_of_atoms_equal(top_improper_atoms2, mol_improper_atoms1)
+        assert_tuple_of_atoms_equal(top_improper_atoms3, mol_improper_atoms2)
+
 
     # test_get_fractional_bond_order
     # test_two_of_same_molecule

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -852,7 +852,8 @@ class TopologyMolecule:
     def _convert_to_topology_atom_tuples(self, molecule_atom_tuples):
         for atom_tuple in molecule_atom_tuples:
             mol_atom_indices = (a.molecule_atom_index for a in atom_tuple)
-            yield tuple(self.atom(i) for i in mol_atom_indices)
+            top_mol_atom_indices = (self._ref_to_top_index[mol_idx] for mol_idx in mol_atom_indices)
+            yield tuple(self.atom(i) for i in top_mol_atom_indices)
 
 
 # TODO: pick back up figuring out how we want TopologyMolecules to know their starting TopologyParticle indices

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -599,7 +599,7 @@ class TopologyMolecule:
 
     def atom(self, index):
         """
-        Get the TopologyAtom with a given reference molecule index in this TopologyMolecule
+        Get the TopologyAtom with a given topology molecule index in this TopologyMolecule.
 
         Parameters
         ----------

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -932,7 +932,7 @@ class ForceField(object):
         for molecule_idx, molecule in enumerate(topology.reference_molecules):
             current_molecule_labels = dict()
             for parameter_handler in self._parameter_handlers.values():
-                matches = parameter_handler.get_matches(molecule)
+                matches = parameter_handler.find_matches(molecule)
                 molecule_labels[molecule_idx][parameter_handler.name] = matches
             molecule_labels.append(current_molecule_labels)
         return molecule_labels

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -679,7 +679,7 @@ class ParameterHandler(object):
         # TODO: This is a necessary API point for Lee-Ping's ForceBalance
         pass
 
-    def get_matches(self, entity):
+    def find_matches(self, entity):
         """Find the elements of the topology/molecule matched by a parameter type.
 
         Parameters
@@ -694,10 +694,10 @@ class ParameterHandler(object):
             matching the tuple of particle indices in ``entity``.
 
         """
-        return self._get_matches(entity)
+        return self._find_matches(entity)
 
-    def _get_matches(self, entity, transformed_dict_cls=ValenceDict):
-        """Implement get_matches() and allow using a difference valence dictionary."""
+    def _find_matches(self, entity, transformed_dict_cls=ValenceDict):
+        """Implement find_matches() and allow using a difference valence dictionary."""
         from openforcefield.topology import FrozenMolecule
 
         logger.debug('Finding matches for {}'.format(self.__class__.__name__))
@@ -937,7 +937,7 @@ class ConstraintHandler(ParameterHandler):
         super().__init__(**kwargs)
 
     def create_force(self, system, topology, **kwargs):
-        constraints = self.get_matches(topology)
+        constraints = self.find_matches(topology)
         for (atoms, constraint) in constraints.items():
             # Update constrained atom pairs in topology
             #topology.add_constraint(*atoms, constraint.distance)
@@ -996,7 +996,7 @@ class BondHandler(ParameterHandler):
             force = existing[0]
 
         # Add all bonds to the system.
-        bonds = self.get_matches(topology)
+        bonds = self.find_matches(topology)
         skipped_constrained_bonds = 0  # keep track of how many bonds were constrained (and hence skipped)
         for (atoms, bond_params) in bonds.items():
             # Get corresponding particle indices in Topology
@@ -1084,7 +1084,7 @@ class AngleHandler(ParameterHandler):
             force = existing[0]
 
         # Add all angles to the system.
-        angles = self.get_matches(topology)
+        angles = self.find_matches(topology)
         skipped_constrained_angles = 0  # keep track of how many angles were constrained (and hence skipped)
         for (atoms, angle) in angles.items():
             # Ensure atoms are actually bonded correct pattern in Topology
@@ -1161,7 +1161,7 @@ class ProperTorsionHandler(ParameterHandler):
         else:
             force = existing[0]
         # Add all proper torsions to the system.
-        torsions = self.get_matches(topology)
+        torsions = self.find_matches(topology)
         for (atom_indices, torsion) in torsions.items():
             # Ensure atoms are actually bonded correct pattern in Topology
             for (i, j) in [(0, 1), (1, 2), (2, 3)]:
@@ -1217,7 +1217,7 @@ class ImproperTorsionHandler(ParameterHandler):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def get_matches(self, entity):
+    def find_matches(self, entity):
         """Find the improper torsions in the topology/molecule matched by a parameter type.
 
         Parameters
@@ -1232,7 +1232,7 @@ class ImproperTorsionHandler(ParameterHandler):
             matching the 4-tuple of atom indices in ``entity``.
 
         """
-        return self._get_matches(entity, transformed_dict_cls=ImproperDict)
+        return self._find_matches(entity, transformed_dict_cls=ImproperDict)
 
     def create_force(self, system, topology, **kwargs):
         #force = super(ImproperTorsionHandler, self).create_force(system, topology, **kwargs)
@@ -1248,7 +1248,7 @@ class ImproperTorsionHandler(ParameterHandler):
             force = existing[0]
 
         # Add all improper torsions to the system
-        impropers = self.get_matches(topology)
+        impropers = self.find_matches(topology)
         for (atom_indices, improper) in impropers.items():
             # Ensure atoms are actually bonded correct pattern in Topology
             # For impropers, central atom is atom 1
@@ -1453,7 +1453,7 @@ class vdWHandler(ParameterHandler):
         system.addForce(force)
 
         # Iterate over all defined Lennard-Jones types, allowing later matches to override earlier ones.
-        atoms = self.get_matches(topology)
+        atoms = self.find_matches(topology)
 
         # Create all particles.
         for particle in topology.topology_particles:
@@ -1635,7 +1635,7 @@ class ToolkitAM1BCCHandler(ParameterHandler):
 
     # TODO: Move chargeModel and library residue charges to SMIRNOFF spec
     def postprocess_system(self, system, topology, **kwargs):
-        bonds = self.get_matches(topology)
+        bonds = self.find_matches(topology)
 
         # Apply bond charge increments to all appropriate force groups
         # QUESTION: Should we instead apply this to the Topology in a preprocessing step, prior to spreading out charge onto virtual sites?
@@ -1855,7 +1855,7 @@ class ChargeIncrementModelHandler(ParameterHandler):
 
     # TODO: Move chargeModel and library residue charges to SMIRNOFF spec
     def postprocess_system(self, system, topology, **kwargs):
-        bonds = self.get_matches(topology)
+        bonds = self.find_matches(topology)
 
         # Apply bond charge increments to all appropriate force groups
         # QUESTION: Should we instead apply this to the Topology in a preprocessing step, prior to spreading out charge onto virtual sites?

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -85,11 +85,6 @@ class UnassignedProperTorsionParameterException(UnassignedValenceParameterExcept
     pass
 
 
-class UnassignedImroperTorsionParameterException(UnassignedValenceParameterException):
-    """Exception raised when there are improper torsions terms for which a ParameterHandler can't find parameters."""
-    pass
-
-
 #======================================================================
 # PARAMETER TYPE/LIST
 #======================================================================
@@ -1311,11 +1306,6 @@ class ImproperTorsionHandler(ParameterHandler):
             '{} impropers added, each applied in a six-fold trefoil'.format(
                 len(impropers)))
 
-        # Check that no topological torsions are missing force parameters
-        self._check_all_valence_terms_assigned(assigned_terms=impropers,
-                                               valence_terms=list(topology.impropers),
-                                               exception_cls=UnassignedImroperTorsionParameterException)
-
 
 class vdWHandler(ParameterHandler):
     """Handle SMIRNOFF ``<vdW>`` tags"""
@@ -1498,8 +1488,7 @@ class vdWHandler(ParameterHandler):
             force.setParticleParameters(atom_idx, 0.0, ljtype.sigma,
                                         ljtype.epsilon)
 
-        # Check that no atoms are missing force parameters
-        # QUESTION: Don't we want to allow atoms without force parameters? Or perhaps just *particles* without force parameters, but not atoms?
+        # Check that no atoms (n.b. not particles) are missing force parameters.
         self._check_all_valence_terms_assigned(assigned_terms=atoms,
                                                valence_terms=topology.topology_atoms)
 


### PR DESCRIPTION
This partially re-implement issue #185 . It reimplements valence checks for atoms and bonds only.

Reactivating valence checks for angles and torsions will require larger modifications, but I'd like to take a decision about #216 first in order to minimize the total time I'll spend on this, and implement it in a separate PR.