### PR TITLE
Fix readthedocs build error

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,7 +9,7 @@ dependencies:
     - nbsphinx
     - sphinx_bootstrap_theme
     - m2r >=0.2.1
-    - testpath =0.3.1
+    - testpath ==0.3.1
     # conda build dependencies
     - python
     - setuptools

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,7 +11,7 @@ dependencies:
     - m2r >=0.2.1
     - testpath =0.3.1
     # conda build dependencies
-    - python ==3.6
+    - python
     - setuptools
     - numpy
     - openmm
@@ -26,4 +26,4 @@ dependencies:
     - msgpack-python
     - xmltodict
     - pyyaml
-    - cairo ==1.16
+    - cairo >=1.16


### PR DESCRIPTION
Debugging a readthedocs build error:
```
Solving environment: ...working... failed

UnsatisfiableError: The following specifications were found to be in conflict:
  - cairo==1.16
  - python==3.6
  - rdkit
Use "conda info <package>" to see the dependencies for each package.
```