### PR TITLE
API changes for ForceField serialization

### DIFF
--- a/examples/forcefield_modification/ManipulateParameters.ipynb
+++ b/examples/forcefield_modification/ManipulateParameters.ipynb
@@ -189,7 +189,7 @@
    "outputs": [],
    "source": [
     "smirks = '[*:1]-[#8:2]-[*:3]' # SMIRKS for the parameter to retrieve\n",
-    "parameter = ff.get_handler('Angles').parameters[smirks]"
+    "parameter = ff.get_parameter_handler('Angles').parameters[smirks]"
    ]
   },
   {
@@ -282,7 +282,7 @@
     "# Create a new ForceField containing the smirnoff99Frosst parameter set:\n",
     "forcefield = ForceField('smirnoff99Frosst.offxml')\n",
     "# Inspect the long-range van der Waals method:\n",
-    "vdw_handler = forcefield.get_handler('vdW')\n",
+    "vdw_handler = forcefield.get_parameter_handler('vdW')\n",
     "print(f\"The vdW method is currently set to: {vdw_handler.method}\")"
    ]
   },
@@ -422,7 +422,7 @@
     }
    ],
    "source": [
-    "for vdw_param in forcefield.get_handler('vdW').parameters[0:3]:\n",
+    "for vdw_param in forcefield.get_parameter_handler('vdW').parameters[0:3]:\n",
     "    print(vdw_param)"
    ]
   },

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -153,8 +153,6 @@ xml_ff_w_cosmetic_elements = '''<?xml version='1.0' encoding='ASCII'?>
 '''
 
 
-
-
 #======================================================================
 # TEST UTILITY FUNCTIONS
 #======================================================================
@@ -423,8 +421,7 @@ class TestForceField():
         assert 'cosmetic_element="why not?"' not in string_3
         assert 'parameterize_eval="blah=blah2"' not in string_3
 
-    @pytest.mark.parametrize('filename_extension', ['xml', 'XML', '.xml', '.XML',
-                                                    'offxml', 'OFFXML', '.offxml', '.OFFXML'])
+    @pytest.mark.parametrize('filename_extension', ['xml', 'XML', 'offxml', 'OFFXML'])
     @pytest.mark.parametrize('specified_format', [None, 'xml', 'XML', '.xml', '.XML',
                                                   'offxml', 'OFFXML', '.offxml', '.OFFXML'])
     def test_xml_file_roundtrip(self, filename_extension, specified_format):
@@ -441,8 +438,7 @@ class TestForceField():
         assert open(iofile1.name).read() == open(iofile2.name).read()
 
 
-    @pytest.mark.parametrize('filename_extension', ['xml', 'XML', '.xml', '.XML',
-                                                    'offxml', 'OFFXML', '.offxml', '.OFFXML'])
+    @pytest.mark.parametrize('filename_extension', ['xml', 'XML', 'offxml', 'OFFXML'])
     @pytest.mark.parametrize('specified_format', [None, 'xml', 'XML', '.xml', '.XML',
                                                   'offxml', 'OFFXML', '.offxml', '.OFFXML'])
     def test_xml_file_roundtrip_keep_cosmetic(self, filename_extension, specified_format):
@@ -490,7 +486,7 @@ class TestForceField():
     def test_load_two_sources(self):
         """Test loading data from two SMIRNOFF data sources"""
         ff = ForceField(simple_xml_ff, xml_ff_w_cosmetic_elements, permit_cosmetic_attributes=True)
-        assert len(ff.get_handler('Bonds').parameters) == 4
+        assert len(ff.get_parameter_handler('Bonds').parameters) == 4
 
     def test_load_two_sources_incompatible_tags(self):
         """Test loading data from two SMIRNOFF data sources which have incompatible physics"""
@@ -537,12 +533,8 @@ class TestForceField():
         molecules = []
         molecules.append(Molecule.from_smiles('CCO'))
         molecules.append(Molecule.from_smiles('C1CCCCC1'))
-        # molecules = [Molecule.from_file(get_data_filename(name)) for name in ('molecules/ethanol.mol2',
-        #                                                                      'molecules/cyclohexane.mol2')]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         topology.box_vectors = None
-        #forcefield.get_handler("Electrostatics", {})._method = "Coulomb"
-        #forcefield.get_handler("vdW", {})._method = "cutoff"
 
         omm_system = forcefield.create_openmm_system(topology)
 
@@ -775,8 +767,8 @@ class TestForceField():
 
         molecules = [create_ethanol()]
         forcefield = ForceField('smirnoff99Frosst.offxml')
-        forcefield.get_handler('vdW', {})._method = vdw_method
-        forcefield.get_handler('Electrostatics', {})._method = electrostatics_method
+        forcefield.get_parameter_handler('vdW', {})._method = vdw_method
+        forcefield.get_parameter_handler('Electrostatics', {})._method = electrostatics_method
 
         pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -397,13 +397,11 @@ class TestForceField():
         with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg {'parameters': 'k, length'} passed") as excinfo:
             forcefield = ForceField(xml_ff_w_cosmetic_elements)
 
-        # Create a forcefield from XML successfully
+        # Create a forcefield from XML successfully, by explicitly permitting cosmetic attributes
         forcefield_1 = ForceField(xml_ff_w_cosmetic_elements, permit_cosmetic_attributes=True)
 
         # Convert the forcefield back to XML
         string_1 = forcefield_1.to_string('XML', discard_cosmetic_attributes=False)
-
-        # Ensure that the new XML string has cosmetic attributes in it
 
         # Ensure that the new XML string has cosmetic attributes in it
         assert 'cosmetic_element="why not?"' in string_1
@@ -411,7 +409,7 @@ class TestForceField():
         with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg {'parameters': 'k, length'} passed") as excinfo:
             forcefield = ForceField(string_1, permit_cosmetic_attributes=False)
 
-        # Complete the round trip from forcefield_1 successfully
+        # Complete the forcefield_1 --> string --> forcefield_2 roundtrip
         forcefield_2 = ForceField(string_1, permit_cosmetic_attributes=True)
 
         # Ensure that the forcefield remains the same after the roundtrip

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -26,7 +26,7 @@ from openforcefield.utils.toolkits import OpenEyeToolkitWrapper, RDKitToolkitWra
 from openforcefield.utils import get_data_filename
 
 from openforcefield.topology import Molecule, Topology
-from openforcefield.typing.engines.smirnoff import ForceField, IncompatibleParameterError
+from openforcefield.typing.engines.smirnoff import ForceField, IncompatibleParameterError, SMIRNOFFSpecError
 
 
 #======================================================================
