### PR TITLE
Activate Travis doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,10 @@ install:
 
 script:
   # Run doctests only if both RDKit and OpenEye are installed.
-  - if [[ "$RDKIT" == true && "$OPENEYE" == true ]]; then pytest -v --doctest-modules --nbval-lax --cov=openforcefield; else pytest -v --nbval-lax --cov=openforcefield; fi
+  - if [[ "$RDKIT" == true && "$OPENEYE" == true ]];
+    then pytest -v --ignore=utilities --ignore=examples/deprecated --doctest-modules --nbval-lax --cov=openforcefield;
+    else pytest -v --ignore=utilities --ignore=examples/deprecated --nbval-lax --cov=openforcefield;
+    fi
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ install:
 
 script:
   # Run doctests only if both RDKit and OpenEye are installed.
-  - if [[ "$RDKIT" == true && "$OPENEYE" == true ]]; pytest -v --doctest-modules --nbval-lax --cov=openforcefield; else pytest -v --nbval-lax --cov=openforcefield; fi
+  - if [[ "$RDKIT" == true && "$OPENEYE" == true ]]; then pytest -v --doctest-modules --nbval-lax --cov=openforcefield; else pytest -v --nbval-lax --cov=openforcefield; fi
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,8 @@ install:
   - conda install --use-local openforcefield
 
 script:
-  - pytest -v --nbval-lax --cov=openforcefield
+  # Run doctests only if both RDKit and OpenEye are installed.
+  - if [[ "$RDKIT" == true && "$OPENEYE" == true ]]; pytest -v --doctest-modules --nbval-lax --cov=openforcefield; else pytest -v --nbval-lax --cov=openforcefield; fi
 
 notifications:
     email: false

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ The SMIRNOFF `ForceField` class is essentially a drop-in replacement for the [Op
 ```python
 # Load a molecule into the openforcefield Molecule object
 from openforcefield.topology import Molecule
-molecule = Molecule.from_file(mol_filename)
+from openforcefield.utils import get_data_filename
+sdf_file_path = get_data_filename('molecules/ethanol.sdf')
+molecule = Molecule.from_file(sdf_file_path)
 
 # Create an openforcefield Topology object from the molecule
 from openforcefield.topology import Topology
@@ -61,7 +63,7 @@ forcefield = ForceField('smirnoff99Frosst.offxml')
 openmm_system = forcefield.create_openmm_system(topology)
 
 # Load a SMIRNOFF small molecule forcefield for alkanes, ethers, and alcohols
-forcefield = ForceField(offxml_filename)
+forcefield = ForceField('Frosst_AlkEthOH_parmAtFrosst.offxml')
 ```
 Detailed examples of using SMIRNOFF with the toolkit can be found [in the documentation](https://open-forcefield-toolkit.readthedocs.io/en/topology/examples.html).
 

--- a/examples/deprecated/chemicalEnvironments/create_move_types_and_weights.ipynb
+++ b/examples/deprecated/chemicalEnvironments/create_move_types_and_weights.ipynb
@@ -20,12 +20,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "#!/usr/bin/env python\n",
     "# generic scientific/ipython header\n",
     "from __future__ import print_function\n",
     "from __future__ import division\n",
@@ -104,9 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# make 'moves with weights' dictionary for vdW\n",
@@ -179,9 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -211,9 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# 'VdW', 'Bond', 'Angle', 'Torsion', 'Improper'\n",
@@ -256,9 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -272,6 +261,7 @@
     }
    ],
    "source": [
+    "# NBVAL_SKIP\n",
     "movesWithWeightsTest = movesWithWeightsMaster['Torsion']\n",
     "key = np.random.choice( movesWithWeightsTest.keys() )\n",
     "nSamples = 10000\n",
@@ -320,9 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def GenerateMoveTree( parameterType):\n",
@@ -366,9 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -407,9 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "parameterType = 'Torsion'\n",
@@ -451,9 +435,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/deprecated/chemicalEnvironments/using_environments.ipynb
+++ b/examples/deprecated/chemicalEnvironments/using_environments.ipynb
@@ -34,9 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# import necessary functions\n",
@@ -79,7 +77,6 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
@@ -97,6 +94,7 @@
     }
    ],
    "source": [
+    "# NBVAL_SKIP\n",
     "Env = env.ChemicalEnvironment()\n",
     "atomEnv = env.AtomChemicalEnvironment()\n",
     "bondEnv = env.BondChemicalEnvironment()\n",
@@ -132,7 +130,6 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [
@@ -172,6 +169,7 @@
     }
    ],
    "source": [
+    "# NBVAL_SKIP\n",
     "# define the two replacements strings\n",
     "replacements = [ ('ewg1', '[#7!-1,#8!-1,#16!-1,#9,#17,#35,#53]'),\n",
     "               ('ewg2', '[#7!-1,#8,#16]')]\n",
@@ -261,9 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -308,9 +304,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "## Changing ORtypes and ANDtypes\n",
     "\n",
@@ -329,9 +323,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -397,9 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -452,9 +442,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -499,9 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -529,9 +515,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -567,9 +551,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -588,9 +570,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -611,9 +591,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -644,9 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -703,9 +679,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/deprecated/host_guest_simulation/smirnoff_host_guest.ipynb
+++ b/examples/deprecated/host_guest_simulation/smirnoff_host_guest.ipynb
@@ -45,6 +45,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "from openeye import oechem # OpenEye Python toolkits\n",
     "import oenotebook as oenb\n",
     "# Check license\n",
@@ -113,6 +114,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Create empty OEMol\n",
     "mol = oechem.OEMol()\n",
     "# Convert SMILES\n",
@@ -139,6 +141,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Output host and guest files\n",
     "hostfile = os.path.join(datadir, 'host.mol2')\n",
     "guestfile = os.path.join(datadir, 'guest.mol2')\n",
@@ -173,6 +176,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Read in host file\n",
     "ifile = oechem.oemolistream(hostfile)\n",
     "host = oechem.OEMol()\n",
@@ -203,6 +207,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "#initialize omega for conformer generation\n",
     "omega = oeomega.OEOmega()\n",
     "omega.SetMaxConfs(100) #Generate up to 100 conformers since we'll use for docking\n",
@@ -277,6 +282,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Import modules\n",
     "import nglview\n",
     "import mdtraj\n",
@@ -317,6 +323,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Join OEMols into complex\n",
     "complex = host.CreateCopy()\n",
     "oechem.OEAddMols( complex, outmol)\n",
@@ -411,6 +418,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Keep a list of OEMols of our components\n",
     "oemols = [] \n",
     "\n",
@@ -454,6 +462,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Load force fields for small molecules (plus default ions), water, and (temporarily) hydrogen bonds.\n",
     "# TODO add HBonds constraint through createSystem when openforcefield#32 is implemented, alleviating need for constraints here\n",
     "ff = ForceField('smirnoff99Frosst.offxml', 'hbonds.offxml', 'tip3p.offxml') \n",
@@ -490,6 +499,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Even though we're just going to minimize, we still have to set up an integrator, since a Simulation needs one\n",
     "integrator = openmm.VerletIntegrator(2.0*unit.femtoseconds)\n",
     "# Prep the Simulation using the parameterized system, the integrator, and the topology\n",
@@ -525,6 +535,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Set up NetCDF reporter for storing trajectory; prep for Langevin dynamics\n",
     "from mdtraj.reporters import NetCDFReporter\n",
     "integrator = openmm.LangevinIntegrator(300*unit.kelvin, 1./unit.picosecond, 2.*unit.femtoseconds)\n",
@@ -562,6 +573,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Load stored trajectory using MDTraj; the trajectory doesn't contain chemistry info so we also load a PDB\n",
     "traj= mdtraj.load(os.path.join(datadir, 'trajectory.nc'), top=os.path.join(datadir, 'complex_solvated.pdb'))\n",
     "\n",
@@ -586,6 +598,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Save centered trajectory for viewing elsewhere\n",
     "traj.save_netcdf(os.path.join(datadir, 'trajectory_centered.nc'))"
    ]
