### PR TITLE
Add BRD4:inhibitor example and MyBinder badges for protein-ligand examples

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,22 +1,8 @@
+# Environment file for Jupyter notebook examples
 name: openforcefield
 channels:
     - conda-forge
     - omnia
     - defaults
 dependencies:
-    - python
-    - setuptools
-    - numpy
-    - openmm
-    - networkx
-    - parmed
-    - rdkit
-    - ambermini
-    - packaging
-    # Serialization: Should these be optional?
-    - toml
-    - bson
-    - msgpack-python
-    - xmltodict
-    - pyyaml
-    - cairo ==1.16
+    - openforcefield

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,22 @@
+name: openforcefield
+channels:
+    - conda-forge
+    - omnia
+    - defaults
+dependencies:
+    - python
+    - setuptools
+    - numpy
+    - openmm
+    - networkx
+    - parmed
+    - rdkit
+    - ambermini
+    - packaging
+    # Serialization: Should these be optional?
+    - toml
+    - bson
+    - msgpack-python
+    - xmltodict
+    - pyyaml
+    - cairo ==1.16

--- a/examples/using_smirnoff_with_amber_protein_forcefield/BRD4_inhibitor_benchmark.ipynb
+++ b/examples/using_smirnoff_with_amber_protein_forcefield/BRD4_inhibitor_benchmark.ipynb
@@ -1,0 +1,267 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using SMIRNOFF with Amber on BRD4:inhibitor complexes: Exporting parameterized complexes to Amber, Gromacs, and CHARMM\n",
+    "\n",
+    "This example applies SMIRNOFF parameters to BRD4 inhibitors from the [living review on binding free energy benchmark systems](https://www.annualreviews.org/doi/abs/10.1146/annurev-biophys-070816-033654) by Mobley and Gilson. The BRD4 system comes from the [accompanying GitHub repository](https://github.com/MobleyLab/benchmarksets/tree/master/input_files/BRD4).\n",
+    "\n",
+    "This example uses [ParmEd](http://parmed.github.io) to combine a protein parameterized with Amber with a ligand parameterized with SMIRNOFF. This example is meant to illustrate how to apply parameters to a single ligand, but it's also easy to process many ligands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieve protein and ligand files for BRD4 and a docked inhibitor\n",
+    "import requests\n",
+    "sources = {\n",
+    "    'receptor.pdb' : 'https://raw.githubusercontent.com/MobleyLab/benchmarksets/master/input_files/BRD4/pdb/BRD4.pdb',\n",
+    "    'ligand.pdb' : 'https://raw.githubusercontent.com/MobleyLab/benchmarksets/master/input_files/BRD4/pdb/ligand-1.pdb',\n",
+    "    'ligand.sdf' : 'https://raw.githubusercontent.com/MobleyLab/benchmarksets/master/input_files/BRD4/sdf/ligand-1.sdf',\n",
+    "}\n",
+    "for (filename, url) in sources.items():\n",
+    "    r = requests.get(url)\n",
+    "    open(filename, 'w').write(r.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Parametrize a molecule with smirnoff99Frosst\n",
+    "\n",
+    "First, we parametrize the ligand with the smirnoff99Frosst force field."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use both a PDB file and an SDF file for the ligand."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Unable to load toolkit <openforcefield.utils.toolkits.OpenEyeToolkitWrapper object at 0x110401240>.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No module named 'openeye'\n",
+      "Warning: Cannot import openeye toolkit; not all functionality will be available.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "In AmberToolsToolkitwrapper.computer_partial_charges_am1bcc: Molecule 'BRD4, Ligand 1' has more than one conformer, but this function will only generate charges for the first one.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create an OpenFF Topology of the ligand from the SDF file\n",
+    "from openforcefield.topology import Molecule\n",
+    "ligand_off_topology = Molecule('ligand.sdf').to_topology()\n",
+    "\n",
+    "# Read in the coordinates of the ligand from the PDB file\n",
+    "from simtk.openmm.app import PDBFile\n",
+    "ligand_pdbfile = PDBFile('ligand.pdb')\n",
+    "\n",
+    "# Load the smirnoff99Frosst system from disk\n",
+    "from openforcefield.typing.engines.smirnoff import ForceField\n",
+    "force_field = ForceField('smirnoff99Frosst.offxml')\n",
+    "\n",
+    "# Parametrize the toluene molecule\n",
+    "ligand_system = force_field.create_openmm_system(ligand_off_topology)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and we convert the OpenMM `System` to a ParmEd `Structure` that we'll be able to mix with the protein\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "  <b>Warning:</b> ParmEd's Structure model is inspired by AMBER. Some information in an OpenMM System are not directly translatable into a Structure. In particular, long-range interaction treatment method (e.g., PME, CutoffPeriodic) and parameters (e.g., cutoff and cutoff switching distance, PME error tolerance) are known to be lost during the conversion.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import parmed\n",
+    "\n",
+    "# Convert OpenMM System into a ParmEd Structure.\n",
+    "ligand_structure = parmed.openmm.load_topology(ligand_pdbfile.topology,\n",
+    "                                                ligand_system,\n",
+    "                                                xyz=ligand_pdbfile.positions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create a ParmEd `Structure` of an AMBER-parametrized receptor\n",
+    "\n",
+    "We have to create a ParmEd `Structure` of the receptor (BRD4) to combine to the toluene `Structure`. \n",
+    "Here we assign Amber14 parameters using OpenMM.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <b>Note:</b> If you already have AMBER (prmtop/inpcrd), GROMACS (top/gro), or any other file specifying the protein parameters supported by ParmEd, you can simply load the files directly into a Structure using ParmEd's functionalities. See https://parmed.github.io/ParmEd/html/readwrite.html .\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "receptor_pdbfile = PDBFile('receptor.pdb')\n",
+    "\n",
+    "# Load the AMBER protein force field through OpenMM.\n",
+    "from simtk.openmm import app\n",
+    "omm_forcefield = app.ForceField('amber14-all.xml')\n",
+    "\n",
+    "# Parameterize the protein.\n",
+    "receptor_system = omm_forcefield.createSystem(receptor_pdbfile.topology)\n",
+    "\n",
+    "# Convert the protein System into a ParmEd Structure.\n",
+    "receptor_structure = parmed.openmm.load_topology(receptor_pdbfile.topology,\n",
+    "                                                 receptor_system,\n",
+    "                                                 xyz=receptor_pdbfile.positions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Combine receptor and ligand structures\n",
+    "\n",
+    "We can then merge the receptor and ligand `Structure` objects into a single one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "complex_structure = receptor_structure + ligand_structure"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Export to OpenMM, Amber, and gromacs\n",
+    "\n",
+    "Once we have the `Structure` of the complex, we can chose to create a `System` object that we can simulate with OpenMM:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from simtk.openmm.app import NoCutoff, HBonds\n",
+    "from simtk import unit\n",
+    "\n",
+    "# Convert the Structure to an OpenMM System in vacuum.\n",
+    "complex_system = complex_structure.createSystem(nonbondedMethod=NoCutoff,\n",
+    "                                                nonbondedCutoff=9.0*unit.angstrom,\n",
+    "                                                constraints=HBonds,\n",
+    "                                                removeCMMotion=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Export the System to an OpenMM System XML and PDB file\n",
+    "complex_structure.save('complex.pdb', overwrite=True)\n",
+    "from simtk.openmm import XmlSerializer\n",
+    "with open('complex.xml', 'w') as f:\n",
+    "    f.write(XmlSerializer.serialize(complex_system))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or export it to Amber `prmtop` and `inpcrd`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Export the Structure to AMBER files\n",
+    "complex_structure.save('complex.prmtop', overwrite=True)\n",
+    "complex_structure.save('complex.inpcrd', overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or export it to gramacs `gro` and `top`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Export the Structure to Gromacs files\n",
+    "complex_structure.save('complex.gro', overwrite=True)\n",
+    "complex_structure.save('complex.top', overwrite=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/using_smirnoff_with_amber_protein_forcefield/README.md
+++ b/examples/using_smirnoff_with_amber_protein_forcefield/README.md
@@ -2,7 +2,14 @@
 
 These examples illustrate how the [ParmEd](http://parmed.github.io/ParmEd/html/index.html) utility can be used to merge a small molecule parameterized by SMIRNOFF with a traditionally parameterized protein (or other biopolymer) to create a fully parameterized protein-ligand system.
 
-* [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/protein-ligand-examples?filepath=examples%2Fusing_smirnoff_with_amber_protein_forcefield%2FBRD4_inhibitor_benchmark.ipynb)
- ['BRD4_inhibitor_benchmark.ipynb']('BRD4_inhibitor_benchmark.ipynb') - BRD4:inhibitor from the [free energy benchmark systems living review](https://www.annualreviews.org/doi/abs/10.1146/annurev-biophys-070816-033654)
-* [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/protein-ligand-examples?filepath=examples%2Ftoluene_in_T4_lysozyme.ipynb)
- ['toluene_in_T4_lysozyme.ipynb'](toluene_in_T4_lysozyme.ipynb) - toluene binding to T4 lysozyme L99A
+### BRD4:inhibitor complex
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/protein-ligand-examples?filepath=examples%2Fusing_smirnoff_with_amber_protein_forcefield%2FBRD4_inhibitor_benchmark.ipynb)
+
+['BRD4_inhibitor_benchmark.ipynb']('BRD4_inhibitor_benchmark.ipynb') contains an example illustrating applying SMIRNOFF and Amber14 parameters to a BRD4:inhibitor complex taken from the [free energy benchmark systems living review](https://www.annualreviews.org/doi/abs/10.1146/annurev-biophys-070816-033654) [GitHub repo](https://github.com/MobleyLab/benchmarksets/tree/master/input_files/BRD4).
+
+### Toluene in complex with T4 lysozyme L99A
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/protein-ligand-examples?filepath=examples%2Ftoluene_in_T4_lysozyme.ipynb)
+
+['toluene_in_T4_lysozyme.ipynb'](toluene_in_T4_lysozyme.ipynb) contains an example illustrating applying SMIRNOFF and Amber99SB-ILDN parameters to toluene complexed with T4 lysozyme L99A.

--- a/examples/using_smirnoff_with_amber_protein_forcefield/README.md
+++ b/examples/using_smirnoff_with_amber_protein_forcefield/README.md
@@ -10,6 +10,6 @@ These examples illustrate how the [ParmEd](http://parmed.github.io/ParmEd/html/i
 
 ### Toluene in complex with T4 lysozyme L99A
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/master?filepath=examples%2Ftoluene_in_T4_lysozyme.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/master?filepath=examples%2Fusing_smirnoff_with_amber_protein_forcefield%2Ftoluene_in_T4_lysozyme.ipynb)
 
 [`toluene_in_T4_lysozyme.ipynb`](toluene_in_T4_lysozyme.ipynb) contains an example illustrating applying SMIRNOFF and Amber99SB-ILDN parameters to toluene complexed with T4 lysozyme L99A.

--- a/examples/using_smirnoff_with_amber_protein_forcefield/README.md
+++ b/examples/using_smirnoff_with_amber_protein_forcefield/README.md
@@ -4,12 +4,12 @@ These examples illustrate how the [ParmEd](http://parmed.github.io/ParmEd/html/i
 
 ### BRD4:inhibitor complex
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/protein-ligand-examples?filepath=examples%2Fusing_smirnoff_with_amber_protein_forcefield%2FBRD4_inhibitor_benchmark.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/master?filepath=examples%2Fusing_smirnoff_with_amber_protein_forcefield%2FBRD4_inhibitor_benchmark.ipynb)
 
 ['BRD4_inhibitor_benchmark.ipynb']('BRD4_inhibitor_benchmark.ipynb') contains an example illustrating applying SMIRNOFF and Amber14 parameters to a BRD4:inhibitor complex taken from the [free energy benchmark systems living review](https://www.annualreviews.org/doi/abs/10.1146/annurev-biophys-070816-033654) [GitHub repo](https://github.com/MobleyLab/benchmarksets/tree/master/input_files/BRD4).
 
 ### Toluene in complex with T4 lysozyme L99A
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/protein-ligand-examples?filepath=examples%2Ftoluene_in_T4_lysozyme.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/master?filepath=examples%2Ftoluene_in_T4_lysozyme.ipynb)
 
 ['toluene_in_T4_lysozyme.ipynb'](toluene_in_T4_lysozyme.ipynb) contains an example illustrating applying SMIRNOFF and Amber99SB-ILDN parameters to toluene complexed with T4 lysozyme L99A.

--- a/examples/using_smirnoff_with_amber_protein_forcefield/README.md
+++ b/examples/using_smirnoff_with_amber_protein_forcefield/README.md
@@ -6,10 +6,10 @@ These examples illustrate how the [ParmEd](http://parmed.github.io/ParmEd/html/i
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/master?filepath=examples%2Fusing_smirnoff_with_amber_protein_forcefield%2FBRD4_inhibitor_benchmark.ipynb)
 
-['BRD4_inhibitor_benchmark.ipynb']('BRD4_inhibitor_benchmark.ipynb') contains an example illustrating applying SMIRNOFF and Amber14 parameters to a BRD4:inhibitor complex taken from the [free energy benchmark systems living review](https://www.annualreviews.org/doi/abs/10.1146/annurev-biophys-070816-033654) [GitHub repo](https://github.com/MobleyLab/benchmarksets/tree/master/input_files/BRD4).
+[`BRD4_inhibitor_benchmark.ipynb`](BRD4_inhibitor_benchmark.ipynb) contains an example illustrating applying SMIRNOFF and Amber14 parameters to a BRD4:inhibitor complex taken from the [free energy benchmark systems living review](https://www.annualreviews.org/doi/abs/10.1146/annurev-biophys-070816-033654) [GitHub repo](https://github.com/MobleyLab/benchmarksets/tree/master/input_files/BRD4).
 
 ### Toluene in complex with T4 lysozyme L99A
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/master?filepath=examples%2Ftoluene_in_T4_lysozyme.ipynb)
 
-['toluene_in_T4_lysozyme.ipynb'](toluene_in_T4_lysozyme.ipynb) contains an example illustrating applying SMIRNOFF and Amber99SB-ILDN parameters to toluene complexed with T4 lysozyme L99A.
+[`toluene_in_T4_lysozyme.ipynb`](toluene_in_T4_lysozyme.ipynb) contains an example illustrating applying SMIRNOFF and Amber99SB-ILDN parameters to toluene complexed with T4 lysozyme L99A.

--- a/examples/using_smirnoff_with_amber_protein_forcefield/README.md
+++ b/examples/using_smirnoff_with_amber_protein_forcefield/README.md
@@ -1,3 +1,6 @@
-## Combining a SMIRNOFF parameterized small molecule with an AMBER parameterized protein using ParmEd
+## Combining a SMIRNOFF parameterized small molecule with an Amber parameterized protein using ParmEd
 
-This example illustrates how the [ParmEd](http://parmed.github.io/ParmEd/html/index.html) utility can be used to merge a small molecule parameterized by SMIRNOFF with a traditionally parameterized protein (or other biopolymer) to create a fully parameterized protein-ligand system.
+These examples illustrate how the [ParmEd](http://parmed.github.io/ParmEd/html/index.html) utility can be used to merge a small molecule parameterized by SMIRNOFF with a traditionally parameterized protein (or other biopolymer) to create a fully parameterized protein-ligand system.
+
+* ['BRD4_inhibitor_benchmark.ipynb']('BRD4_inhibitor_benchmark.ipynb') - BRD4:inhibitor from the [free energy benchmark systems living review](https://www.annualreviews.org/doi/abs/10.1146/annurev-biophys-070816-033654)
+* ['toluene_in_T4_lysozyme.ipynb'](toluene_in_T4_lysozyme.ipynb) - toluene binding to T4 lysozyme L99A

--- a/examples/using_smirnoff_with_amber_protein_forcefield/README.md
+++ b/examples/using_smirnoff_with_amber_protein_forcefield/README.md
@@ -2,5 +2,7 @@
 
 These examples illustrate how the [ParmEd](http://parmed.github.io/ParmEd/html/index.html) utility can be used to merge a small molecule parameterized by SMIRNOFF with a traditionally parameterized protein (or other biopolymer) to create a fully parameterized protein-ligand system.
 
-* ['BRD4_inhibitor_benchmark.ipynb']('BRD4_inhibitor_benchmark.ipynb') - BRD4:inhibitor from the [free energy benchmark systems living review](https://www.annualreviews.org/doi/abs/10.1146/annurev-biophys-070816-033654)
-* ['toluene_in_T4_lysozyme.ipynb'](toluene_in_T4_lysozyme.ipynb) - toluene binding to T4 lysozyme L99A
+* [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/protein-ligand-examples?filepath=examples%2Fusing_smirnoff_with_amber_protein_forcefield%2FBRD4_inhibitor_benchmark.ipynb)
+ ['BRD4_inhibitor_benchmark.ipynb']('BRD4_inhibitor_benchmark.ipynb') - BRD4:inhibitor from the [free energy benchmark systems living review](https://www.annualreviews.org/doi/abs/10.1146/annurev-biophys-070816-033654)
+* [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openforcefield/protein-ligand-examples?filepath=examples%2Ftoluene_in_T4_lysozyme.ipynb)
+ ['toluene_in_T4_lysozyme.ipynb'](toluene_in_T4_lysozyme.ipynb) - toluene binding to T4 lysozyme L99A


### PR DESCRIPTION
This PR adds another Jupyter notebook that illustrates combining a SMIRNOFF-parameterized BRD4 inhibitor with BRD4 from the [living review of binding free energy test systems](https://www.annualreviews.org/doi/abs/10.1146/annurev-biophys-070816-033654) [GitHub repo](https://github.com/MobleyLab/benchmarksets/tree/master/input_files/BRD4).