@@ -393,9 +393,11 @@ class TestForceField():
         """
         Test roundtripping a forcefield to XML with and without retaining cosmetic elements
         """
-        forcefield_1 = ForceField(xml_ff_w_cosmetic_elements, discard_cosmetic_attributes=False)
+        forcefield_1 = ForceField(xml_ff_w_cosmetic_elements, permit_cosmetic_attributes=True)
         string_1 = forcefield_1.to_string('XML', discard_cosmetic_attributes=False)
-        forcefield_2 = ForceField(string_1, discard_cosmetic_attributes=False)
+        with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg {'parameters': 'k, length'} passed") as excinfo:
+            forcefield_2 = ForceField(string_1, permit_cosmetic_attributes=False)
+        forcefield_2 = ForceField(string_1, permit_cosmetic_attributes=True)
         string_2 = forcefield_2.to_string('XML', discard_cosmetic_attributes=False)
         assert string_1 == string_2
 

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -27,6 +27,7 @@ from openforcefield.utils.toolkits import OpenEyeToolkitWrapper, RDKitToolkitWra
 from openforcefield.utils import get_data_filename
 from openforcefield.topology import Molecule, Topology
 from openforcefield.typing.engines.smirnoff import ForceField, IncompatibleParameterError, SMIRNOFFSpecError
+from openforcefield.typing.engines.smirnoff import XMLParameterIOHandler
 
 
 #======================================================================
@@ -423,7 +424,8 @@ class TestForceField():
 
     @pytest.mark.parametrize('filename_extension', ['xml', 'XML', 'offxml', 'OFFXML'])
     @pytest.mark.parametrize('specified_format', [None, 'xml', 'XML', '.xml', '.XML',
-                                                  'offxml', 'OFFXML', '.offxml', '.OFFXML'])
+                                                  'offxml', 'OFFXML', '.offxml', '.OFFXML',
+                                                  XMLParameterIOHandler()])
     def test_xml_file_roundtrip(self, filename_extension, specified_format):
         """
         Test roundtripping a ForceField to and from an XML file
@@ -432,15 +434,16 @@ class TestForceField():
         iofile1 = NamedTemporaryFile(suffix='.' + filename_extension)
         iofile2 = NamedTemporaryFile(suffix='.' + filename_extension)
         forcefield_1 = ForceField(simple_xml_ff)
-        forcefield_1.to_file(iofile1.name, format=specified_format)
+        forcefield_1.to_file(iofile1.name, io_format=specified_format)
         forcefield_2 = ForceField(iofile1.name)
-        forcefield_2.to_file(iofile2.name, format=specified_format)
+        forcefield_2.to_file(iofile2.name, io_format=specified_format)
         assert open(iofile1.name).read() == open(iofile2.name).read()
 
 
     @pytest.mark.parametrize('filename_extension', ['xml', 'XML', 'offxml', 'OFFXML'])
     @pytest.mark.parametrize('specified_format', [None, 'xml', 'XML', '.xml', '.XML',
-                                                  'offxml', 'OFFXML', '.offxml', '.OFFXML'])
+                                                  'offxml', 'OFFXML', '.offxml', '.OFFXML',
+                                                  XMLParameterIOHandler()])
     def test_xml_file_roundtrip_keep_cosmetic(self, filename_extension, specified_format):
         """
         Test roundtripping a forcefield to an XML file with and without retaining cosmetic elements
@@ -458,7 +461,7 @@ class TestForceField():
         forcefield_1 = ForceField(xml_ff_w_cosmetic_elements, permit_cosmetic_attributes=True)
 
         # Convert the forcefield back to XML, keeping cosmetic attributes
-        forcefield_1.to_file(iofile1.name, discard_cosmetic_attributes=False, format=specified_format)
+        forcefield_1.to_file(iofile1.name, discard_cosmetic_attributes=False, io_format=specified_format)
 
         # Ensure that the new XML string has cosmetic attributes in it
         assert 'cosmetic_element="why not?"' in open(iofile1.name).read()
@@ -470,11 +473,11 @@ class TestForceField():
         forcefield_2 = ForceField(iofile1.name, permit_cosmetic_attributes=True)
 
         # Ensure that the forcefield remains the same after the roundtrip
-        forcefield_2.to_file(iofile2.name, discard_cosmetic_attributes=False, format=specified_format)
+        forcefield_2.to_file(iofile2.name, discard_cosmetic_attributes=False, io_format=specified_format)
         assert open(iofile1.name).read() == open(iofile2.name).read()
 
         # Discard the cosmetic attributes and ensure that the string is different
-        forcefield_2.to_file(iofile3.name, discard_cosmetic_attributes=True, format=specified_format)
+        forcefield_2.to_file(iofile3.name, discard_cosmetic_attributes=True, io_format=specified_format)
         assert open(iofile1.name).read() != open(iofile3.name).read()
 
         # Ensure that the new XML string does NOT have cosmetic attributes in it

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -387,9 +387,9 @@ class TestForceField():
 
         """
         forcefield_1 = ForceField(simple_xml_ff)
-        string_1 = forcefield_1._parameter_io_handlers['XML'].to_string(forcefield_1.to_smirnoff_data())
+        string_1 = forcefield_1._parameter_io_handlers['XML'].to_string(forcefield_1._to_smirnoff_data())
         forcefield_2 = ForceField(string_1)
-        string_2 = forcefield_2._parameter_io_handlers['XML'].to_string(forcefield_2.to_smirnoff_data())
+        string_2 = forcefield_2._parameter_io_handlers['XML'].to_string(forcefield_2._to_smirnoff_data())
         assert string_1 == string_2
 
     @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -487,6 +487,18 @@ class TestForceField():
 
 
 
+    def test_load_two_sources(self):
+        """Test loading data from two SMIRNOFF data sources"""
+        ff = ForceField(simple_xml_ff, xml_ff_w_cosmetic_elements, permit_cosmetic_attributes=True)
+        assert len(ff.get_handler('Bonds').parameters) == 4
+
+    def test_load_two_sources_incompatible_tags(self):
+        """Test loading data from two SMIRNOFF data sources which have incompatible physics"""
+        # Make an XML forcefield with a modifiedvdW 1-4 scaling factor
+        nonstandard_xml_ff = xml_ff_w_comments.replace('scale14="0.5"', 'scale14="1.0"')
+        with pytest.raises(IncompatibleParameterError, match="handler value: 0.5, incompatible value: 1.0") as excinfo:
+            ff = ForceField(simple_xml_ff, nonstandard_xml_ff)
+
     @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
     def test_parameterize_ethanol(self, toolkit_registry, registry_description):
         from simtk.openmm import app
@@ -728,8 +740,6 @@ class TestForceField():
         for particle_index in range(topology.n_topology_particles):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q != (0. * unit.elementary_charge)
-        #from simtk.openmm import XmlSerializer
-        #print(XmlSerializer.serialize(omm_system))
 
 
 

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -131,7 +131,7 @@ xml_ff_w_cosmetic_elements = '''<?xml version='1.0' encoding='ASCII'?>
     <Bond smirks="[#6X4:1]-[#6X3:2]" id="b2" k="634.0" length="1.51"/>
   </Bonds>
   <!-- WARNING: AMBER functional forms drop the factor of 2 in the angle energy term, so cross-comparing this file with a corresponding .frcmod file, it will appear that the values here are twice as large as they should be. -->
-  <Angles angle_unit="degrees" k_unit="kilocalories_per_mole/radian**2">
+  <Angles angle_unit="degrees" k_unit="kilocalories_per_mole/radian**2" cosmetic_element="why not?">
     <Angle smirks="[*:1]~[#6X4:2]-[*:3]" angle="109.5" id="a1" k="100.0"/>
     <Angle smirks="[#1:1]-[#6X4:2]-[#1:3]" angle="109.5" id="a2" k="70.0"/>
   </Angles>
@@ -151,6 +151,8 @@ xml_ff_w_cosmetic_elements = '''<?xml version='1.0' encoding='ASCII'?>
   <ToolkitAM1BCC/>
 </SMIRNOFF>
 '''
+
+
 
 
 #======================================================================
@@ -378,19 +380,32 @@ class TestForceField():
 
     def test_xml_string_roundtrip(self):
         """
