### PR TITLE
Fix `!1` typo in smirnoff99Frosst

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -7,8 +7,19 @@ Releases follow the ``major.minor.micro`` scheme recommended by `PEP440 <https:/
 * ``minor`` increments add features but do not break API compatibility
 * ``micro`` increments represent bugfix releases or improvements in documentation
 
-0.2.0
------
+0.2.1 - Bugfix release
+----------------------
+
+This release features various documentation fixes, minor bugfixes, and code cleanup.
+
+Bugfixes
+""""""""
+* [(PR #268)](https://github.com/openforcefield/openforcefield/pull/268): Fix "!..." typo in smirnoff99Frosst [(issue #247)](https://github.com/openforcefield/openforcefield/issues/247)
+* [(PR #267)](https://github.com/openforcefield/openforcefield/pull/267): Add neglected `<ToolkitAM1BCC>` to the SMIRNOFF 0.2 spec
+* [(PR #244)](https://github.com/openforcefield/openforcefield/pull/244): Improvements and typo fixes for BRD4:inhibitor benchmark
+
+0.2.0 - Initial RDKit support
+-----------------------------
 
 This version of the toolkit introduces many new features on the way to a 1.0.0 release.
 
@@ -24,8 +35,8 @@ New features
 * API improvements to more closely follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ guidelines
 * Improved documentation and examples
 
-0.1.0
------
+0.1.0 - Early preview release
+-----------------------------
 
 This is an early preview release of the toolkit that matches the functionality described in the preprint describing the SMIRNOFF v0.1 force field format: `[DOI] <https://doi.org/10.1101/286542>`_.
 

--- a/openforcefield/data/forcefield/smirnoff99Frosst.offxml
+++ b/openforcefield/data/forcefield/smirnoff99Frosst.offxml
@@ -3,7 +3,7 @@
 <SMIRNOFF version="0.2" aromaticity_model="OEAroModel_MDL">
 
   <!-- SMIRNOFF (SMIRKS Native Open Force Field) template file -->
-  <Date>2019-02-14</Date>
+  <Date>2019-04-11</Date>
   <Author>C. I. Bayly, OpenEye/UC Irvine; C. C. Bannan, UC Irvine; D. L. Mobley, UC Irvine</Author>
   <!-- This file is meant for processing via openforcefield.typing.engines.smirnoff -->
   <!-- WARNING: AMBER functional forms drop the factor of 2 in the bond energy term, so cross-comparing this file with a corresponding .frcmod file, it will appear that the values here are twice as large as they should be. -->
@@ -193,7 +193,7 @@
     <Proper smirks="[*:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" id="t53" idivf1="1" k1="1.000" periodicity1="3" phase1="0.0"/>
     <Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" id="t54" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" id="t55" idivf1="1" k1="2.700" periodicity1="1" phase1="0.0"/>
-    <Proper smirks="[!1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" id="t56" idivf1="1" k1="0.156" periodicity1="3" phase1="0.0"/>
+    <Proper smirks="[!#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" id="t56" idivf1="1" k1="0.156" periodicity1="3" phase1="0.0"/>
     <Proper smirks="[!#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" id="t57" idivf1="1" k1="1.000" periodicity1="3" phase1="0.0"/>
     <Proper smirks="[*:1]-[#7X4:2]-[#6X3:3]~[*:4]" id="t58" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[*:1]-[#6X4:2]-[#7X3$(*~[#6X3,#6X2]):3]~[*:4]" id="t59" idivf1="1" k1="0.000" periodicity1="2" phase1="0.0" phase2="0.0" k2="0.000" periodicity2="3" idivf2="1"/>

--- a/utilities/convert_frosst/smirnoff99Frosst.offxml
+++ b/utilities/convert_frosst/smirnoff99Frosst.offxml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='ASCII'?>
 <SMIRNOFF version="0.1" aromaticity_model="OEAroModel_MDL">
   <!-- SMIRNOFF (SMIRKS Native Open Force Field) template file -->
-  <Date>Date: Feb. 14, 2019</Date>
+  <Date>Date: April 11, 2019</Date>
   <Author>C. I. Bayly, OpenEye/UC Irvine; C. C. Bannan, UC Irvine; D. L. Mobley, UC Irvine</Author>
   <!-- This file is meant for processing via openforcefield.typing.engines.smirnoff -->
   <!-- WARNING: AMBER functional forms drop the factor of 2 in the bond energy term, so cross-comparing this file with a corresponding .frcmod file, it will appear that the values here are twice as large as they should be. -->
@@ -195,7 +195,7 @@
     <Proper smirks="[*:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" id="t53" idivf1="1" k1="1.000" periodicity1="3" phase1="0.0"/>
     <Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" id="t54" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" id="t55" idivf1="1" k1="2.700" periodicity1="1" phase1="0.0"/>
-    <Proper smirks="[!1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" id="t56" idivf1="1" k1="0.156" periodicity1="3" phase1="0.0"/>
+    <Proper smirks="[!#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" id="t56" idivf1="1" k1="0.156" periodicity1="3" phase1="0.0"/>
     <Proper smirks="[!#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" id="t57" idivf1="1" k1="1.000" periodicity1="3" phase1="0.0"/>
     <Proper smirks="[*:1]-[#7X4:2]-[#6X3:3]~[*:4]" id="t58" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[*:1]-[#6X4:2]-[#7X3$(*~[#6X3,#6X2]):3]~[*:4]" id="t59" idivf1="1" k1="0.000" periodicity1="2" phase1="0.0" phase2="0.0" k2="0.000" periodicity2="3" idivf2="1"/>

--- a/utilities/convert_frosst/smirnoffishFrcmod.parm99Frosst.txt
+++ b/utilities/convert_frosst/smirnoffishFrcmod.parm99Frosst.txt
@@ -14,7 +14,8 @@ DATE
 # Date: Feb. 27, 2018
 # Date: Nov. 7, 2018
 # Date: Dec. 12, 2018
-Date: Feb. 14, 2019
+# Date: Feb. 14, 2019
+Date: April 11, 2019
 
 # Author: please make sure all authors are on one line, only last line will be used
 AUTHOR
@@ -362,7 +363,7 @@ DIHE
 [*:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]         1  1.000    0.0     3  Frosst CT-N3-CJ-CJ  from CT-CT-CJ-CJ
 [#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]        1  0.000    0.0     1   Frosst generic
 [#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]   1  2.700    0.0     1  Frosst H_-N3-CJ-CJ  from CJ-CJ-CJ-HC
-[!1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]        1  0.156    0.0     3  Frosst CT-N3-CJ-CT  N3-CT-CJ-CJ
+[!#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]        1  0.156    0.0     3  Frosst CT-N3-CJ-CT  N3-CT-CJ-CJ
 [!#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]  1  1.000    0.0     3  Frosst SO-N3-CJ-CJ  from S-CT-CJ-CJ
 #
 # conj trivalent Nsp3-Csp2


### PR DESCRIPTION
As discussed in issue #247 I fixed `!1` to `!#1` in parameter `t56`. 
In doing this I followed the same procedure I usually would, I changed the relevant files in the `utilities/convert_frosst/` folder for the posterity of the forcefield and then I changed `openforcefield/data/forcefield/smirnoff99frosst.offxml`. 

In this process I noticed that the `offxml` file in the `convert_frosst` folder and the one in the smirnoff99Frosst repo have smirnoff spec version 0.1.0 in the file where the one in the data/forcefield/ folder has spec 0.2.0.