@@ -608,7 +621,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.8"
   },
   "toc": {
    "nav_menu": {},

--- a/examples/deprecated/partial_bondorder/test_partialbondorder.ipynb
+++ b/examples/deprecated/partial_bondorder/test_partialbondorder.ipynb
@@ -30,6 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Load our forcefield from this directory. Use of partial bond orders here means there is only one [#6X3]~[#6X3] \n",
     "# bond parameter line rather than three which otherwise would be required\n",
     "ffxml = 'Frosst_AlkEthOH_extracarbons.offxml'\n",
@@ -133,6 +134,7 @@
     }
    ],
    "source": [
+    "# NBVAL_SKIP\n",
     "topology = generateTopologyFromOEMol(mol)\n",
     "system = ff.createSystem(topology, [mol], chargeMethod = 'OECharges_AM1BCCSym', verbose = True)"
    ]
@@ -163,7 +165,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/examples/deprecated/rdkit_openeye_comparison/compare_rdk_oe_mol_loading.ipynb
+++ b/examples/deprecated/rdkit_openeye_comparison/compare_rdk_oe_mol_loading.ipynb
@@ -281,6 +281,7 @@
     }
    ],
    "source": [
+    "# NBVAL_SKIP\n",
     "from openforcefield.topology import Molecule\n",
     "\n",
     "#molecules = Molecule.from_file(get_data_filename('molecules/MiniDrugBank.sdf'), \n",
@@ -303,6 +304,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "rdk_mols_from_smiles_from_oe_mols_from_3d = []\n",
     "for oe_mol in oe_mols_from_3d:\n",
     "    if oe_mol is None:\n",
@@ -621,6 +623,7 @@
     }
    ],
    "source": [
+    "# NBVAL_SKIP\n",
     "mol_sets_to_compare = ((('oe_mols_from_3d', oe_mols_from_3d), \n",
     "                        ('rdk_mols_from_3d', rdk_mols_from_3d)),\n",
     "                       #(('oe_mols_from_smiles', oe_mols_from_smiles), \n",
@@ -707,7 +710,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/examples/deprecated/testing/OE_bondorder_testing.ipynb
+++ b/examples/deprecated/testing/OE_bondorder_testing.ipynb
@@ -27,11 +27,10 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "from openeye.oechem import *\n",
     "mol = OEMol()\n",
     "#smiles = 'CC(c1ccccc1)C(=O)[O-]'\n",
@@ -52,9 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def get_atom_properties(mol):\n",
@@ -147,9 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -160,6 +155,7 @@
     }
    ],
    "source": [
+    "# NBVAL_SKIP\n",
     "atomic_numbers, names, bonds, bond_orders = get_atom_properties(mol)\n",
     "mol = make_mol_from_properties( atomic_numbers, names, bonds, bond_orders)\n",
     "smiles = OECreateIsoSmiString(mol)\n",
@@ -178,23 +174,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/deprecated/testing/test_impropers/test_impropers.ipynb
+++ b/examples/deprecated/testing/test_impropers/test_impropers.ipynb
@@ -15,11 +15,10 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Import stuff we need\n",
     "from openforcefield.typing.engines.smirnoff import forcefield, generateTopologyFromOEMol\n",
     "import openeye.oechem as oechem\n",
@@ -37,11 +36,10 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Load our forcefield \n",
     "#ffxml = 'forcefield/smirnoff99Frosst.offxml'\n",
     "ffxml = 'smirnoff99Frosst_modified.offxml'\n",
@@ -51,9 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -75,6 +71,7 @@
     }
    ],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Initialize o-xylene and benzene as a test molecules\n",
     "molnames = ['benzene', 'o-xylene','1,2-ditert-butylbenzene'] \n",
     "oemols = []\n",