-        Test
-        1) loading a forcefield from string
-        2) writing it to an XML string ("string_1")
-        3) Initialize "forcefield_2" using "string_1"
-        4) serialize "forcefield_2" to "string_2"
-        5) Check that "string_1" is equal to "string_2"
-
+        Test writing a ForceField to XML
         """
         forcefield_1 = ForceField(simple_xml_ff)
-        string_1 = forcefield_1._parameter_io_handlers['XML'].to_string(forcefield_1._to_smirnoff_data())
+        string_1 = forcefield_1.to_string('XML')
         forcefield_2 = ForceField(string_1)
-        string_2 = forcefield_2._parameter_io_handlers['XML'].to_string(forcefield_2._to_smirnoff_data())
+        string_2 = forcefield_2.to_string('XML')
         assert string_1 == string_2
+
+
+    def test_xml_string_roundtrip_keep_cosmetic(self):
+        """
+        Test roundtripping a forcefield to XML with and without retaining cosmetic elements
+        """
+        forcefield_1 = ForceField(xml_ff_w_cosmetic_elements, discard_cosmetic_attributes=False)
+        string_1 = forcefield_1.to_string('XML', discard_cosmetic_attributes=False)
+        forcefield_2 = ForceField(string_1, discard_cosmetic_attributes=False)
+        string_2 = forcefield_2.to_string('XML', discard_cosmetic_attributes=False)
+        assert string_1 == string_2
+
+        # Discard the cosmetic attributes and ensure that the string is different
+        string_3 = forcefield_2.to_string('XML', discard_cosmetic_attributes=True)
+        assert string_1 != string_3
+
+
+
+
 
     @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
     def test_parameterize_ethanol(self, toolkit_registry, registry_description):

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -332,7 +332,7 @@ class TestParameterType:
                                   length=1.02*unit.angstrom,
                                   k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
                                   pilot='alice',
-                                  discard_cosmetic_attributes=False
+                                  permit_cosmetic_attributes=True
                                   )
         param_dict= p1.to_dict(discard_cosmetic_attributes=False)
         assert ('pilot', 'alice') in param_dict.items()
@@ -347,7 +347,7 @@ class TestParameterType:
                                   length=1.02*unit.angstrom,
                                   k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
                                   pilot='alice',
-                                  discard_cosmetic_attributes=False
+                                  permit_cosmetic_attributes=True
                                   )
         param_dict = p1.to_dict(discard_cosmetic_attributes=True)
         assert ('pilot', 'alice') not in param_dict.items()
@@ -358,14 +358,13 @@ class TestParameterType:
         """
         from simtk import unit
 
-        #with pytest.raises(SMIRNOFFSpecError, match="Incompatible kwarg {'pilot': 'alice'}") as context:
-        p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
-                                  length=1.02*unit.angstrom,
-                                  k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
-                                  pilot='alice',
-                                  discard_cosmetic_attributes=True
-                                  )
-        assert not(hasattr(p1, 'pilot'))
+        with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg {'pilot': 'alice'}") as context:
+            p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
+                                      length=1.02*unit.angstrom,
+                                      k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+                                      pilot='alice',
+                                      permit_cosmetic_attributes=False
+                                      )
 
     def test_single_term_proper_torsion(self):
         """
@@ -433,7 +432,7 @@ class TestParameterType:
         """
         from simtk import unit
 
-        with pytest.raises(SMIRNOFFSpecError, match="Incompatible kwarg {'phase3': ") as context:
+        with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg {'phase3': ") as context:
             p1 = ProperTorsionHandler.ProperTorsionType(smirks='[*:1]-[*:2]-[*:3]-[*:4]',
                                                         phase1=30 * unit.degree,
                                                         periodicity1=2,

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -332,9 +332,9 @@ class TestParameterType:
                                   length=1.02*unit.angstrom,
                                   k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
                                   pilot='alice',
-                                  permit_cosmetic_attributes=True
+                                  discard_cosmetic_attributes=False
                                   )
-        param_dict= p1.to_dict(return_cosmetic_attributes=True)
+        param_dict= p1.to_dict(discard_cosmetic_attributes=False)
         assert ('pilot', 'alice') in param_dict.items()
 
     def test_read_but_dont_write_cosmetic_parameter_attribute(self):
@@ -347,9 +347,9 @@ class TestParameterType:
                                   length=1.02*unit.angstrom,
                                   k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
                                   pilot='alice',
-                                  permit_cosmetic_attributes=True
+                                  discard_cosmetic_attributes=False
                                   )
-        param_dict = p1.to_dict(return_cosmetic_attributes=False)
+        param_dict = p1.to_dict(discard_cosmetic_attributes=True)
         assert ('pilot', 'alice') not in param_dict.items()
 
     def test_error_cosmetic_parameter_attribute(self):
