### PR TITLE
Automatically test README and scripts in examples/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_install:
 
 install:
   # Create test environment for package
-  - conda create -n test python=$PYTHON_VER pip pytest pytest-cov
+  - conda create -n test python=$PYTHON_VER pip pytest pytest-cov nbval
   - source activate test
 
   # TODO: Do we still need the beta version or can we do simply -c openeye openeye-toolkits?
@@ -88,7 +88,7 @@ install:
   - conda install --use-local openforcefield
 
 script:
-  - pytest -v --cov=openforcefield openforcefield/tests/
+  - pytest -v --cov=openforcefield openforcefield/tests/ --nbval-lax
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ install:
   - conda install --use-local openforcefield
 
 script:
-  - pytest -v --cov=openforcefield openforcefield/tests/ --nbval-lax
+  - pytest -v --nbval-lax --cov=openforcefield
 
 notifications:
     email: false

--- a/openforcefield/tests/test_examples.py
+++ b/openforcefield/tests/test_examples.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+#======================================================================
+# MODULE DOCSTRING
+#======================================================================
+
+"""
+Test that the examples in the repo run without errors.
+"""
+
+#======================================================================
+# GLOBAL IMPORTS
+#======================================================================
+
+import glob
+import os
+import re
+import subprocess
+import textwrap
+
+import pytest
+
+from openforcefield.utils import temporary_directory
+
+
+#======================================================================
+# TEST UTILITIES
+#======================================================================
+
+ROOT_DIR_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..')
+
+
+def run_script_file(file_path):
+    """Run through the shell a python script."""
+    cmd = ['python', file_path]
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError:
+        raise Exception('Example {file_path} failed'.format(file_path=file_path))
+
+
+def run_script_str(script_str):
+    """Execute a Python string through the shell in a temporary directory.
+
+    With respect to eval, this has the advantage of catching all import errors.
+
+    """
+    with temporary_directory() as tmp_dir:
+        temp_file_path = os.path.join(tmp_dir, 'temp.py')
+        # Create temporary python script.
+        with open(temp_file_path, 'w') as f:
+            f.write(script_str)
+        # Run the Python script.
+        try:
+            run_script_file(temp_file_path)
+        except:
+            script_str = textwrap.indent(script_str, '    ')
+            raise Exception(f'The following script failed:\n{script_str}')
+
+
+def find_examples():
+    """Find all examples in the examples folder.
+
+    Returns
+    -------
+    example_file_paths : List[str]
+        List of python script to execute.
+    """
+    slow_examples = {
+        os.path.join('SMIRNOFF_comparison', 'compare_set_energies.py')
+    }
+    examples_dir_path = os.path.join(ROOT_DIR_PATH, 'examples')
+
+    example_file_paths = []
+    for example_file_path in glob.glob(os.path.join(examples_dir_path, '*', '*.py')):
+        example_file_path = os.path.relpath(example_file_path)
+        # Check if this is a slow test.
+        for slow_example in slow_examples:
+            if slow_example in example_file_path:
+                # This is a slow example.
+                example_file_path = pytest.param(example_file_path, marks=pytest.mark.slow)
+        example_file_paths.append(example_file_path)
+    return example_file_paths
+
+
+def find_readme_examples():
+    """Yield the Python scripts in a readme file.
+
+    Returns
+    -------
+    readme_examples : List[str]
+        The list of Python scripts included in the README.md files.
+    """
+    readme_file_path = os.path.join(ROOT_DIR_PATH, 'README.md')
+    with open(readme_file_path, 'r') as f:
+        readme_content = f.read()
+    return re.findall('```python(.*?)```', readme_content, flags=re.DOTALL)
+
+
+#======================================================================
+# TESTS
+#======================================================================
+
+@pytest.mark.parametrize('readme_example_str', find_readme_examples())
+def test_readme(readme_example_str):
+    """Test the example"""
+    run_script_str(readme_example_str)
+
+
+@pytest.mark.parametrize('example_file_path', find_examples())
+def test_examples(example_file_path):
+    """Test that the example run without errors."""
+    run_script_file(example_file_path)

--- a/openforcefield/typing/chemistry/environment.py
+++ b/openforcefield/typing/chemistry/environment.py
@@ -84,11 +84,11 @@ def _convert_embedded_SMIRKS(smirks):
     a_out = 0
     while smirks.find('$(') != -1:
         # Find first atom