@@ -151,11 +148,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# Next step -- need AMBER prmtop/crd files for o-xylene and/or benzene for comparison\n",
     "# I should be able to get these by hand-typing them with parm@frosst types and then generating from the frcmod, etc.\n",
     "\n",
@@ -205,11 +201,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "frcmod = 'parm_Frosst.frcmod'\n",
     "for (idx, molname) in enumerate(molnames):\n",
     "    prmtop = molname+'.prmtop'\n",
@@ -228,11 +223,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "from openforcefield.typing.engines.smirnoff import forcefield_utils as ff_utils\n",
     "import numpy as np\n",
     "import simtk.unit as unit\n",
@@ -272,11 +266,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "# We can use the same code as the above but just switch the assertion about checking terms to on\n",
     "for idx, molname in enumerate(molnames):\n",
     "    print(\"Examining %s...\" % molname)\n",
@@ -315,9 +308,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -111,7 +111,7 @@ class TestParameterList:
             parameters.index('[#2:1]')
 
         p4 = ParameterType(smirks='[#2:1]')
-        with pytest.raises(ValueError, match='ParameterType object at [0-9a-zA-Z]+[>] is not in list') as excinfo:
+        with pytest.raises(ValueError, match='is not in list') as excinfo:
             parameters.index(p4)
 
     def test_contains(self):

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -3021,9 +3021,9 @@ class FrozenMolecule(Serializable):
         --------
 
         >>> molecule = Molecule.from_iupac('imatinib')