@@ -363,7 +363,7 @@ class TestParameterType:
                                       length=1.02*unit.angstrom,
                                       k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
                                       pilot='alice',
-                                      permit_cosmetic_attributes=False
+                                      discard_cosmetic_attributes=True
                                       )
 
     def test_single_term_proper_torsion(self):
@@ -464,6 +464,10 @@ class TestParameterType:
 # TODO: test_nonbonded_settings (ensure that choices in Electrostatics and vdW tags resolve
 #                                to correct openmm.NonbondedForce subtypes, that setting different cutoffs raises
 #                                exceptions, etc)
+
+# TODO: test_extend_parameter_section
+
+
 # TODO: test_(all attributes of all ParameterTypes)
 # TODO: test_add_parameter_fractional_bondorder
 # TODO: test_get_indexed_attrib

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -464,10 +464,6 @@ class TestParameterType:
 # TODO: test_nonbonded_settings (ensure that choices in Electrostatics and vdW tags resolve
 #                                to correct openmm.NonbondedForce subtypes, that setting different cutoffs raises
 #                                exceptions, etc)
-
-# TODO: test_extend_parameter_section
-
-
 # TODO: test_(all attributes of all ParameterTypes)
 # TODO: test_add_parameter_fractional_bondorder
 # TODO: test_get_indexed_attrib

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -358,13 +358,14 @@ class TestParameterType:
         """
         from simtk import unit
 
-        with pytest.raises(SMIRNOFFSpecError, match="Incompatible kwarg {'pilot': 'alice'}") as context:
-            p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
-                                      length=1.02*unit.angstrom,
-                                      k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
-                                      pilot='alice',
-                                      discard_cosmetic_attributes=True
-                                      )
+        #with pytest.raises(SMIRNOFFSpecError, match="Incompatible kwarg {'pilot': 'alice'}") as context:
+        p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
+                                  length=1.02*unit.angstrom,
+                                  k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+                                  pilot='alice',
+                                  discard_cosmetic_attributes=True
+                                  )
+        assert not(hasattr(p1, 'pilot'))
 
     def test_single_term_proper_torsion(self):
         """

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -590,7 +590,7 @@ class ForceField:
         # Uppercase the format string to avoid case mismatches
         io_format = io_format.upper()
 
-        # Remove "." (format strings do not include it
+        # Remove "." (ParameterIOHandler tags do not include it)
         io_format = io_format.strip('.')
 
         # Find or initialize ParameterIOHandler for this format

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -384,7 +384,7 @@ class ForceField:
 
         Parameters
         ----------
-        parameter_handler : A ParameterHandler-derived object
+        parameter_handler : A ParameterHandler object
             The ParameterHandler to register. The TAGNAME attribute of this object will be used as the key for
             registration.
 
@@ -407,7 +407,7 @@ class ForceField:
 
         Parameters
         ----------
-        parameter_io_handler :  A ParameterIOHandler-derived object
+        parameter_io_handler :  A ParameterIOHandler object
             The ParameterIOHandler to register. The FORMAT attribute of this object will be used
             to associate it to a file format/suffix.
 

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -549,7 +549,9 @@ class ForceField:
         if tagname in self._parameter_handlers:
             # If a handler of this class already exists, ensure that the two handlers encode compatible science
             old_handler = self._parameter_handlers[tagname]
-            old_handler.check_handler_compatibility(new_handler)
+            # If no handler kwargs were provided, skip the compatibility check
+            if handler_kwargs != {}:
+                old_handler.check_handler_compatibility(new_handler)
             return_handler = old_handler
         elif tagname in self._parameter_handler_classes:
             # Otherwise, register this handler in the forcefield

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -620,10 +620,10 @@ class ForceField:
         # TODO: If a non-first source fails here, the forcefield might be partially modified
         for source in sources:
             smirnoff_data = self.parse_smirnoff_from_source(source)
-            self.load_smirnoff_data(smirnoff_data)
+            self._load_smirnoff_data(smirnoff_data)
 
 
-    def to_smirnoff_data(self):
+    def _to_smirnoff_data(self):
         """
         Convert this ForceField and all related ParameterHandlers to an OrderedDict representing a SMIRNOFF
         data object.
@@ -650,7 +650,7 @@ class ForceField:
         return smirnoff_dict
 
     # TODO: Should we call this "from_dict"?
-    def load_smirnoff_data(self, smirnoff_data):
+    def _load_smirnoff_data(self, smirnoff_data):
         """
         Add parameters from a SMIRNOFF-format data structure to this ForceField.
 

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -191,7 +191,7 @@ class ForceField:
                  parameter_handler_classes=None,
                  parameter_io_handler_classes=None,
                  disable_version_check=False,
-                 discard_cosmetic_attributes=True):
+                 permit_cosmetic_attributes=False):
         """Create a new :class:`ForceField` object from one or more SMIRNOFF parameter definition files.
 
         Parameters
@@ -213,8 +213,8 @@ class ForceField:
         disable_version_check : bool, optional, default=False
             If True, will disable checks against the current highest supported forcefield version.
             This option is primarily intended for forcefield development.
-        discard_cosmetic_attributes : bool, optional. Default = True
-            Whether to discard non-spec kwargs from data sources.
+        permit_cosmetic_attributes : bool, optional. Default = False
+            Whether to retain non-spec kwargs from data sources.
 
         Examples
         --------
@@ -255,7 +255,7 @@ class ForceField:
             parameter_io_handler_classes)
 
         # Parse all sources containing SMIRNOFF parameter definitions
-        self.parse_sources(sources, discard_cosmetic_attributes=discard_cosmetic_attributes)
+        self.parse_sources(sources, permit_cosmetic_attributes=permit_cosmetic_attributes)
 
     def _initialize(self):
         """