-        atom, a_in, a_out = _find_embedded_brackets(smirks, '\[', '\]')
+        atom, a_in, a_out = _find_embedded_brackets(smirks, r'\[', r'\]')
         d = atom.find('$(')
         # Find atom with the $ string embedded
         while d == -1:
-            atom, temp_in, temp_out = _find_embedded_brackets(smirks[a_out+1:], '\[', '\]')
+            atom, temp_in, temp_out = _find_embedded_brackets(smirks[a_out+1:], r'\[', r'\]')
             a_in = a_out + temp_in + 1
             a_out += temp_out + 1
             d = atom.find('$(')
@@ -106,11 +106,11 @@ def _convert_embedded_SMIRKS(smirks):
         else:
             ring_out = ''
 
-        embedded, p_in, p_out = _find_embedded_brackets(atom, '\(', '\)')
+        embedded, p_in, p_out = _find_embedded_brackets(atom, r'\(', r'\)')
         # two forms of embedded strings $(*~stuff) or $([..]~stuff)
         # in the latter case the first atom refers the current atom
         if embedded[1] == '[':
-            first, f_in, f_out = _find_embedded_brackets(embedded, '\[','\]')
+            first, f_in, f_out = _find_embedded_brackets(embedded, r'\[', r'\]')
             first = _convert_embedded_SMIRKS(first)
             new_atom = atom[:d]+first[1:-1]+atom[p_out+1:]
             embedded = embedded[f_out+1:]
@@ -270,7 +270,7 @@ class ChemicalEnvironment(object):
 
             # Add label to the end of SMARTS
             else:
-                sub_string, start, end = _find_embedded_brackets(smirks, '\[','\]')
+                sub_string, start, end = _find_embedded_brackets(smirks, r'\[', r'\]')
                 if self.ring is not None:
                     return sub_string[:-1] + ':' + str(self.index) + ']'+str(self.ring)
                 else:
@@ -466,21 +466,21 @@ class ChemicalEnvironment(object):
         # Define the regular expressions used for all SMIRKS decorators
         # There are a limited number of descriptors for smirks string they are:
         # That is a # followed by one or more ints w/or w/o at ! in front '!#16'
-        element_num = "!?[#]\d+"
+        element_num = r"!?[#]\d+"
         # covers element symbols, i.e. N,C,O,Br not followed by a number
         element_sym = "!?[A-Z][a-z]?"
         # covers element symbols that are aromatic:
         aro_sym = "!?[cnops]"
         # replacement strings
-        replace_str = "\$\w+"
+        replace_str = r"\$\w+"
         # a or A w/ or w/o a ! in front 'A'
         aro_ali = "!?[aA]"
         # the decorators (D,H,j,r,V,X,^) followed by one or more integers
-        needs_int = "!?[DHjrVX^]\d+"
+        needs_int = r"!?[DHjrVX^]\d+"
         # R(x), +, - do not need to be followed by a integer w/ or w/o a ! 'R2'
-        optional_int = "!?[Rx+-]\d*"
+        optional_int = r"!?[Rx+-]\d*"
         # chirality options, "@", "@@", "@int" w/ or w/o a ! in front
-        chirality = "!?[@]\d+|!?[@]@?"
+        chirality = r"!?[@]\d+|!?[@]@?"
 
         # Generate RegEx string for decorators:
         self.no_bracket_atom_reg = r'('+'|'.join([element_sym, aro_sym, replace_str])+')'
@@ -613,7 +613,7 @@ into ChemicalEnvironments." % smirks)
         store = list() # to store indices while branching
         bondingTo = idx # which atom are we going to bond to
 
-        atom_string, start, end = _find_embedded_brackets(smirks, '\[', '\]')
+        atom_string, start, end = _find_embedded_brackets(smirks, r'\[', r'\]')
 
         if start != 0: # first atom is not in square brackets
             if start != -1:
@@ -665,7 +665,7 @@ into ChemicalEnvironments." % smirks)
                 continue
 
             # find beginning and end of next [atom]
-            atom_string, start, end = _find_embedded_brackets(leftover, '\[', '\]')
+            atom_string, start, end = _find_embedded_brackets(leftover, r'\[', r'\]')
 
             if start != -1: # no more square brackets
                 bond_string = leftover[:start]


### PR DESCRIPTION
This is an attempt to test with Travis every example in the `examples/` folder and in the `README.md` file in the root directory (see #211).

I still have to add testing for the ipython notebooks, but I want to check that Travis finds the example files first.