-        >>> molecule.to_file('imatinib.mol2', outfile_format='mol2')
-        >>> molecule.to_file('imatinib.sdf', outfile_format='sdf')
-        >>> molecule.to_file('imatinib.pdb', outfile_format='pdb')
+        >>> molecule.to_file('imatinib.mol2', outfile_format='mol2')  # doctest: +SKIP
+        >>> molecule.to_file('imatinib.sdf', outfile_format='sdf')  # doctest: +SKIP
+        >>> molecule.to_file('imatinib.pdb', outfile_format='pdb')  # doctest: +SKIP
 
         """
 

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -1395,13 +1395,23 @@ class FrozenMolecule(Serializable):
     Examples
     --------
 
-    Create a molecule from a mol2 file
+    Create a molecule from a sdf file
 
-    >>> molecule = FrozenMolecule.from_file('molecule.mol2')
+    >>> from openforcefield.utils import get_data_filename
+    >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+    >>> molecule = FrozenMolecule.from_file(sdf_filepath)
+
+    Convert to OpenEye OEMol object
+
+    >>> oemol = molecule.to_openeye()
 
     Create a molecule from an OpenEye molecule
 
     >>> molecule = FrozenMolecule.from_openeye(oemol)
+
+    Convert to RDKit Mol object
+
+    >>> rdmol = molecule.to_rdkit()
 
     Create a molecule from an RDKit molecule
 
@@ -1461,20 +1471,33 @@ class FrozenMolecule(Serializable):
 
         >>> empty_molecule = FrozenMolecule()
 
-        Create a molecule from another molecule:
-
-        >>> molecule_copy = FrozenMolecule(molecule_copy)
-
         Create a molecule from a file that can be used to construct a molecule,
         using either a filename or file-like object:
 
-        >>> molecule = FrozenMolecule('molecule.mol2')
-        >>> molecule = FrozenMolecule(open('molecule.mol2', 'r'))
-        >>> molecule = FrozenMolecule(gzip.GzipFile('molecule.mol2.gz', 'r'))
+        >>> from openforcefield.utils import get_data_filename
+        >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+        >>> molecule = FrozenMolecule(sdf_filepath)
+        >>> molecule = FrozenMolecule(open(sdf_filepath, 'r'), file_format='sdf')
+
+        >>> import gzip
+        >>> mol2_gz_filepath = get_data_filename('molecules/toluene.mol2.gz')
+        >>> molecule = FrozenMolecule(gzip.GzipFile(mol2_gz_filepath, 'r'), file_format='mol2')
+
+        Create a molecule from another molecule:
+
+        >>> molecule_copy = FrozenMolecule(molecule)
+
+        Convert to OpenEye OEMol object
+
+        >>> oemol = molecule.to_openeye()
 
         Create a molecule from an OpenEye molecule:
 
         >>> molecule = FrozenMolecule(oemol)
+
+        Convert to RDKit Mol object
+
+        >>> rdmol = molecule.to_rdkit()
 
         Create a molecule from an RDKit molecule:
 
@@ -1814,6 +1837,9 @@ class FrozenMolecule(Serializable):
         Examples
         --------
 
+        >>> from openforcefield.utils import get_data_filename
+        >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+        >>> molecule = Molecule(sdf_filepath)
         >>> smiles = molecule.to_smiles()
 
         """
@@ -2014,9 +2040,9 @@ class FrozenMolecule(Serializable):
         Examples
         --------
 
-        >>> molecule = Molecule.from_smiles('CCCCCC')
-        >>> molecule.generate_conformers()
-        >>> molecule.compute_partial_charges()
+        molecule = Molecule.from_smiles('CCCCCC')
+        molecule.generate_conformers()
+        molecule.compute_partial_charges()
 
         Raises
         ------
@@ -2171,16 +2197,17 @@ class FrozenMolecule(Serializable):
 
         Define a methane molecule
 
-        >>> molecule = Molecule(name='methane')
+        >>> molecule = Molecule()
+        >>> molecule.name = 'methane'
         >>> C = molecule.add_atom(6, 0, False)
         >>> H1 = molecule.add_atom(1, 0, False)
         >>> H2 = molecule.add_atom(1, 0, False)
         >>> H3 = molecule.add_atom(1, 0, False)
         >>> H4 = molecule.add_atom(1, 0, False)
-        >>> molecule.add_bond(C, H1, False, 1)
-        >>> molecule.add_bond(C, H2, False, 1)
-        >>> molecule.add_bond(C, H3, False, 1)
-        >>> molecule.add_bond(C, H4, False, 1)
+        >>> bond_idx = molecule.add_bond(C, H1, False, 1)
+        >>> bond_idx = molecule.add_bond(C, H2, False, 1)
+        >>> bond_idx = molecule.add_bond(C, H3, False, 1)
+        >>> bond_idx = molecule.add_bond(C, H4, False, 1)
 
         """
         # Create an atom
@@ -2797,6 +2824,9 @@ class FrozenMolecule(Serializable):
         Examples
         --------
 
+        >>> from openforcefield.utils import get_data_filename
+        >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+        >>> molecule = Molecule(sdf_filepath)
         >>> iupac_name = molecule.to_iupac()
 
         """
@@ -2828,7 +2858,7 @@ class FrozenMolecule(Serializable):
 
         Create a molecule from a Topology object that contains exactly one molecule
 
-        >>> molecule = Molecule.from_topology(topology)
+        >>> molecule = Molecule.from_topology(topology)  # doctest: +SKIP
 
         """
         # TODO: Ensure we are dealing with an openforcefield Topology object
@@ -2892,7 +2922,7 @@ class FrozenMolecule(Serializable):
 
         Examples
         --------
-        >>> from openforcefield.tests.utils.utils import get_monomer_mol2file
+        >>> from openforcefield.tests.utils import get_monomer_mol2file
         >>> mol2_filename = get_monomer_mol2file('cyclohexane')
         >>> molecule = Molecule.from_file(mol2_filename)
 
@@ -3060,6 +3090,9 @@ class FrozenMolecule(Serializable):
 
         Create a molecule from an RDKit molecule
 
+        >>> from rdkit import Chem
+        >>> from openforcefield.tests.utils import get_data_filename
+        >>> rdmol = Chem.MolFromMolFile(get_data_filename('systems/monomers/ethanol.sdf'))
         >>> molecule = Molecule.from_rdkit(rdmol)
 
         """