@@ -376,7 +376,7 @@ class ForceField:
                     serialization_format] = parameter_io_handler_class
 
     def register_parameter_handler(self, parameter_handler_class,
-                                   parameter_handler_kwargs, discard_cosmetic_attributes=True):
+                                   parameter_handler_kwargs, permit_cosmetic_attributes=False):
         """
         Register a new ParameterHandler from a specified class, instantiating the ParameterHandler object and making it
         available for lookup in the ForceField. ParameterHandler-level attributes will be read from
@@ -390,8 +390,8 @@ class ForceField:
             The ParameterHandler to register
         parameter_handler_kwargs : dict:
             Hierarchical dict structured in compliance with the SMIRNOFF spec.
-        discard_cosmetic_attributes : bool, optional. Default = True
-            Whether to discard non-spec kwargs if a new ParameterHandler is initialized.
+        permit_cosmetic_attributes : bool, optional. Default = False
+            Whether to permit non-spec kwargs if a new ParameterHandler is initialized.
 
         Returns
         -------
@@ -407,7 +407,7 @@ class ForceField:
                     self._parameter_handlers[tagname]))
 
         new_handler = parameter_handler_class(**parameter_handler_kwargs,
-                                              discard_cosmetic_attributes=discard_cosmetic_attributes)
+                                              permit_cosmetic_attributes=permit_cosmetic_attributes)
 
 
         self._parameter_handlers[new_handler._TAGNAME] = new_handler
@@ -517,7 +517,7 @@ class ForceField:
             raise Exception(
                 msg)  # TODO: Should we raise a more specific exception here?
 
-    def get_handler(self, tagname, handler_kwargs=None, discard_cosmetic_attributes=True):
+    def get_handler(self, tagname, handler_kwargs=None, permit_cosmetic_attributes=False):
         """Retrieve the parameter handlers associated with the provided tagname.
 
         If the parameter handler has not yet been instantiated, it will be created and returned.
@@ -532,8 +532,8 @@ class ForceField:
         handler_kwargs : dict, optional. Default = None
             Dict to be passed to the handler for construction or checking compatibility. If None, will be assumed
             to represent handler defaults.
-        discard_cosmetic_attributes : bool, optional. Default = True
-            Whether to discard non-spec kwargs in smirnoff_data.
+        permit_cosmetic_attributes : bool, optional. Default = False
+            Whether to permit non-spec kwargs in smirnoff_data.
 
         Returns
         -------
