### PR TITLE
Restore numpydoc in rtd environment.yml

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,6 +4,13 @@ channels:
     - omnia
     - defaults
 dependencies:
+    # readthedocs dependencies
+    - numpydoc
+    - nbsphinx
+    - sphinx_bootstrap_theme
+    - m2r >=0.2.1
+    - testpath =0.3.1
+    # conda build dependencies
     - python
     - numpy
     - openmm
@@ -19,7 +26,3 @@ dependencies:
     - xmltodict
     - pyyaml
     - cairo ==1.16
-    - nbsphinx
-    - sphinx_bootstrap_theme
-    - m2r >=0.2.1
-    - testpath =0.3.1

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,7 +11,7 @@ dependencies:
     - m2r >=0.2.1
     - testpath =0.3.1
     # conda build dependencies
-    - python
+    - python ==3.6
     - numpy
     - openmm
     - networkx

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,6 +12,7 @@ dependencies:
     - testpath =0.3.1
     # conda build dependencies
     - python ==3.6
+    - setuptools
     - numpy
     - openmm
     - networkx


### PR DESCRIPTION
This PR restores `numpydoc` in the readthedocs `environment.yml` which was accidentally deleted in #238 