@@ -3089,6 +3122,9 @@ class FrozenMolecule(Serializable):
 
         Convert a molecule to RDKit
 
+        >>> from openforcefield.utils import get_data_filename
+        >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+        >>> molecule = Molecule(sdf_filepath)
         >>> rdmol = molecule.to_rdkit()
 
         """
@@ -3120,7 +3156,11 @@ class FrozenMolecule(Serializable):
 
         Create a Molecule from an OpenEye OEMol
 
-        >>> molecule = Molecule.from_openeye(oemol)
+        >>> from openeye import oechem
+        >>> from openforcefield.tests.utils import get_data_filename
+        >>> ifs = oechem.oemolistream(get_data_filename('systems/monomers/ethanol.mol2'))
+        >>> oemols = list(ifs.GetOEGraphMols())
+        >>> molecule = Molecule.from_openeye(oemols[0])
 
         """
         toolkit = OpenEyeToolkitWrapper()
@@ -3183,18 +3223,23 @@ class FrozenMolecule(Serializable):
             * 'Wiberg' : Wiberg bond order
         toolkit_registry : openforcefield.utils.toolkits ToolkitRegistry
             The toolkit registry to use for molecule operations
+
         Examples
         --------
 
         Get fractional Wiberg bond orders
 
         >>> molecule = Molecule.from_iupac('imatinib')