@@ -556,7 +556,7 @@ class ForceField:
             new_ph_class = self._parameter_handler_classes[tagname]
             handler = self.register_parameter_handler(new_ph_class,
                                                       handler_kwargs,
-                                                      discard_cosmetic_attributes=discard_cosmetic_attributes)
+                                                      permit_cosmetic_attributes=permit_cosmetic_attributes)
 
         if handler is None:
             msg = "Cannot find a registered parameter handler for tag '{}'\n".format(
@@ -603,7 +603,7 @@ class ForceField:
         return io_handler
 
 
-    def parse_sources(self, sources, discard_cosmetic_attributes=True):
+    def parse_sources(self, sources, permit_cosmetic_attributes=True):
         """Parse a SMIRNOFF force field definition.
 
         Parameters
@@ -616,8 +616,8 @@ class ForceField:
             If multiple files are specified, any top-level tags that are repeated will be merged if they are compatible,
             with files appearing later in the sequence resulting in parameters that have higher precedence.
             Support for multiple files is primarily intended to allow solvent parameters to be specified by listing them last in the sequence.
-        discard_cosmetic_attributes : bool, optional. Default = True
-            Whether to discard non-spec kwargs present in the source.
+        permit_cosmetic_attributes : bool, optional. Default = False
+            Whether to permit non-spec kwargs present in the source.
         .. notes ::
 
            * New SMIRNOFF sections are handled independently, as if they were specified in the same file.
@@ -636,7 +636,7 @@ class ForceField:
         for source in sources:
             smirnoff_data = self.parse_smirnoff_from_source(source)
             self._load_smirnoff_data(smirnoff_data,
-                                     discard_cosmetic_attributes=discard_cosmetic_attributes)
+                                     permit_cosmetic_attributes=permit_cosmetic_attributes)
 
 
     def _to_smirnoff_data(self, discard_cosmetic_attributes=True):
@@ -669,7 +669,7 @@ class ForceField:
         return smirnoff_dict
 
     # TODO: Should we call this "from_dict"?
-    def _load_smirnoff_data(self, smirnoff_data, discard_cosmetic_attributes=True):
+    def _load_smirnoff_data(self, smirnoff_data, permit_cosmetic_attributes=False):
         """
         Add parameters from a SMIRNOFF-format data structure to this ForceField.
 
@@ -677,8 +677,8 @@ class ForceField:
         ----------
         smirnoff_data : OrderedDict
             A representation of a SMIRNOFF-format data structure. Begins at top-level 'SMIRNOFF' key.
-        discard_cosmetic_attributes : bool, optional. Default = True
-            Whether to discard non-spec kwargs in smirnoff_data.
+        permit_cosmetic_attributes : bool, optional. Default = False
+            Whether to permit non-spec kwargs in smirnoff_data.
         """
 
         # Ensure that SMIRNOFF is a top-level key of the dict
@@ -725,9 +725,9 @@ class ForceField:
             # compatibility if a handler for this parameter name already exists
             handler = self.get_handler(parameter_name,
                                        section_dict,
-                                       discard_cosmetic_attributes=discard_cosmetic_attributes)
+                                       permit_cosmetic_attributes=permit_cosmetic_attributes)
             handler._add_parameters(section_dict,
-                                    discard_cosmetic_attributes=discard_cosmetic_attributes)
+                                    permit_cosmetic_attributes=permit_cosmetic_attributes)
 
 
 

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -407,7 +407,9 @@ class ForceField:
 
         Parameters
         ----------
-        parameter_io_handler :  ParameterIOHandler
+        parameter_io_handler :  A ParameterIOHandler-derived object
+            The ParameterIOHandler to register. The FORMAT attribute of this object will be used
+            to associate it to a file format/suffix.
 
         """
         io_format = parameter_io_handler._FORMAT
@@ -426,7 +428,8 @@ class ForceField:
     def _check_for_missing_valence_terms(name, topology, assigned_terms,
                                          topological_terms):
         """
-        Check to ensure there are no missing valence terms in the given topology, identifying potential gaps in parameter coverage.
+        Check to ensure there are no missing valence terms in the given topology, identifying potential gaps in
+        parameter coverage.
 
         .. warning :: This API is experimental and subject to change.
 
@@ -510,7 +513,7 @@ class ForceField:
 
         Parameters
         ----------
-        tagame : str
+        tagname : str
             The name of the parameter to be handled.
         handler_kwargs : dict, optional. Default = None
             Dict to be passed to the handler for construction or checking compatibility. If None, will be assumed
@@ -611,8 +614,8 @@ class ForceField:
             Support for multiple files is primarily intended to allow solvent parameters to be specified by listing them last in the sequence.
         permit_cosmetic_attributes : bool, optional. Default = False
             Whether to permit non-spec kwargs present in the source.
-        .. notes ::
 
+        .. notes ::
            * New SMIRNOFF sections are handled independently, as if they were specified in the same file.
            * If a SMIRNOFF section that has already been read appears again, its definitions are appended to the end of the previously-read
              definitions if the sections are configured with compatible attributes; otherwise, an ``IncompatibleTagException`` is raised.

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -789,7 +789,7 @@ class ForceField:
         raise IOError(msg)
 
 
-    def to_string(self, format='XML', discard_cosmetic_attributes=True):
+    def to_string(self, io_format='XML', discard_cosmetic_attributes=True):
         """
         Write this Forcefield and all its associated parameters to a string in a given format which
         complies with the SMIRNOFF spec.
@@ -797,7 +797,7 @@ class ForceField:
 
         Parameters
         ----------
-        format : str, optional. Default='XML'
+        io_format : str or ParameterIOHandler, optional. Default='XML'
             The serialization format to write to
         discard_cosmetic_attributes : bool, default=True
             Whether to discard any non-spec attributes stored in the ForceField.
@@ -808,13 +808,16 @@ class ForceField:
             The string representation of the serialized forcefield
         """
         # Resolve which IO handler to use
-        io_handler = self.get_parameter_io_handler(format)
+        if isinstance(io_format, ParameterIOHandler):
+            io_handler = io_format
+        else:
+            io_handler = self.get_parameter_io_handler(io_format)
 
         smirnoff_data = self._to_smirnoff_data(discard_cosmetic_attributes=discard_cosmetic_attributes)
         string_data = io_handler.to_string(smirnoff_data)
         return string_data
 
-    def to_file(self, filename, format=None, discard_cosmetic_attributes=True):
+    def to_file(self, filename, io_format=None, discard_cosmetic_attributes=True):
         """
         Write this Forcefield and all its associated parameters to a string in a given format which
         complies with the SMIRNOFF spec.
@@ -824,7 +827,7 @@ class ForceField:
         ----------
         filename : str
             The filename to write to
-        format : str
+        io_format : str or ParameterIOHandler, optional. Default=None
             The serialization format to write out. If None, will attempt to be inferred from the filename.
         discard_cosmetic_attributes : bool, default=True
             Whether to discard any non-spec attributes stored in the ForceField.
@@ -834,16 +837,21 @@ class ForceField:
         forcefield_string : str
             The string representation of the serialized forcefield
         """
-        if format is None:
-            basename, format = os.path.splitext(filename)
+
+        if io_format is None:
+            basename, io_format = os.path.splitext(filename)
 
 
-        # Handle the fact that .offxml is the same as .xml
-        if format.lower() == 'offxml' or format.lower() == '.offxml':
-            format = 'xml'
 
         # Resolve which IO handler to use
-        io_handler = self.get_parameter_io_handler(format)
+        if isinstance(io_format, ParameterIOHandler):
+            io_handler = io_format
+        else:
+            # Handle the fact that .offxml is the same as .xml
+            if io_format.lower() == 'offxml' or io_format.lower() == '.offxml':
+                io_format = 'xml'
+            io_handler = self.get_parameter_io_handler(io_format)
+
 
         # Write out the SMIRNOFF data to the IOHandler
         smirnoff_data = self._to_smirnoff_data(discard_cosmetic_attributes=discard_cosmetic_attributes)

--- a/openforcefield/typing/engines/smirnoff/io.py
+++ b/openforcefield/typing/engines/smirnoff/io.py
@@ -246,29 +246,29 @@ class XMLParameterIOHandler(ParameterIOHandler):
             raise ParseError(e)
 
     def to_file(self, filename, smirnoff_data):
-        """Write the current forcefield parameter set to a file, autodetecting the type from the extension.
+        """Write the current forcefield parameter set to a file.
 
         Parameters
         ----------
         filename : str
             The name of the file to be written.
-            The `.offxml` file extension must be present.
+            The `.offxml` or `.xml` file extension must be present.
         smirnoff_data : dict
             A dict structured in compliance with the SMIRNOFF data spec.
 
         """
         xml_string = self.to_string(smirnoff_data)
-        (basename, extension) = os.path.splitext(filename)
-        if extension == '.offxml':
-            with open(filename, 'wb') as of:
-                of.write(xml_string)
-        else:
-            msg = "Cannot export forcefield parameters to file '{}'\n".format(
-                filename)
-            msg += 'Export to extension {} not implemented yet.\n'.format(
-                extension)
-            msg += "Supported choices are: ['.offxml']"
-            raise NotImplementedError(msg)
+        #(basename, extension) = os.path.splitext(filename)
+        #if extension == '.offxml' or extension == '.xml':
+        with open(filename, 'w') as of:
+            of.write(xml_string)
+        # else:
+        #     msg = "Cannot export forcefield parameters to file '{}'\n".format(
+        #         filename)
+        #     msg += 'Export to extension {} not implemented yet.\n'.format(
+        #         extension)
+        #     msg += "Supported choices are: ['.offxml']"
+        #     raise NotImplementedError(msg)
 
     def to_string(self, smirnoff_data):
         """

--- a/openforcefield/typing/engines/smirnoff/io.py
+++ b/openforcefield/typing/engines/smirnoff/io.py
@@ -89,7 +89,6 @@ class ParameterIOHandler:
 
         """
         pass
-        #self._forcefield = forcefield
 
     def parse_file(self, filename):
         """
@@ -305,25 +304,4 @@ class XMLParameterIOHandler(ParameterIOHandler):
         prepend_all_keys(smirnoff_data['SMIRNOFF'])
         return xmltodict.unparse(smirnoff_data, pretty=True)
 
-    def to_xml(self, smirnoff_data):
-        """Render the forcefield parameter set to XML.
 
-        Returns
-        -------
-        smirnoff_data : dict
-            A dictionary structures in comliance with the SMIRNOFF data spec.
-        """
-        return self.to_string(smirnoff_data)
-
-    # # TODO: Do we need this? Should we use built-in dict-based serialization?
-    # def __getstate__(self):
-    #     """Serialize to XML.
-    #     """
-    #     return self.to_xml()
-    #
-    # # TODO: Do we need this? Should we use built-in dict-based serialization?
-    # def __setstate__(self, state):
-    #     """Deserialize from XML.
-    #     """
-    #     self._initialize()
-    #     self.parse_xml(state)

--- a/openforcefield/typing/engines/smirnoff/io.py
+++ b/openforcefield/typing/engines/smirnoff/io.py
@@ -312,8 +312,6 @@ class XMLParameterIOHandler(ParameterIOHandler):
                     prepend_all_keys(item)
 
         prepend_all_keys(smirnoff_data['SMIRNOFF'])
-        print(smirnoff_data)
-        print()
         return xmltodict.unparse(smirnoff_data, pretty=True)
 
     def to_xml(self, smirnoff_data):

--- a/openforcefield/typing/engines/smirnoff/io.py
+++ b/openforcefield/typing/engines/smirnoff/io.py
@@ -258,17 +258,8 @@ class XMLParameterIOHandler(ParameterIOHandler):
 
         """
         xml_string = self.to_string(smirnoff_data)
-        #(basename, extension) = os.path.splitext(filename)
-        #if extension == '.offxml' or extension == '.xml':
         with open(filename, 'w') as of:
             of.write(xml_string)
-        # else:
-        #     msg = "Cannot export forcefield parameters to file '{}'\n".format(
-        #         filename)
-        #     msg += 'Export to extension {} not implemented yet.\n'.format(
-        #         extension)
-        #     msg += "Supported choices are: ['.offxml']"
-        #     raise NotImplementedError(msg)
 
     def to_string(self, smirnoff_data):
         """

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -319,7 +319,7 @@ class ParameterType:
 
     # TODO: Can we provide some shared tools for returning settable/gettable attributes, and checking unit-bearing attributes?
 
-    def __init__(self, smirks=None, permit_cosmetic_attributes=True, **kwargs):
+    def __init__(self, smirks=None, permit_cosmetic_attributes=False, **kwargs):
         """
         Create a ParameterType
 

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -1101,8 +1101,7 @@ class BondHandler(ParameterHandler):
                                     other_handler):
         """
         Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
-        called if a second handler is attempted to be initialized for the same tag. If no value is given for a field, it
-        will be assumed to expect the ParameterHandler class default.
+        called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
         ----------
@@ -1225,8 +1224,7 @@ class AngleHandler(ParameterHandler):
                                     other_handler):
         """
         Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
-        called if a second handler is attempted to be initialized for the same tag. If no value is given for a field, it
-        will be assumed to expect the ParameterHandler class default.
+        called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
         ----------
@@ -1339,8 +1337,7 @@ class ProperTorsionHandler(ParameterHandler):
                                     other_handler):
         """
         Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
