### PR TITLE
Add tests for constraints and multiple molecule parameterization

### DIFF
--- a/openforcefield/data/forcefield/tip3p.offxml
+++ b/openforcefield/data/forcefield/tip3p.offxml
@@ -3,11 +3,11 @@
 <SMIRNOFF version="1.0" aromaticity_model="OEAroModel_MDL">
 
   <!-- SMIRks Native Open Force Field (SMIRNOFF) file -->
-  <Date>2018-07-14</Date>
+  <Date>2019-04-04</Date>
   <Author>J. D. Chodera, MSKCC; A. Rizzi, Weill Cornell; C. C. Bannan, UC Irvine</Author>
 
   <!-- SMIRNOFF file implementing TIP3P water model. -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0*angstroms" cutoff="9.0*angstroms" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstroms" cutoff="9.0" cutoff_unit="angstroms" long_range_dispersion="isotropic">
     <!-- TIP3P water oxygen with charge override -->
     <!-- WARNING: charges are not supported yet (see issue openforcefield#25), and they are currently here only for documentation -->
     <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" id="n1" sigma="0.31507524065751241" epsilon="0.635968" charge="-0.834"/>

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -694,6 +694,37 @@ class TestForceField():
 
 
 #======================================================================
+# TEST CONSTRAINTS
+#======================================================================
+
+class TestForceFieldConstraints:
+    """Tests that constraints are correctly applied and behave correctly."""
+
+    @classmethod
+    def check_molecule_constraints(cls, molecule, system, bond_elements, bond_length):
+        """Check that the bonds in the molecule is correctly constrained."""
+        for constraint_idx in range(system.getNumConstraints()):
+            atom1_idx, atom2_idx, distance = system.getConstraintParameters(constraint_idx)
+            atom_elements = {molecule.atoms[atom1_idx].element.symbol,
+                             molecule.atoms[atom2_idx].element.symbol}
+            assert atom_elements == bond_elements
+            assert np.isclose(distance/unit.angstrom, bond_length/unit.angstrom)
+
+    def test_constraints_hbonds(self):
+        """Test that hydrogen bonds constraints are applied correctly to a ethane molecule."""
+        # Parametrize an ethane molecule.
+        ethane = Molecule.from_smiles('CC')
+        topology = Topology.from_molecules([ethane])
+        ff = ForceField(XML_FF_GENERICS, 'old/hbonds.offxml')
+        system = ff.create_openmm_system(topology)
+
+        # Check that all C-H bonds have been constrained to the FF bond length.
+        self.check_molecule_constraints(ethane, system,
+                                        bond_elements={'C', 'H'},
+                                        bond_length=GENERIC_BOND_LENGTH)
+
+
+#======================================================================
 # TEST PARAMETER ASSIGNMENT
 #======================================================================
 

--- a/openforcefield/tests/test_smirnoff.py
+++ b/openforcefield/tests/test_smirnoff.py
@@ -595,6 +595,7 @@ class TestSolventSupport:
     """Test support for rigid solvents like TIP3P.
     """
 
+    # TODO: Move this to test_forcefield::TestForceFieldConstraints when it will be possible to specify TIP3P electrostatics.
     def test_tip3p_constraints(self):
         """Test that TIP3P distance costraints are correctly applied."""
         # Specify TIP3P constraint distances
@@ -614,6 +615,7 @@ class TestSolventSupport:
         ff = ForceField(tip3p_offxml_filename)
         system = ff.create_system(topology)
 
+        # TODO: This is probably unnecessary and we can simply check that the System has all the Constraints in their position.
         # Run dynamics.
         integrator = openmm.VerletIntegrator(2.0 * unit.femtoseconds)
         context = openmm.Context(system, integrator)
@@ -629,6 +631,7 @@ class TestSolventSupport:
         err_msg = 'expected distances [O-H1, O-H2, H1-H2]: {} A, new distances: {} A'
         assert np.allclose(expected_distances, distances), err_msg.format(expected_distances, distances)
 
+    # TODO: Move this to test_forcefield::TestForceFieldParameterAssignment when it will be possible to specify TIP3P electrostatics.
     def test_tip3p_solvated_molecule_energy():
         """Check the energy of a TIP3P solvated molecule is the same with SMIRNOFF and OpenMM.
 


### PR DESCRIPTION
Fixes #152 and #180.

I've ended up testing the parametrization of multiple molecules by mixing the AlkEthOH AMBER files with ParmEd and comparing those parameters with the multi-molecule `System` generated by `ForceField`.

I found an issue with mixing AMBER files with ParmEd while adding the test (see ParmEd/ParmEd#1045), but I think I found a workaround. It's good to keep that in mind though.