+        >>> molecule.generate_conformers()
         >>> fractional_bond_orders = molecule.get_fractional_bond_orders(method='Wiberg')
 
         """
+        # TODO: Let ToolkitRegistry handle this once compute_fractional_bond_orders will be added to the Wrappers API.
+        if method != 'Wiberg':
+            raise NotImplementedError('Only Wiberg bond order is currently implemented')
         # TODO: Use memoization to speed up subsequent calls; use decorator?
         fractional_bond_orders = toolkit_registry.call(
-            'compute_fractional_bond_orders', method=method)
+            'compute_wiberg_bond_orders', molecule=self)
         return fractional_bond_orders
 
     def _construct_angles(self):
@@ -3306,13 +3351,23 @@ class Molecule(FrozenMolecule):
     Examples
     --------
 
-    Create a molecule from a mol2 file
+    Create a molecule from an sdf file
 
-    >>> molecule = Molecule.from_file('molecule.mol2')
+    >>> from openforcefield.utils import get_data_filename
+    >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+    >>> molecule = Molecule(sdf_filepath)
+
+    Convert to OpenEye OEMol object
+
+    >>> oemol = molecule.to_openeye()
 
     Create a molecule from an OpenEye molecule
 
     >>> molecule = Molecule.from_openeye(oemol)
+
+    Convert to RDKit Mol object
+
+    >>> rdmol = molecule.to_rdkit()
 
     Create a molecule from an RDKit molecule
 
@@ -3358,20 +3413,33 @@ class Molecule(FrozenMolecule):
 
         >>> empty_molecule = Molecule()
 
-        Create a molecule from another molecule:
-
-        >>> molecule_copy = Molecule(molecule_copy)
-
         Create a molecule from a file that can be used to construct a molecule,
         using either a filename or file-like object:
 
-        >>> molecule = Molecule('molecule.mol2')
-        >>> molecule = Molecule(open('molecule.mol2', 'r'))
-        >>> molecule = Molecule(gzip.GzipFile('molecule.mol2.gz', 'r'))
+        >>> from openforcefield.utils import get_data_filename
+        >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+        >>> molecule = Molecule(sdf_filepath)
+        >>> molecule = Molecule(open(sdf_filepath, 'r'), file_format='sdf')
+
+        >>> import gzip
+        >>> mol2_gz_filepath = get_data_filename('molecules/toluene.mol2.gz')
+        >>> molecule = Molecule(gzip.GzipFile(mol2_gz_filepath, 'r'), file_format='mol2')
+
+        Create a molecule from another molecule:
+
+        >>> molecule_copy = Molecule(molecule)
+
+        Convert to OpenEye OEMol object
+
+        >>> oemol = molecule.to_openeye()
 
         Create a molecule from an OpenEye molecule:
 
         >>> molecule = Molecule(oemol)
+
+        Convert to RDKit Mol object
+
+        >>> rdmol = molecule.to_rdkit()
 
         Create a molecule from an RDKit molecule:
 
@@ -3421,16 +3489,17 @@ class Molecule(FrozenMolecule):
 
         Define a methane molecule
 
-        >>> molecule = Molecule(name='methane')
+        >>> molecule = Molecule()
+        >>> molecule.name = 'methane'
         >>> C = molecule.add_atom(6, 0, False)
         >>> H1 = molecule.add_atom(1, 0, False)
         >>> H2 = molecule.add_atom(1, 0, False)
         >>> H3 = molecule.add_atom(1, 0, False)
         >>> H4 = molecule.add_atom(1, 0, False)
-        >>> molecule.add_bond(C, H1, False, 1)
-        >>> molecule.add_bond(C, H2, False, 1)
-        >>> molecule.add_bond(C, H3, False, 1)
-        >>> molecule.add_bond(C, H4, False, 1)
+        >>> bond_idx = molecule.add_bond(C, H1, False, 1)
+        >>> bond_idx = molecule.add_bond(C, H2, False, 1)
+        >>> bond_idx = molecule.add_bond(C, H3, False, 1)
+        >>> bond_idx = molecule.add_bond(C, H4, False, 1)
 
         """
         atom_index = self._add_atom(

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -890,21 +890,21 @@ class Topology(Serializable):
     Import some utilities
 
     >>> from simtk.openmm import app
-    >>> from openforcefield.tests.utils import get_monomer_mol2file, get_packmol_pdbfile
-    >>> pdb_filename = get_packmol_pdbfile('cyclohexane_ethanol_0.4_0.6')
+    >>> from openforcefield.tests.utils import get_data_filename, get_packmol_pdbfile
+    >>> pdb_filepath = get_packmol_pdbfile('cyclohexane_ethanol_0.4_0.6')
     >>> monomer_names = ('cyclohexane', 'ethanol')
 
-    Create a Topology object from a PDB file and mol2 files defining the molecular contents
+    Create a Topology object from a PDB file and sdf files defining the molecular contents
 
     >>> from openforcefield.topology import Molecule, Topology
-    >>> pdbfile = app.PDBFile(pdb_filename)
-    >>> mol2_filenames = [get_monomer_mol2file(name) for name in monomer_names]
-    >>> unique_molecules = [Molecule.from_file(mol2_filename) for mol2_filename in mol2_filenames]
+    >>> pdbfile = app.PDBFile(pdb_filepath)
+    >>> sdf_filepaths = [get_data_filename(f'systems/monomers/{name}.sdf') for name in monomer_names]
+    >>> unique_molecules = [Molecule.from_file(sdf_filepath) for sdf_filepath in sdf_filepaths]
     >>> topology = Topology.from_openmm(pdbfile.topology, unique_molecules=unique_molecules)
 
     Create a Topology object from a PDB file and IUPAC names of the molecular contents
 
-    >>> pdbfile = app.PDBFile(pdb_filename)
+    >>> pdbfile = app.PDBFile(pdb_filepath)
     >>> unique_molecules = [Molecule.from_iupac(name) for name in monomer_names]
     >>> topology = Topology.from_openmm(pdbfile.topology, unique_molecules=unique_molecules)
 
@@ -912,17 +912,15 @@ class Topology(Serializable):
 
     >>> topology = Topology()
     >>> molecule = Molecule.from_iupac('benzene')
-    >>> [ topology.add_molecule(molecule) for index in range(10) ]
-
-    Create a deep copy of the Topology and its contents
-
-    >>> topology_copy = Topology(topology)
+    >>> molecule_topology_indices = [topology.add_molecule(molecule) for index in range(10)]
 
     Create a Topology from an OpenEye Molecule, including perception of chains and residues
     (requires the OpenEye toolkit)
 
-    >>> oemol = oechem.oemolistream('input.pdb')
-    >>> topology = Topology.from_openeye(oemol)
+    from openeye import oechem
+    ifs = oechem.oemolistream(get_data_filename('systems/monomers/ethanol.mol2'))
+    oemol = list(ifs.GetOEGraphMols())[0]
+    topology = Topology.from_openeye(oemol)
 
     """
 

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -890,21 +890,22 @@ class Topology(Serializable):
     Import some utilities
 
     >>> from simtk.openmm import app
-    >>> from openforcefield.tests.utils.utils import get_monomer_mol2file, get_packmol_pdbfile
-    >>> pdb_filename = get_packmol_pdbfile('cyclohexane_ethanol_0.4_0.6.pdb')
+    >>> from openforcefield.tests.utils import get_monomer_mol2file, get_packmol_pdbfile
+    >>> pdb_filename = get_packmol_pdbfile('cyclohexane_ethanol_0.4_0.6')
     >>> monomer_names = ('cyclohexane', 'ethanol')
 
     Create a Topology object from a PDB file and mol2 files defining the molecular contents
 
+    >>> from openforcefield.topology import Molecule, Topology
     >>> pdbfile = app.PDBFile(pdb_filename)
-    >>> mol2_filenames = [ get_monomer_mol2file(name) for name in monomer_names ]
-    >>> unique_molecules = [ Molecule.from_file(mol2_filename) for mol2_filename in mol2_filenames ]
+    >>> mol2_filenames = [get_monomer_mol2file(name) for name in monomer_names]
+    >>> unique_molecules = [Molecule.from_file(mol2_filename) for mol2_filename in mol2_filenames]
     >>> topology = Topology.from_openmm(pdbfile.topology, unique_molecules=unique_molecules)
 
     Create a Topology object from a PDB file and IUPAC names of the molecular contents
 
     >>> pdbfile = app.PDBFile(pdb_filename)
-    >>> unique_molecules = [ Molecule.from_iupac(name) for name in monomer_names ]
+    >>> unique_molecules = [Molecule.from_iupac(name) for name in monomer_names]
     >>> topology = Topology.from_openmm(pdbfile.topology, unique_molecules=unique_molecules)
 
     Create an empty Topology object and add a few copies of a single benzene molecule

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -914,14 +914,6 @@ class Topology(Serializable):
     >>> molecule = Molecule.from_iupac('benzene')
     >>> molecule_topology_indices = [topology.add_molecule(molecule) for index in range(10)]
 
-    Create a Topology from an OpenEye Molecule, including perception of chains and residues
-    (requires the OpenEye toolkit)
-
-    from openeye import oechem
-    ifs = oechem.oemolistream(get_data_filename('systems/monomers/ethanol.mol2'))
-    oemol = list(ifs.GetOEGraphMols())[0]
-    topology = Topology.from_openeye(oemol)
-
     """
 
     def __init__(self, other=None):

--- a/openforcefield/utils/serialization.py
+++ b/openforcefield/utils/serialization.py
@@ -51,8 +51,8 @@ class Serializable(abc.ABC):
     ...     def from_dict(cls, d):
     ...         return cls(d['description'])
     ...
-    ... # Create an example object
-    ... thing = Thing('blorb')
+    >>> # Create an example object
+    >>> thing = Thing('blorb')
 
     Get `JSON <https://www.json.org/>`_ representation:
 
@@ -78,14 +78,6 @@ class Serializable(abc.ABC):
 
     >>> thing_from_yaml = Thing.from_yaml(yaml_thing)
 
-    Get `TOML <https://github.com/toml-lang/toml>`_ representation:
-
-    >>> toml_thing = thing.to_toml()
-
-    Reconstruct an objecft from its `TOML <https://github.com/toml-lang/toml>`_ representation:
-
-    >>> thing_from_toml = Thing.from_toml(toml_thing)
-
     Get `MessagePack <https://msgpack.org/index.html>`_ representation:
 
     >>> messagepack_thing = thing.to_messagepack()
@@ -97,10 +89,6 @@ class Serializable(abc.ABC):
     Get `XML <https://www.w3.org/XML/>`_ representation:
 
     >>> xml_thing = thing.to_xml()
-
-    Reconstruct an objecft from its `XML <https://www.w3.org/XML/>`_ representation:
-
-    >>> thing_from_xml = Thing.from_xml(xml_thing)
 
     """
 

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -660,13 +660,13 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         Create a Molecule from an OpenEye OEMol
 
-        >>> from openforcefield.topology import Molecule
-        >>> molecule = Molecule.from_smiles('CC')
-        >>> oemol = molecule.to_openeye()
+        >>> from openeye import oechem
+        >>> from openforcefield.tests.utils import get_data_filename
+        >>> ifs = oechem.oemolistream(get_data_filename('systems/monomers/ethanol.mol2'))
+        >>> oemols = list(ifs.GetOEGraphMols())
+
         >>> toolkit_wrapper = OpenEyeToolkitWrapper()
-        >>> molecule_from_oemol = toolkit_wrapper.from_openeye(oemol)
-        >>> molecule_from_oemol == molecule
-        True
+        >>> molecule = toolkit_wrapper.from_openeye(oemols[0])
 
         """
         from openeye import oechem
@@ -1784,12 +1784,12 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
         Create a molecule from an RDKit molecule
 
-        >>> from openforcefield.topology import Molecule
-        >>> molecule = Molecule.from_smiles('CCO')
-        >>> rdmol = molecule.to_rdkit()
-        >>> molecule_from_rdkit = Molecule.from_rdkit(rdmol)
-        >>> molecule_from_rdkit == molecule
-        True
+        >>> from rdkit import Chem
+        >>> from openforcefield.tests.utils import get_data_filename
+        >>> rdmol = Chem.MolFromMolFile(get_data_filename('systems/monomers/ethanol.sdf'))
+
+        >>> toolkit_wrapper = RDKitToolkitWrapper()
+        >>> molecule = toolkit_wrapper.from_rdkit(rdmol)
 
         """
         from rdkit import Chem

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -660,8 +660,13 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         Create a Molecule from an OpenEye OEMol
 
+        >>> from openforcefield.topology import Molecule
+        >>> molecule = Molecule.from_smiles('CC')
+        >>> oemol = molecule.to_openeye()
         >>> toolkit_wrapper = OpenEyeToolkitWrapper()
-        >>> molecule = toolkit_wrapper.from_openeye(oemol)
+        >>> molecule_from_oemol = toolkit_wrapper.from_openeye(oemol)
+        >>> molecule_from_oemol == molecule
+        True
 
         """
         from openeye import oechem
@@ -837,6 +842,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         Create an OpenEye molecule from a Molecule
 
+        >>> from openforcefield.topology import Molecule
         >>> toolkit_wrapper = OpenEyeToolkitWrapper()
         >>> molecule = Molecule.from_smiles('CC')
         >>> oemol = toolkit_wrapper.to_openeye(molecule)
@@ -1778,7 +1784,12 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
         Create a molecule from an RDKit molecule
 
-        >>> molecule = Molecule.from_rdkit(rdmol)
+        >>> from openforcefield.topology import Molecule
+        >>> molecule = Molecule.from_smiles('CCO')
+        >>> rdmol = molecule.to_rdkit()
+        >>> molecule_from_rdkit = Molecule.from_rdkit(rdmol)
+        >>> molecule_from_rdkit == molecule
+        True
 
         """
         from rdkit import Chem
@@ -1966,7 +1977,9 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
         Convert a molecule to RDKit
 
-        >>> rdmol = molecule.to_rdkit()
+        >>> from openforcefield.topology import Molecule
+        >>> ethanol = Molecule.from_smiles('CCO')
+        >>> rdmol = ethanol.to_rdkit()
 
         """
         from rdkit import Chem, Geometry
@@ -2739,25 +2752,30 @@ class ToolkitRegistry(object):
     >>> from openforcefield.utils.toolkits import ToolkitRegistry
     >>> toolkit_registry = ToolkitRegistry()
     >>> toolkit_precedence = [OpenEyeToolkitWrapper, RDKitToolkitWrapper, AmberToolsToolkitWrapper]
-    >>> [ toolkit_registry.register(toolkit) for toolkit in toolkit_precedence if toolkit.is_available() ]
+    >>> for toolkit in toolkit_precedence:
+    ...     if toolkit.is_available():
+    ...         toolkit_registry.register_toolkit(toolkit)
 
     Register specified toolkits, raising an exception if one is unavailable
 
     >>> toolkit_registry = ToolkitRegistry()
     >>> toolkits = [OpenEyeToolkitWrapper, AmberToolsToolkitWrapper]
-    >>> for toolkit in toolkits: toolkit_registry.register(toolkit)
+    >>> for toolkit in toolkits:
+    ...     toolkit_registry.register_toolkit(toolkit)
 
     Register all available toolkits in arbitrary order
 
     >>> from openforcefield.utils import all_subclasses
     >>> toolkits = all_subclasses(ToolkitWrapper)
-    >>> [ toolkit_registry.register(toolkit) for toolkit in toolkits if toolkit.is_available() ]
+    >>> for toolkit in toolkit_precedence:
+    ...     if toolkit.is_available():
+    ...         toolkit_registry.register_toolkit(toolkit)
 
     Retrieve the global singleton toolkit registry, which is created when this module is imported from all available
     toolkits:
 
     >>> from openforcefield.utils.toolkits import GLOBAL_TOOLKIT_REGISTRY as toolkit_registry
-    >>> print(toolkit_registry.registered_toolkits())
+    >>> available_toolkits = toolkit_registry.registered_toolkits
 
     """
 
@@ -2903,6 +2921,7 @@ class ToolkitRegistry(object):
 
         Create a molecule, and call the toolkit ``to_smiles()`` method directly
 
+        >>> from openforcefield.topology import Molecule
         >>> molecule = Molecule.from_smiles('Cc1ccccc1')
         >>> toolkit_registry = ToolkitRegistry(register_imported_toolkit_wrappers=True)
         >>> method = toolkit_registry.resolve('to_smiles')
@@ -2935,9 +2954,7 @@ class ToolkitRegistry(object):
 
         ``*args`` and ``**kwargs`` are passed to the desired method, and return values of the method are returned
 
-        This is a convenient shorthand for
-
-        >>> toolkit_registry.resolve_method(method_name)(*args, **kwargs)
+        This is a convenient shorthand for ``toolkit_registry.resolve_method(method_name)(*args, **kwargs)``
 
         Parameters
         ----------
@@ -2953,6 +2970,7 @@ class ToolkitRegistry(object):
 
         Create a molecule, and call the toolkit ``to_smiles()`` method directly
 
+        >>> from openforcefield.topology import Molecule
         >>> molecule = Molecule.from_smiles('Cc1ccccc1')
         >>> toolkit_registry = ToolkitRegistry(register_imported_toolkit_wrappers=True)
         >>> smiles = toolkit_registry.call('to_smiles', molecule)

--- a/openforcefield/utils/utils.py
+++ b/openforcefield/utils/utils.py
@@ -59,7 +59,7 @@ def temporary_cd(dir_path):
     --------
     >>> dir_path = '/tmp'
     >>> with temporary_cd(dir_path):
-    ...     # do something in dir_path
+    ...     pass  # do something in dir_path
 
     """
     import os


### PR DESCRIPTION
I've added Travis doctests only in the environment with OpenEye and RDKit installed because it handling different environments and making test pass anyway would have made the examples less clear.