-        called if a second handler is attempted to be initialized for the same tag. If no value is given for a field, it
-        will be assumed to expect the ParameterHandler class default.
+        called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
         ----------
@@ -1454,8 +1451,7 @@ class ImproperTorsionHandler(ParameterHandler):
                                     other_handler):
         """
         Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
-        called if a second handler is attempted to be initialized for the same tag. If no value is given for a field, it
-        will be assumed to expect the ParameterHandler class default.
+        called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
         ----------
@@ -1701,7 +1697,7 @@ class vdWHandler(ParameterHandler):
     @property
     def switch_width(self):
         """The switching width used for long-range van der Waals interactions"""
-        return self.switch_width
+        return self._switch_width
 
     @switch_width.setter
     def switch_width(self, other):
@@ -1711,7 +1707,7 @@ class vdWHandler(ParameterHandler):
             raise IncompatibleParameterError(
                 f"Attempted to set vdW switch_width to {other}, which is not compatible with "
                 f"expected unit {unit_to_check}")
-        self.switch_width = other
+        self._switch_width = other
 
     def _validate_parameters(self):
         """
@@ -1764,8 +1760,7 @@ class vdWHandler(ParameterHandler):
                                     other_handler):
         """
         Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
-        called if a second handler is attempted to be initialized for the same tag. If no value is given for a field, it
-        will be assumed to expect the ParameterHandler class default.
+        called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
         ----------
@@ -1998,8 +1993,7 @@ class ElectrostaticsHandler(ParameterHandler):
                                     other_handler):
         """
         Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
-        called if a second handler is attempted to be initialized for the same tag. If no value is given for a field, it
-        will be assumed to expect the ParameterHandler class default.
+        called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
         ----------
@@ -2147,8 +2141,7 @@ class ToolkitAM1BCCHandler(ParameterHandler):
                                     assume_missing_is_default=True):
         """
         Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
-        called if a second handler is attempted to be initialized for the same tag. If no value is given for a field, it
-        will be assumed to expect the ParameterHandler class default.
+        called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
         ----------
@@ -2360,8 +2353,7 @@ class ChargeIncrementModelHandler(ParameterHandler):
                                     assume_missing_is_default=True):
         """
         Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
-        called if a second handler is attempted to be initialized for the same tag. If no value is given for a field, it
-        will be assumed to expect the ParameterHandler class default.
+        called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
         ----------

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -1450,7 +1450,6 @@ class ImproperTorsionHandler(ParameterHandler):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-
     def check_handler_compatibility(self,
                                     other_handler):
         """

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -628,20 +628,9 @@ class ParameterHandler:
             element_name = self._INFOTYPE._ELEMENT_NAME
 
         for key, val in smirnoff_data.items():
-            # If we're reading the parameter list, iterate through and attach units to
-            # each parameter_dict, then use it to initialize a ParameterType
+            # We don't initialize parameters here, only ParameterHandler attributes
             if key == element_name:
-                # Don't populate parameter list here
                 continue
-                # # If there are multiple parameters, this will be a list. If there's just one, make it a list
-                # if not (isinstance(val, list)):
-                #     val = [val]
-                # for unitless_param_dict in val:
-                #     param_dict = attach_units(unitless_param_dict, attached_units)
-                #     new_parameter = self._INFOTYPE(**param_dict,
-                #                                    discard_cosmetic_attributes=discard_cosmetic_attributes)
-                #     self._parameters.append(new_parameter)
-
             elif key in allowed_header_attribs:
                 attr_name = '_' + key
                 # TODO: create @property.setter here if attrib requires unit
@@ -681,7 +670,6 @@ class ParameterHandler:
             # If we're reading the parameter list, iterate through and attach units to
             # each parameter_dict, then use it to initialize a ParameterType
             if key == element_name:
-                # Don't populate parameter list here
                 # If there are multiple parameters, this will be a list. If there's just one, make it a list
                 if not (isinstance(val, list)):
                     val = [val]

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -163,7 +163,7 @@ class ParameterList(list):
 
         Parameters
         ----------
-        parameter : a ParameterType-derived object
+        parameter : a ParameterType object
 
         """
         # TODO: Ensure that newly added parameter is the same type as existing?
@@ -192,7 +192,7 @@ class ParameterList(list):
 
         Parameters
         ----------
-        item : ParameterType-derived object or str
+        item : ParameterType object or str
             The parameter or SMIRKS to look up in this ParameterList
 
         Returns
@@ -216,7 +216,7 @@ class ParameterList(list):
         ----------
         index : int
             The numerical position to insert the parameter at
-        parameter : a ParameterType-derived object
+        parameter : a ParameterType object
             The parameter to insert
         """
         # TODO: Ensure that newly added parameter is the same type as existing?
@@ -276,13 +276,13 @@ class ParameterList(list):
 
     def to_list(self, discard_cosmetic_attributes=True):
         """
-        Render this ParameterList to a normal list, serializing each ParameterType-derived object in it to dict.
+        Render this ParameterList to a normal list, serializing each ParameterType object in it to dict.
 
         Parameters
         ----------
 
         discard_cosmetic_attributes : bool, optional. Default = True
-            Whether to discard non-spec attributes of each ParameterType-derived object.
+            Whether to discard non-spec attributes of each ParameterType object.
 
         Returns
         -------
@@ -451,7 +451,7 @@ class ParameterType:
 
     def to_dict(self, discard_cosmetic_attributes=True):
         """
-        Convert this ParameterType-derived object to dict. A unit-bearing attribute ('X') will be converted to two dict
+        Convert this ParameterType object to dict. A unit-bearing attribute ('X') will be converted to two dict
         entries, one (['X'] containing the unitless value, and another (['X_unit']) containing a string representation
         of its unit.
 
@@ -464,7 +464,7 @@ class ParameterType:
         Returns
         -------
         smirnoff_dict : dict
-            The SMIRNOFF-compliant dict representation of this ParameterType-derived object.
+            The SMIRNOFF-compliant dict representation of this ParameterType object.
         output_units : dict[str: simtk.unit.Unit]
             A mapping from each simtk.unit.Quanitity-valued ParameterType attribute
             to the unit it was converted to during serialization.
@@ -768,8 +768,8 @@ class ParameterHandler:
 
         Returns
         -------
-        list of ParameterType-derived objects
-            A list of matching ParameterType-derived objects
+        list of ParameterType objects
+            A list of matching ParameterType objects
         """
         # TODO: This is a necessary API point for Lee-Ping's ForceBalance
         pass
@@ -1105,7 +1105,7 @@ class BondHandler(ParameterHandler):
 
         Parameters
         ----------
-        other_handler : a ParameterHandler-derived object
+        other_handler : a ParameterHandler object
             The handler to compare to.
 
         Raises
@@ -1228,7 +1228,7 @@ class AngleHandler(ParameterHandler):
 
         Parameters
         ----------
-        other_handler : a ParameterHandler-derived object
+        other_handler : a ParameterHandler object
             The handler to compare to.
 
         Raises
@@ -1341,7 +1341,7 @@ class ProperTorsionHandler(ParameterHandler):
 
         Parameters
         ----------
-        other_handler : a ParameterHandler-derived object
+        other_handler : a ParameterHandler object
             The handler to compare to.
 
         Raises
@@ -1455,7 +1455,7 @@ class ImproperTorsionHandler(ParameterHandler):
 
         Parameters
         ----------
-        other_handler : a ParameterHandler-derived object
+        other_handler : a ParameterHandler object
             The handler to compare to.
 
         Raises
@@ -1764,7 +1764,7 @@ class vdWHandler(ParameterHandler):
 
         Parameters
         ----------
-        other_handler : a ParameterHandler-derived object
+        other_handler : a ParameterHandler object
             The handler to compare to.
 
         Raises
@@ -1997,7 +1997,7 @@ class ElectrostaticsHandler(ParameterHandler):
 
         Parameters
         ----------
-        other_handler : a ParameterHandler-derived object
+        other_handler : a ParameterHandler object
             The handler to compare to.
 
         Raises
@@ -2145,7 +2145,7 @@ class ToolkitAM1BCCHandler(ParameterHandler):
 
         Parameters
         ----------
-        other_handler : a ParameterHandler-derived object
+        other_handler : a ParameterHandler object
             The handler to compare to.
 
         Raises
@@ -2357,7 +2357,7 @@ class ChargeIncrementModelHandler(ParameterHandler):
 
         Parameters
         ----------
-        other_handler : a ParameterHandler-derived object
+        other_handler : a ParameterHandler object
             The handler to compare to.
 
         Raises

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -1100,7 +1100,7 @@ class BondHandler(ParameterHandler):
     def check_handler_compatibility(self,
                                     other_handler):
         """
-        Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
+        Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
@@ -1223,7 +1223,7 @@ class AngleHandler(ParameterHandler):
     def check_handler_compatibility(self,
                                     other_handler):
         """
-        Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
+        Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
@@ -1336,7 +1336,7 @@ class ProperTorsionHandler(ParameterHandler):
     def check_handler_compatibility(self,
                                     other_handler):
         """
-        Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
+        Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
@@ -1450,7 +1450,7 @@ class ImproperTorsionHandler(ParameterHandler):
     def check_handler_compatibility(self,
                                     other_handler):
         """
-        Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
+        Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
@@ -1759,7 +1759,7 @@ class vdWHandler(ParameterHandler):
     def check_handler_compatibility(self,
                                     other_handler):
         """
-        Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
+        Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
@@ -1992,7 +1992,7 @@ class ElectrostaticsHandler(ParameterHandler):
     def check_handler_compatibility(self,
                                     other_handler):
         """
-        Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
+        Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
@@ -2140,7 +2140,7 @@ class ToolkitAM1BCCHandler(ParameterHandler):
                                     other_handler,
                                     assume_missing_is_default=True):
         """
-        Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
+        Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
 
         Parameters
@@ -2352,7 +2352,7 @@ class ChargeIncrementModelHandler(ParameterHandler):
                                     other_handler,
                                     assume_missing_is_default=True):
         """
-        Checks whether this ParameterHandler encodes the same physics as another ParameterHandler. This is
+        Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
 
         Parameters

--- a/openforcefield/utils/structure.py
+++ b/openforcefield/utils/structure.py
@@ -48,7 +48,7 @@ def generateSMIRNOFFStructure(oemol):
 
     # If it's a nonperiodic box, then we can't use default (PME) settings
     if omm_top.getPeriodicBoxVectors() is None:
-        mol_ff.get_handler("Electrostatics", {})._method = 'Coulomb'
+        mol_ff.get_parameter_handler("Electrostatics", {})._method = 'Coulomb'
 
     system = mol_ff.create_openmm_system(off_top)
 


### PR DESCRIPTION
This PR:
- [x] closes #278 
- [x] closes #288
- [x] implements basic `ParameterHandler` compatibility checks
- [x] changes behavior of `ForceField`'s `register_X_handler` and `get_X_handler` functions to accept initialized objects instead of classes (details in PR comments)
- [x] enables extending parameter lists when reading multiple SMIRNOFF data sources

Status:
- [x] Ready for review