### PR TITLE
Fix #276: standardize variable/method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ The SMIRNOFF `ForceField` class is essentially a drop-in replacement for the [Op
 ```python
 # Load a molecule into the openforcefield Molecule object
 from openforcefield.topology import Molecule
-from openforcefield.utils import get_data_filename
-sdf_file_path = get_data_filename('molecules/ethanol.sdf')
+from openforcefield.utils import get_data_file_path
+sdf_file_path = get_data_file_path('molecules/ethanol.sdf')
 molecule = Molecule.from_file(sdf_file_path)
 
 # Create an openforcefield Topology object from the molecule

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -8,6 +8,10 @@ Style guide
 
 Development for the ``openforcefield`` toolkit conforms to the recommendations given by the `Software Development Best Practices for Computational Chemistry <https://github.com/choderalab/software-development>`_ guide.
 
+The naming conventions of classes, functions, and variables follows `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_, consistently with the best practices guide. The naming conventions used in this library not covered by PEP8 are:
+- Use ``file_path``, ``file_name``, and ``file_stem`` to indicate ``path/to/stem.extension``, ``stem.extension``, and ``stem`` respectively, consistently with the variables in the standard ``pathlib`` library.
+- Use ``n_x`` to abbreviate "number of X` (e.g. `n_atoms`, `n_molecules`).
+
 Contributing
 """"""""""""
 

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -65,7 +65,7 @@ Miscellaneous utility functions.
     all_subclasses
     temporary_cd
     temporary_directory
-    get_data_filename
+    get_data_file_path
 
 Structure tools
 ---------------

--- a/examples/SMIRNOFF_simulation/run_simulation.ipynb
+++ b/examples/SMIRNOFF_simulation/run_simulation.ipynb
@@ -27,14 +27,14 @@
    "outputs": [],
    "source": [
     "from simtk.openmm.app import PDBFile\n",
-    "from openforcefield.utils import get_data_filename"
+    "from openforcefield.utils import get_data_file_path"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use the `get_data_filename` utility function to easily access the data installed with the toolkit. Here you have the option to load example systems of increasing complexity. For speed, we recommend that you begin by loading a system with a single ethanol and a single cyclohexane."
+    "We use the `get_data_file_path` utility function to easily access the data installed with the toolkit. Here you have the option to load example systems of increasing complexity. For speed, we recommend that you begin by loading a system with a single ethanol and a single cyclohexane."
    ]
   },
   {
@@ -44,10 +44,10 @@
    "outputs": [],
    "source": [
     "# 1 molecule of ethanol and 1 of cyclohexane.\n",
-    "pdb_file_path = get_data_filename('systems/test_systems/1_cyclohexane_1_ethanol.pdb')\n",
+    "pdb_file_path = get_data_file_path('systems/test_systems/1_cyclohexane_1_ethanol.pdb')\n",
     "\n",
     "# 40%-60% cyclohexane-ethanol mixture.\n",
-    "# pdb_file_path = get_data_filename('systems/packmol_boxes/cyclohexane_ethanol_0.4_0.6.pdb')\n",
+    "# pdb_file_path = get_data_file_path('systems/packmol_boxes/cyclohexane_ethanol_0.4_0.6.pdb')\n",
     "\n",
     "pdbfile = PDBFile(pdb_file_path)"
    ]
@@ -85,8 +85,8 @@
    "source": [
     "from openforcefield.utils.toolkits import OpenEyeToolkitWrapper\n",
     "if OpenEyeToolkitWrapper.is_available():\n",
-    "    ethanol = Molecule.from_file(get_data_filename('molecules/ethanol.mol2'))\n",
-    "    cyclohexane = Molecule.from_file(get_data_filename('molecules/cyclohexane.mol2'))"
+    "    ethanol = Molecule.from_file(get_data_file_path('molecules/ethanol.mol2'))\n",
+    "    cyclohexane = Molecule.from_file(get_data_file_path('molecules/cyclohexane.mol2'))"
    ]
   },
   {

--- a/examples/deprecated/SMIRNOFF_comparison/compare_molecule_energies.py
+++ b/examples/deprecated/SMIRNOFF_comparison/compare_molecule_energies.py
@@ -21,8 +21,8 @@ inpcrd_filepath = os.path.join(datapath, molname + '.crd')
 if not os.path.isdir(datapath):
     print("Extracting archived molecule files.")
     # Extract the AlkEthOH dataset shipped with the toolkit in data/molecules/ in the working directory.
-    from openforcefield.tests.utils import get_data_filename
-    tarfile_path = os.path.join(get_data_filename('molecules'), 'AlkEthOH_tripos.tar.gz')
+    from openforcefield.tests.utils import get_data_file_path
+    tarfile_path = os.path.join(get_data_file_path('molecules'), 'AlkEthOH_tripos.tar.gz')
     import tarfile
     with tarfile.open(tarfile_path, 'r:gz') as tar:
         tar.extractall()

--- a/examples/deprecated/SMIRNOFF_comparison/compare_set_energies.py
+++ b/examples/deprecated/SMIRNOFF_comparison/compare_set_energies.py
@@ -16,8 +16,8 @@ datapath = './AlkEthOH_tripos/AlkEthOH_test_filt1'
 if not os.path.isdir(datapath):
     print("Extracting archived molecule files.")
     # Extract the AlkEthOH dataset shipped with the toolkit in data/molecules/ in the working directory.
-    from openforcefield.tests.utils import get_data_filename
-    tarfile_path = os.path.join(get_data_filename('molecules'), 'AlkEthOH_tripos.tar.gz')
+    from openforcefield.tests.utils import get_data_file_path
+    tarfile_path = os.path.join(get_data_file_path('molecules'), 'AlkEthOH_tripos.tar.gz')
     import tarfile
     with tarfile.open(tarfile_path, 'r:gz') as tar:
         tar.extractall()

--- a/examples/deprecated/liquid_box/openff_simulation.py
+++ b/examples/deprecated/liquid_box/openff_simulation.py
@@ -13,7 +13,7 @@ from mdtraj.reporters import NetCDFReporter
 from openforcefield.typing.engines.smirnoff import ForceField
 # LPW: openforcefield's PME is different from openmm's PME
 from openforcefield.typing.engines.smirnoff.forcefield import PME
-from openforcefield.utils import get_data_filename
+from openforcefield.utils import get_data_file_path
 
 # Import the OpenEye toolkit
 from openeye import oechem
@@ -33,7 +33,7 @@ data_freq = 1000 # number of steps per written simulation statistics
 pdb = PDBFile(pdb_filename)
 
 # Load a SMIRNOFF forcefield
-forcefield = ForceField(get_data_filename('forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml'))
+forcefield = ForceField(get_data_file_path('forcefield/Frosst_AlkEthOH_parmAtFrosst.offxml'))
 
 # Load molecule using OpenEye tools
 mol = oechem.OEGraphMol()

--- a/examples/deprecated/mixedFF_structure/README.md
+++ b/examples/deprecated/mixedFF_structure/README.md
@@ -5,8 +5,8 @@ This example illustrates how the [ParmEd](http://parmed.github.io/ParmEd/html/in
 The essential idea is to first create a ParmEd structure from the SMIRNOFF parameterized small molecule
 ```python
 # Load the small molecule
-from openforcefield.utils import get_data_filename
-ligand_filename = get_data_filename('molecules/toluene.mol2')
+from openforcefield.utils import get_data_file_path
+ligand_filename = get_data_file_path('molecules/toluene.mol2')
 molecule = Molecule.from_file(ligand_filename)
 
 # Load the smirnoff99Frosst force field
@@ -20,7 +20,7 @@ Next, a ParmEd structure is created for the protein (parameterized with AMBER us
 ```python
 # Load the protein topology
 from openforcefield.utils import generate_protein_structure
-protein_pdb_filename = get_data_filename('proteins/T4-protein.pdb')
+protein_pdb_filename = get_data_file_path('proteins/T4-protein.pdb')
 protein_pdbfile = app.PDBFile(protein_pdb_filename)
 
 # Load the AMBER protein force field, along with a solvent force field

--- a/examples/deprecated/mixedFF_structure/generate_mixedFF_complex.py
+++ b/examples/deprecated/mixedFF_structure/generate_mixedFF_complex.py
@@ -10,8 +10,8 @@ Illustrate how to combine a SMIRNOFF parameterized small molecule with an AMBER 
 #
 
 # Load the small molecule
-from openforcefield.utils import get_data_filename
-ligand_filename = get_data_filename('molecules/toluene.mol2')
+from openforcefield.utils import get_data_file_path
+ligand_filename = get_data_file_path('molecules/toluene.mol2')
 molecule = Molecule.from_file(ligand_filename)
 
 # Load the smirnoff99Frosst force field
@@ -27,7 +27,7 @@ print('Molecule:', molecule_structure)
 #
 
 # Load the protein topology
-protein_pdb_filename = get_data_filename('proteins/T4-protein.pdb')
+protein_pdb_filename = get_data_file_path('proteins/T4-protein.pdb')
 protein_pdbfile = app.PDBFile(protein_pdb_filename)
 
 # Load the AMBER protein force field, along with a solvent force field

--- a/examples/deprecated/rdkit_openeye_comparison/compare_rdk_oe_mol_loading.ipynb
+++ b/examples/deprecated/rdkit_openeye_comparison/compare_rdk_oe_mol_loading.ipynb
@@ -130,7 +130,7 @@
    "outputs": [],
    "source": [
     "from openforcefield.utils.toolkits import RDKitToolkitWrapper, OpenEyeToolkitWrapper, UndefinedStereochemistryError\n",
-    "from openforcefield.utils import get_data_filename\n",
+    "from openforcefield.utils import get_data_file_path\n",
     "import difflib\n",
     "\n",
     "OETKW = OpenEyeToolkitWrapper()\n",
@@ -204,7 +204,7 @@
     "from rdkit import Chem\n",
     "\n",
     "\n",
-    "rdk_mols_from_3d = Molecule.from_file(get_data_filename('molecules/MiniDrugBank.sdf'), \n",
+    "rdk_mols_from_3d = Molecule.from_file(get_data_file_path('molecules/MiniDrugBank.sdf'), \n",
     "                                      toolkit_registry = RDKTKW,\n",
     "                                      file_format='sdf',\n",
     "                                      allow_undefined_stereo=True)\n",
@@ -284,8 +284,8 @@
     "# NBVAL_SKIP\n",
     "from openforcefield.topology import Molecule\n",
     "\n",
-    "#molecules = Molecule.from_file(get_data_filename('molecules/MiniDrugBank.sdf'), \n",
-    "oe_mols_from_3d = Molecule.from_file(get_data_filename('molecules/MiniDrugBank_tripos.mol2'), \n",
+    "#molecules = Molecule.from_file(get_data_file_path('molecules/MiniDrugBank.sdf'), \n",
+    "oe_mols_from_3d = Molecule.from_file(get_data_file_path('molecules/MiniDrugBank_tripos.mol2'), \n",
     "                                     toolkit_registry = OETKW,\n",
     "                                     file_format='sdf',\n",
     "                                     allow_undefined_stereo=False)"

--- a/examples/forcefield_modification/ManipulateParameters.ipynb
+++ b/examples/forcefield_modification/ManipulateParameters.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "from openforcefield.topology import Molecule, Topology\n",
     "from openforcefield.typing.engines.smirnoff.forcefield import ForceField\n",
-    "from openforcefield.utils import get_data_filename\n",
+    "from openforcefield.utils import get_data_file_path\n",
     "from simtk import openmm, unit\n",
     "import numpy as np"
    ]
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "molecule = Molecule.from_file(get_data_filename('molecules/ethanol.sdf'))"
+    "molecule = Molecule.from_file(get_data_file_path('molecules/ethanol.sdf'))"
    ]
   },
   {
@@ -306,16 +306,16 @@
     "from simtk.openmm import app\n",
     "\n",
     "# A 239-molecule mixture of cyclohexane and ethanol\n",
-    "pdbfile = app.PDBFile(get_data_filename('systems/packmol_boxes/cyclohexane_ethanol_0.4_0.6.pdb'))\n",
+    "pdbfile = app.PDBFile(get_data_file_path('systems/packmol_boxes/cyclohexane_ethanol_0.4_0.6.pdb'))\n",
     "\n",
     "# A 340-molecule mixture of propane, methane, and butanol.\n",
-    "#pdbfile = app.PDBFile(get_data_filename('systems/packmol_boxes/propane_methane_butanol_0.2_0.3_0.5.pdb'))\n",
+    "#pdbfile = app.PDBFile(get_data_file_path('systems/packmol_boxes/propane_methane_butanol_0.2_0.3_0.5.pdb'))\n",
     "\n",
     "# One cyclohexane in a box of roughly 1400 waters\n",
-    "#pdbfile = app.PDBFile(get_data_filename('systems/packmol_boxes/cyclohexane_water.pdb'))\n",
+    "#pdbfile = app.PDBFile(get_data_file_path('systems/packmol_boxes/cyclohexane_water.pdb'))\n",
     "\n",
     "# One ethanol in a box of roughly 1300 waters\n",
-    "#pdbfile = app.PDBFile(get_data_filename('systems/packmol_boxes/ethanol_water.pdb'))\n",
+    "#pdbfile = app.PDBFile(get_data_file_path('systems/packmol_boxes/ethanol_water.pdb'))\n",
     "\n"
    ]
   },

--- a/examples/inspect_assigned_parameters/inspect_assigned_parameters.ipynb
+++ b/examples/inspect_assigned_parameters/inspect_assigned_parameters.ipynb
@@ -439,7 +439,7 @@
     }
    ],
    "source": [
-    "from openforcefield.utils import get_data_filename\n",
+    "from openforcefield.utils import get_data_file_path\n",
     "from openforcefield.topology import Molecule\n",
     "from openforcefield.typing.engines.smirnoff import ForceField\n",
     "from openforcefield.utils.structure import get_molecule_parameterIDs\n",

--- a/examples/using_smirnoff_with_amber_protein_forcefield/toluene_in_T4_lysozyme.ipynb
+++ b/examples/using_smirnoff_with_amber_protein_forcefield/toluene_in_T4_lysozyme.ipynb
@@ -28,7 +28,7 @@
    "source": [
     "from simtk.openmm.app import PDBFile\n",
     "\n",
-    "from openforcefield.utils import get_data_filename\n",
+    "from openforcefield.utils import get_data_file_path\n",
     "from openforcefield.topology import Molecule, Topology\n",
     "from openforcefield.typing.engines.smirnoff import ForceField"
    ]
@@ -40,7 +40,7 @@
    "outputs": [],
    "source": [
     "# Create an OpenFF Topology of toluene from a pdb file.\n",
-    "toluene_pdb_file_path = get_data_filename('molecules/toluene.pdb')\n",
+    "toluene_pdb_file_path = get_data_file_path('molecules/toluene.pdb')\n",
     "toluene_pdbfile = PDBFile(toluene_pdb_file_path)\n",
     "toluene = Molecule.from_smiles('Cc1ccccc1')\n",
     "off_topology = Topology.from_openmm(openmm_topology=toluene_pdbfile.topology,\n",
@@ -104,7 +104,7 @@
     "omm_forcefield = app.ForceField('amber99sbildn.xml', 'tip3pfb.xml')\n",
     "\n",
     "# Load the solvated receptor from a PDB file.\n",
-    "t4_pdb_file_path = get_data_filename('systems/test_systems/T4_lysozyme_water_ions.pdb')\n",
+    "t4_pdb_file_path = get_data_file_path('systems/test_systems/T4_lysozyme_water_ions.pdb')\n",
     "t4_pdb_file = PDBFile(t4_pdb_file_path)\n",
     "\n",
     "# Obtain the updated OpenMM Topology and positions.\n",

--- a/openforcefield/data/molecules/README.md
+++ b/openforcefield/data/molecules/README.md
@@ -5,7 +5,7 @@ This is a list of the molecule files provided here including a brief description
 * `AlkEthOH_tripos.tar.gz`: `*.crd`, `*.top`, and `*.mol2` (with Tripos SYBYL atom types) for all the molecules in
 the AlkEthOH dataset. All molecules were taken from
 https://github.com/openforcefield/open-forcefield-data/blob/master/Model-Systems/AlkEthOH_distrib/inputfiles.tar.gz.
-All the files in the archive can be accessed through `openforcefield.tests.utils:get_alkethoh_filepath()`. The archive
+All the files in the archive can be accessed through `openforcefield.tests.utils:get_alkethoh_file_path()`. The archive
 has the following structure:
     - `AlkEthOH_rings_filt1`: A collection of cyclic alkanes, alcohols, and ethers.
     - `AlkEthOH_chain_filt1`: Acyclic alkanes, alcohols, and ethers.

--- a/openforcefield/tests/conftest.py
+++ b/openforcefield/tests/conftest.py
@@ -34,9 +34,9 @@ def untar_full_alkethoh_and_freesolv_set():
     """
     import os
     import tarfile
-    from openforcefield.utils import get_data_filename
+    from openforcefield.utils import get_data_file_path
 
-    molecule_dir_path = get_data_filename('molecules')
+    molecule_dir_path = get_data_file_path('molecules')
     for tarfile_name in ['AlkEthOH_tripos.tar.gz', 'FreeSolv.tar.gz']:
         tarfile_path = os.path.join(molecule_dir_path, tarfile_name)
         with tarfile.open(tarfile_path, 'r:gz') as tar:

--- a/openforcefield/tests/test_chemicalenvironment.py
+++ b/openforcefield/tests/test_chemicalenvironment.py
@@ -1,6 +1,6 @@
 from functools import partial
 from openforcefield.typing.chemistry import *
-from openforcefield.utils import get_data_filename
+from openforcefield.utils import get_data_file_path
 from unittest import TestCase
 import pytest
 from openforcefield.utils.toolkits import OPENEYE_AVAILABLE

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -23,7 +23,7 @@ import numpy as np
 import pytest
 from openforcefield.utils.toolkits import OpenEyeToolkitWrapper, RDKitToolkitWrapper, AmberToolsToolkitWrapper, ToolkitRegistry
 
-from openforcefield.utils import get_data_filename
+from openforcefield.utils import get_data_file_path
 
 from openforcefield.topology import Molecule, Topology
 from openforcefield.typing.engines.smirnoff import ForceField, IncompatibleParameterError
@@ -34,7 +34,7 @@ from openforcefield.typing.engines.smirnoff import ForceField, IncompatibleParam
 #======================================================================
 
 # File paths.
-TIP3P_SDF_FILE_PATH = get_data_filename(os.path.join('systems', 'monomers', 'water.sdf'))
+TIP3P_SDF_FILE_PATH = get_data_file_path(os.path.join('systems', 'monomers', 'water.sdf'))
 
 GENERIC_BOND_LENGTH = 1.09 * unit.angstrom
 XML_FF_GENERICS = f"""<?xml version='1.0' encoding='ASCII'?>
@@ -396,7 +396,7 @@ class TestForceField():
         from simtk.openmm import app
 
         forcefield = ForceField('smirnoff99Frosst.offxml')
-        pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
         molecules = []
         molecules.append(Molecule.from_smiles('CCO'))
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
@@ -408,12 +408,12 @@ class TestForceField():
         from simtk.openmm import app
 
         forcefield = ForceField('smirnoff99Frosst.offxml')
-        pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
         # toolkit_wrapper = RDKitToolkitWrapper()
         molecules = []
         molecules.append(Molecule.from_smiles('CCO'))
         molecules.append(Molecule.from_smiles('C1CCCCC1'))
-        # molecules = [Molecule.from_file(get_data_filename(name)) for name in ('molecules/ethanol.mol2',
+        # molecules = [Molecule.from_file(get_data_file_path(name)) for name in ('molecules/ethanol.mol2',
         #                                                                      'molecules/cyclohexane.mol2')]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 
@@ -424,12 +424,12 @@ class TestForceField():
         from simtk.openmm import app
 
         forcefield = ForceField('smirnoff99Frosst.offxml')
-        pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
         # toolkit_wrapper = RDKitToolkitWrapper()
         molecules = []
         molecules.append(Molecule.from_smiles('CCO'))
         molecules.append(Molecule.from_smiles('C1CCCCC1'))
-        # molecules = [Molecule.from_file(get_data_filename(name)) for name in ('molecules/ethanol.mol2',
+        # molecules = [Molecule.from_file(get_data_file_path(name)) for name in ('molecules/ethanol.mol2',
         #                                                                      'molecules/cyclohexane.mol2')]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         topology.box_vectors = None
@@ -445,7 +445,7 @@ class TestForceField():
         from simtk.openmm import app
 
         forcefield = ForceField('smirnoff99Frosst.offxml')
-        pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
         # toolkit_wrapper = RDKitToolkitWrapper()
         molecules = []
         molecules.append(Molecule.from_smiles('CC'))
@@ -462,10 +462,10 @@ class TestForceField():
         from simtk.openmm import app
 
         forcefield = ForceField('smirnoff99Frosst.offxml')
-        box_filename = get_data_filename(os.path.join('systems', 'packmol_boxes', box))
+        box_filename = get_data_file_path(os.path.join('systems', 'packmol_boxes', box))
         pdbfile = app.PDBFile(box_filename)
         mol_names = ['water', 'cyclohexane', 'ethanol', 'propane', 'methane', 'butanol']
-        sdf_files = [get_data_filename(os.path.join('systems', 'monomers', name+'.sdf')) for name in mol_names]
+        sdf_files = [get_data_file_path(os.path.join('systems', 'monomers', name+'.sdf')) for name in mol_names]
         molecules = [Molecule.from_file(sdf_file) for sdf_file in sdf_files]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, )
 
@@ -483,16 +483,16 @@ class TestForceField():
         from simtk.openmm import XmlSerializer
 
         forcefield = ForceField('smirnoff99Frosst.offxml')
-        pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
         # Load the unique molecules with one atom ordering
-        molecules1 = [Molecule.from_file(get_data_filename('molecules/ethanol.sdf'))]
+        molecules1 = [Molecule.from_file(get_data_file_path('molecules/ethanol.sdf'))]
         topology1 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules1,
                                          )
         omm_system1 = forcefield.create_openmm_system(topology1,
                                                       toolkit_registry=toolkit_registry)
         # Load the unique molecules with a different atom ordering
-        molecules2 = [Molecule.from_file(get_data_filename('molecules/ethanol_reordered.sdf'))]
+        molecules2 = [Molecule.from_file(get_data_file_path('molecules/ethanol_reordered.sdf'))]
         topology2 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules2,
                                          )
@@ -519,10 +519,10 @@ class TestForceField():
 
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[RDKitToolkitWrapper, AmberToolsToolkitWrapper])
         forcefield = ForceField('smirnoff99Frosst.offxml')
-        pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
 
         # Load the unique molecules with one atom ordering
-        molecules1 = [Molecule.from_file(get_data_filename('molecules/ethanol.sdf'))]
+        molecules1 = [Molecule.from_file(get_data_file_path('molecules/ethanol.sdf'))]
         topology1 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules1,
                                          
@@ -531,7 +531,7 @@ class TestForceField():
                                                       toolkit_registry=toolkit_registry)
 
         # Load the unique molecules with a different atom ordering
-        molecules2 = [Molecule.from_file(get_data_filename('molecules/ethanol_reordered.sdf'))]
+        molecules2 = [Molecule.from_file(get_data_file_path('molecules/ethanol_reordered.sdf'))]
         topology2 = Topology.from_openmm(pdbfile.topology,
                                          unique_molecules=molecules2,
                                          )
@@ -554,9 +554,9 @@ class TestForceField():
         from simtk.openmm import app
 
         forcefield = ForceField('smirnoff99Frosst.offxml')
-        pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
         #toolkit_wrapper = RDKitToolkitWrapper()
-        molecules = [ Molecule.from_file(get_data_filename(name)) for name in ('molecules/ethanol.mol2',) ]
+        molecules = [ Molecule.from_file(get_data_file_path(name)) for name in ('molecules/ethanol.mol2',) ]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 
         parmed_system = forcefield.create_parmed_structure(topology, positions=pdbfile.getPositions())
@@ -569,9 +569,9 @@ class TestForceField():
 
         from simtk.openmm import app, NonbondedForce
 
-        filename = get_data_filename('forcefield/smirnoff99Frosst.offxml')
+        filename = get_data_file_path('forcefield/smirnoff99Frosst.offxml')
         forcefield = ForceField(filename)
-        pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         omm_system = forcefield.create_openmm_system(topology, charge_from_molecules=molecules,
                                                      toolkit_registry=toolkit_registry)
@@ -586,7 +586,7 @@ class TestForceField():
 
         # In 1_ethanol_reordered.pdb, the first three atoms go O-C-C instead of C-C-O. This part of the test ensures
         # that the charges are correctly mapped according to this PDB in the resulting system.
-        pdbfile2 = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol_reordered.pdb'))
+        pdbfile2 = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol_reordered.pdb'))
         topology2 = Topology.from_openmm(pdbfile2.topology, unique_molecules=molecules)
 
         omm_system2 = forcefield.create_openmm_system(topology2, charge_from_molecules=molecules,
@@ -613,9 +613,9 @@ class TestForceField():
 
         from simtk.openmm import app, NonbondedForce
 
-        filename = get_data_filename('forcefield/smirnoff99Frosst.offxml')
+        filename = get_data_file_path('forcefield/smirnoff99Frosst.offxml')
         forcefield = ForceField(filename)
-        pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, )
 
         omm_system = forcefield.create_openmm_system(topology,
@@ -642,9 +642,9 @@ class TestForceField():
         """Test to ensure an exception is raised when an unrecognized kwarg is passed """
         from simtk.openmm import app
 
-        filename = get_data_filename('forcefield/smirnoff99Frosst.offxml')
+        filename = get_data_file_path('forcefield/smirnoff99Frosst.offxml')
         forcefield = ForceField(filename)
-        pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
         molecules = []
         molecules.append(Molecule.from_smiles('CCO'))
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
@@ -672,7 +672,7 @@ class TestForceField():
         forcefield.get_handler('vdW', {})._method = vdw_method
         forcefield.get_handler('Electrostatics', {})._method = electrostatics_method
 
-        pdbfile = app.PDBFile(get_data_filename('systems/test_systems/1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 
         if not(has_periodic_box):
@@ -748,7 +748,7 @@ def generate_alkethoh_parameters_assignment_cases():
     # Get all the molecules ids from the tarfiles. The tarball is extracted
     # in conftest.py if slow tests are activated.
     import tarfile
-    alkethoh_tar_file_path = get_data_filename(os.path.join('molecules', 'AlkEthOH_tripos.tar.gz'))
+    alkethoh_tar_file_path = get_data_file_path(os.path.join('molecules', 'AlkEthOH_tripos.tar.gz'))
     with tarfile.open(alkethoh_tar_file_path, 'r:gz') as tar:
         # Collect all the files discarding the duplicates in the test_filt1 folder.
         slow_test_cases = {extract_id(m.name) for m in tar.getmembers()
@@ -800,7 +800,7 @@ def generate_freesolv_parameters_assignment_cases():
 
     # Get all the tarball XML files available. The tarball is extracted
     # in conftest.py if slow tests are activated.
-    freesolv_tar_file_path = get_data_filename(os.path.join('molecules', 'FreeSolv.tar.gz'))
+    freesolv_tar_file_path = get_data_file_path(os.path.join('molecules', 'FreeSolv.tar.gz'))
     with tarfile.open(freesolv_tar_file_path, 'r:gz') as tar:
         slow_test_cases = {extract_id(m.name) for m in tar.getmembers() if '.xml' in m.name}
 
@@ -956,7 +956,7 @@ class TestForceFieldParameterAssignment:
 def test_electrostatics_options(self):
     """Test parameter assignment using smirnoff99Frosst on laromustine with various long-range electrostatics options.
     """
-    molecules_filename = get_data_filename('molecules/laromustine_tripos.mol2')
+    molecules_filename = get_data_file_path('molecules/laromustine_tripos.mol2')
     molecule = openforcefield.topology.Molecule.from_file(molecules_filename)
     forcefield = ForceField([smirnoff99Frosst_offxml_filename, chargeincrement_offxml_filename])
     for method in ['PME', 'reaction-field', 'Coulomb']:
@@ -972,7 +972,7 @@ def test_electrostatics_options(self):
 def test_chargeincrement(self):
     """Test parameter assignment using smirnoff99Frosst on laromustine with ChargeIncrementModel.
     """
-    molecules_filename = get_data_filename('molecules/laromustine_tripos.mol2')
+    molecules_filename = get_data_file_path('molecules/laromustine_tripos.mol2')
     molecule = openforcefield.topology.Molecule.from_file(molecules_filename)
     forcefield = ForceField(['smirnoff99Frosst.offxml', 'chargeincrement-test'])
     check_system_creation_from_molecule(forcefield, molecule)
@@ -984,7 +984,7 @@ def test_chargeincrement(self):
 def test_create_system_molecules_parmatfrosst_gbsa(self):
     """Test creation of a System object from small molecules to test parm@frosst forcefield with GBSA support.
     """
-    molecules_filename = get_data_filename('molecules/AlkEthOH_test_filt1_tripos.mol2')
+    molecules_filename = get_data_file_path('molecules/AlkEthOH_test_filt1_tripos.mol2')
     check_parameter_assignment(
         offxml_filename='Frosst_AlkEthOH_GBSA.offxml', molecules_filename=molecules_filename)
     # TODO: Figure out if we just want to check that energy is finite (this is what the original test did,

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -396,7 +396,7 @@ class TestForceField():
             forcefield = ForceField(xml_ff_w_cosmetic_elements)
 
         # Create a forcefield from XML successfully, by explicitly permitting cosmetic attributes
-        forcefield_1 = ForceField(xml_ff_w_cosmetic_elements, permit_cosmetic_attributes=True)
+        forcefield_1 = ForceField(xml_ff_w_cosmetic_elements, allow_cosmetic_attributes=True)
 
         # Convert the forcefield back to XML
         string_1 = forcefield_1.to_string('XML', discard_cosmetic_attributes=False)
@@ -405,10 +405,10 @@ class TestForceField():
         assert 'cosmetic_element="why not?"' in string_1
         assert 'parameterize_eval="blah=blah2"' in string_1
         with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg {'parameters': 'k, length'} passed") as excinfo:
-            forcefield = ForceField(string_1, permit_cosmetic_attributes=False)
+            forcefield = ForceField(string_1, allow_cosmetic_attributes=False)
 
         # Complete the forcefield_1 --> string --> forcefield_2 roundtrip
-        forcefield_2 = ForceField(string_1, permit_cosmetic_attributes=True)
+        forcefield_2 = ForceField(string_1, allow_cosmetic_attributes=True)
 
         # Ensure that the forcefield remains the same after the roundtrip
         string_2 = forcefield_2.to_string('XML', discard_cosmetic_attributes=False)
@@ -457,7 +457,7 @@ class TestForceField():
             forcefield = ForceField(xml_ff_w_cosmetic_elements)
 
         # Create a forcefield from XML successfully
-        forcefield_1 = ForceField(xml_ff_w_cosmetic_elements, permit_cosmetic_attributes=True)
+        forcefield_1 = ForceField(xml_ff_w_cosmetic_elements, allow_cosmetic_attributes=True)
 
         # Convert the forcefield back to XML, keeping cosmetic attributes
         forcefield_1.to_file(iofile1.name, discard_cosmetic_attributes=False, io_format=specified_format)
@@ -466,10 +466,10 @@ class TestForceField():
         assert 'cosmetic_element="why not?"' in open(iofile1.name).read()
         assert 'parameterize_eval="blah=blah2"' in open(iofile1.name).read()
         with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg {'parameters': 'k, length'} passed") as excinfo:
-            forcefield = ForceField(iofile1.name, permit_cosmetic_attributes=False)
+            forcefield = ForceField(iofile1.name, allow_cosmetic_attributes=False)
 
         # Complete the forcefield_1 --> file --> forcefield_2 roundtrip
-        forcefield_2 = ForceField(iofile1.name, permit_cosmetic_attributes=True)
+        forcefield_2 = ForceField(iofile1.name, allow_cosmetic_attributes=True)
 
         # Ensure that the forcefield remains the same after the roundtrip
         forcefield_2.to_file(iofile2.name, discard_cosmetic_attributes=False, io_format=specified_format)
@@ -487,7 +487,7 @@ class TestForceField():
 
     def test_load_two_sources(self):
         """Test loading data from two SMIRNOFF data sources"""
-        ff = ForceField(simple_xml_ff, xml_ff_w_cosmetic_elements, permit_cosmetic_attributes=True)
+        ff = ForceField(simple_xml_ff, xml_ff_w_cosmetic_elements, allow_cosmetic_attributes=True)
         assert len(ff.get_parameter_handler('Bonds').parameters) == 4
 
     def test_load_two_sources_incompatible_tags(self):

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -836,11 +836,11 @@ class TestForceFieldParameterAssignment:
         does the job.
 
         """
-        from openforcefield.tests.utils import get_alkethoh_filepath, compare_amber_smirnoff
+        from openforcefield.tests.utils import get_alkethoh_file_path, compare_amber_smirnoff
 
         # Obtain the path to the input files.
         alkethoh_name = 'AlkEthOH_' + alkethoh_id
-        mol2_filepath, top_filepath, crd_filepath = get_alkethoh_filepath(alkethoh_name, get_amber=True)
+        mol2_filepath, top_filepath, crd_filepath = get_alkethoh_file_path(alkethoh_name, get_amber=True)
 
         # Load molecule.
         molecule = Molecule.from_file(mol2_filepath)
@@ -867,7 +867,7 @@ class TestForceFieldParameterAssignment:
 
         """
         import parmed
-        from openforcefield.tests.utils import (get_alkethoh_filepath,
+        from openforcefield.tests.utils import (get_alkethoh_file_path,
                                                 compare_system_parameters,
                                                 compare_system_energies)
 
@@ -878,7 +878,7 @@ class TestForceFieldParameterAssignment:
         molecules = []
         structures = []
         for alkethoh_id in alketoh_ids:
-            mol2_filepath, top_filepath, crd_filepath = get_alkethoh_filepath(
+            mol2_filepath, top_filepath, crd_filepath = get_alkethoh_file_path(
                 'AlkEthOH_'+alkethoh_id, get_amber=True)
             molecules.append(Molecule.from_file(mol2_filepath))
             amber_parm = parmed.load_file(top_filepath, crd_filepath)
@@ -928,8 +928,8 @@ class TestForceFieldParameterAssignment:
         and improper torsions.
 
         """
-        from openforcefield.tests.utils import get_freesolv_filepath, compare_system_parameters
-        mol2_file_path, xml_file_path = get_freesolv_filepath(freesolv_id, forcefield_version)
+        from openforcefield.tests.utils import get_freesolv_file_path, compare_system_parameters
+        mol2_file_path, xml_file_path = get_freesolv_file_path(freesolv_id, forcefield_version)
 
         # Load molecules.
         molecule = Molecule.from_file(mol2_file_path, allow_undefined_stereo=allow_undefined_stereo)

--- a/openforcefield/tests/test_molecule.py
+++ b/openforcefield/tests/test_molecule.py
@@ -32,7 +32,7 @@ import pytest
 from simtk import unit
 
 from openforcefield.topology.molecule import Molecule, Atom
-from openforcefield.utils import get_data_filename
+from openforcefield.utils import get_data_file_path
 # TODO: Will the ToolkitWrapper allow us to pare that down?
 from openforcefield.utils.toolkits import OpenEyeToolkitWrapper, RDKitToolkitWrapper, AmberToolsToolkitWrapper, ToolkitRegistry
 
@@ -148,7 +148,7 @@ def mini_drug_bank(xfail_mols=None, wip_mols=None):
         molecules = mini_drug_bank.molecules
     else:
         # Load the dataset.
-        file_path = get_data_filename('molecules/MiniDrugBank_tripos.mol2')
+        file_path = get_data_file_path('molecules/MiniDrugBank_tripos.mol2')
         try:
             # We need OpenEye to parse the molecules, but pytest execute this
             # whether or not the test class is skipped so if OE is not available
@@ -265,7 +265,7 @@ class TestMolecule:
     def test_create_from_file(self):
         """Test standard constructor taking a filename or file-like object."""
         # TODO: Expand test to both openeye and rdkit toolkits
-        filename = get_data_filename('molecules/toluene.mol2')
+        filename = get_data_file_path('molecules/toluene.mol2')
 
         molecule1 = Molecule(filename, allow_undefined_stereo=True)
         with open(filename, 'r') as infile:
@@ -280,7 +280,7 @@ class TestMolecule:
         # Ensure that attempting to initialize a single Molecule from a file
         # containing multiple molecules raises a ValueError
         with pytest.raises(ValueError) as exc_info:
-            filename = get_data_filename('molecules/zinc-subset-tripos.mol2.gz')
+            filename = get_data_file_path('molecules/zinc-subset-tripos.mol2.gz')
             molecule = Molecule(filename, allow_undefined_stereo=True)
 
     @pytest.mark.parametrize('molecule', mini_drug_bank())

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -332,7 +332,7 @@ class TestParameterType:
                                   length=1.02*unit.angstrom,
                                   k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
                                   pilot='alice',
-                                  permit_cosmetic_attributes=True
+                                  allow_cosmetic_attributes=True
                                   )
         param_dict= p1.to_dict(discard_cosmetic_attributes=False)
         assert ('pilot', 'alice') in param_dict.items()
@@ -347,7 +347,7 @@ class TestParameterType:
                                   length=1.02*unit.angstrom,
                                   k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
                                   pilot='alice',
-                                  permit_cosmetic_attributes=True
+                                  allow_cosmetic_attributes=True
                                   )
         param_dict = p1.to_dict(discard_cosmetic_attributes=True)
         assert ('pilot', 'alice') not in param_dict.items()
@@ -363,7 +363,7 @@ class TestParameterType:
                                       length=1.02*unit.angstrom,
                                       k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
                                       pilot='alice',
-                                      permit_cosmetic_attributes=False
+                                      allow_cosmetic_attributes=False
                                       )
 
     def test_single_term_proper_torsion(self):

--- a/openforcefield/tests/test_smirnoff.py
+++ b/openforcefield/tests/test_smirnoff.py
@@ -24,7 +24,7 @@ import parmed
 from simtk import unit, openmm
 from simtk.openmm import app
 
-# from openforcefield.utils import get_data_filename  #, generateTopologyFromOEMol, read_molecules
+# from openforcefield.utils import get_data_file_path  #, generateTopologyFromOEMol, read_molecules
 # from openforcefield.utils import check_energy_is_finite, get_energy
 # from openforcefield.tests.utils import get_packmol_pdbfile, get_monomer_mol2file, compare_system_energies
 from openforcefield.tests.utils import *
@@ -39,13 +39,13 @@ pytestmark = pytest.mark.skip('tests in test_smirnoff are outdated and should be
 #=============================================================================================
 
 # TODO: Move these to setup?
-# These paths should only be found in the test data directories, so we need to use get_data_filename()
+# These paths should only be found in the test data directories, so we need to use get_data_file_path()
 AlkEthOH_offxml_filename = 'Frosst_AlkEthOH.offxml'
-AlkEthOH_molecules_filename = get_data_filename('molecules/AlkEthOH_test_filt1_tripos.mol2')
-MiniDrugBank_molecules_filename = get_data_filename('molecules/MiniDrugBank_tripos.mol2')
-#chargeincrement_offxml_filename = get_data_filename('chargeincrement-test.offxml')
+AlkEthOH_molecules_filename = get_data_file_path('molecules/AlkEthOH_test_filt1_tripos.mol2')
+MiniDrugBank_molecules_filename = get_data_file_path('molecules/MiniDrugBank_tripos.mol2')
+#chargeincrement_offxml_filename = get_data_file_path('chargeincrement-test.offxml')
 # TODO: Swtich all paths to use os.path.join
-tip3p_molecule_filename = get_data_filename(os.path.join('systems', 'monomers', 'tip3p_water.mol2'))
+tip3p_molecule_filename = get_data_file_path(os.path.join('systems', 'monomers', 'tip3p_water.mol2'))
 
 # This is the production form of smirnoff99Frosst that should be found in the data directories
 smirnoff99Frosst_offxml_filename = 'smirnoff99Frosst.offxml'
@@ -342,8 +342,8 @@ class TestApplyForceField:
         ff = ForceField('benzene_minimal.offxml')
 
         # Load AMBER files and compare
-        inpcrd = get_data_filename('molecules/benzene.crd')
-        prmtop = get_data_filename('molecules/benzene.top')
+        inpcrd = get_data_file_path('molecules/benzene.crd')
+        prmtop = get_data_file_path('molecules/benzene.top')
         g0, g1, e0, e1 = compare_amber_smirnoff(prmtop, inpcrd, ff, mol, skip_assert=True)
 
         # Check that torsional energies the same to 1 in 10^6
@@ -360,8 +360,8 @@ class TestForceFieldLabeling:
 
     def test_label_molecules(self):
         """Test labeling/getting stats on labeling molecules"""
-        molecules = read_molecules(get_data_filename('molecules/AlkEthOH_test_filt1_tripos.mol2'), verbose=verbose)
-        ffxml = get_data_filename('forcefield/Frosst_AlkEthOH.offxml')
+        molecules = read_molecules(get_data_file_path('molecules/AlkEthOH_test_filt1_tripos.mol2'), verbose=verbose)
+        ffxml = get_data_file_path('forcefield/Frosst_AlkEthOH.offxml')
         get_molecule_parameterIDs(molecules, ffxml)
 
     def test_molecule_labeling(self):
@@ -415,7 +415,7 @@ def test_improper_pyramidal(verbose=False):
     from openeye import oeomega
     from openeye import oequacpac
     from oeommtools.utils import oemol_to_openmmTop, openmmTop_to_oemol
-    from openforcefield.utils import get_data_filename, extractPositionsFromOEMol
+    from openforcefield.utils import get_data_file_path, extractPositionsFromOEMol
     # Prepare ammonia
     mol = oechem.OEMol()
     oechem.OESmilesToMol(mol, 'N')
@@ -484,7 +484,7 @@ def test_change_parameters(verbose=False):
     """Test modification of forcefield parameters."""
     from openeye import oechem
     # Load simple OEMol
-    ifs = oechem.oemolistream(get_data_filename('molecules/AlkEthOH_c100.mol2'))
+    ifs = oechem.oemolistream(get_data_file_path('molecules/AlkEthOH_c100.mol2'))
     mol = oechem.OEMol()
     flavor = oechem.OEIFlavor_Generic_Default | oechem.OEIFlavor_MOL2_Default | oechem.OEIFlavor_MOL2_Forcefield
     ifs.SetFlavor(oechem.OEFormat_MOL2, flavor)
@@ -653,7 +653,7 @@ class TestSolventSupport:
                     force.addBond(particle1=0, particle2=1, length=length_tip3p, k=k_tip3p)
                     force.addBond(particle1=0, particle2=2, length=length_tip3p, k=k_tip3p)
 
-        monomers_dir = get_data_filename(os.path.join('systems', 'monomers'))
+        monomers_dir = get_data_file_path(os.path.join('systems', 'monomers'))
 
         # Load TIP3P molecule
         tip3p_molecule = Molecule.from_file(tip3p_molecule_filename)

--- a/openforcefield/tests/test_smirnoff.py
+++ b/openforcefield/tests/test_smirnoff.py
@@ -26,7 +26,7 @@ from simtk.openmm import app
 
 # from openforcefield.utils import get_data_file_path  #, generateTopologyFromOEMol, read_molecules
 # from openforcefield.utils import check_energy_is_finite, get_energy
-# from openforcefield.tests.utils import get_packmol_pdbfile, get_monomer_mol2file, compare_system_energies
+# from openforcefield.tests.utils import get_packmol_pdb_file_path, get_monomer_mol2_file_path, compare_system_energies
 from openforcefield.tests.utils import *
 from openforcefield.typing.engines.smirnoff import *
 
@@ -539,8 +539,8 @@ class TestForceFieldExport:
         positions : simtk.unit.Quantity with dimension (nparticles,3) with units compatible with angstroms
             Positions corresponding to particles in ``topology``
         """
-        pdbfile = app.PDBFile(get_packmol_pdbfile(packmol_boxname))
-        molecules = [Molecule.from_file(get_monomer_mol2file(name)) for name in monomers]
+        pdbfile = app.PDBFile(get_packmol_pdb_file_path(packmol_boxname))
+        molecules = [Molecule.from_file(get_monomer_mol2_file_path(name)) for name in monomers]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         positions = pdbfile.positions
         return topology, positions

--- a/openforcefield/tests/test_toolkits.py
+++ b/openforcefield/tests/test_toolkits.py
@@ -21,7 +21,7 @@ import pytest
 from openforcefield.utils.toolkits import (OpenEyeToolkitWrapper, RDKitToolkitWrapper,
                                            AmberToolsToolkitWrapper, ToolkitRegistry,
                                            GAFFAtomTypeWarning, UndefinedStereochemistryError)
-from openforcefield.utils import get_data_filename
+from openforcefield.utils import get_data_file_path
 from openforcefield.topology.molecule import Molecule
 
 
@@ -215,7 +215,7 @@ class TestOpenEyeToolkitWrapper:
     def test_get_sdf_coordinates(self):
         """Test OpenEyeToolkitWrapper for importing a single set of coordinates from a sdf file"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        filename = get_data_filename('molecules/toluene.sdf')
+        filename = get_data_file_path('molecules/toluene.sdf')
         molecule = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule._conformers) == 1
         assert molecule._conformers[0].shape == (15,3)
@@ -226,7 +226,7 @@ class TestOpenEyeToolkitWrapper:
         """Test OpenEyeToolkitWrapper for importing multiple sets of coordinates from a sdf file"""
         raise NotImplementedError
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        filename = get_data_filename('molecules/toluene.sdf')
+        filename = get_data_file_path('molecules/toluene.sdf')
         molecule = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule._conformers) == 1
         assert molecule._conformers[0].shape == (15,3)
@@ -235,7 +235,7 @@ class TestOpenEyeToolkitWrapper:
     def test_get_mol2_coordinates(self):
         """Test OpenEyeToolkitWrapper for importing a single set of molecule coordinates"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        filename = get_data_filename('molecules/toluene.mol2')
+        filename = get_data_file_path('molecules/toluene.mol2')
         molecule1 = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule1._conformers) == 1
         assert molecule1._conformers[0].shape == (15, 3)
@@ -262,7 +262,7 @@ class TestOpenEyeToolkitWrapper:
     def test_get_mol2_charges(self):
         """Test OpenEyeToolkitWrapper for importing a mol2 file specifying partial charges"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        filename = get_data_filename('molecules/toluene_charged.mol2')
+        filename = get_data_file_path('molecules/toluene_charged.mol2')
         molecule = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule._conformers) == 1
         assert molecule._conformers[0].shape == (15,3)
@@ -280,7 +280,7 @@ class TestOpenEyeToolkitWrapper:
     def test_get_mol2_gaff_atom_types(self):
         """Test that a warning is raised OpenEyeToolkitWrapper when it detects GAFF atom types in a mol2 file."""
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        mol2_file_path = get_data_filename('molecules/AlkEthOH_test_filt1_ff.mol2')
+        mol2_file_path = get_data_file_path('molecules/AlkEthOH_test_filt1_ff.mol2')
         with pytest.warns(GAFFAtomTypeWarning, match='SYBYL'):
             Molecule.from_file(mol2_file_path, toolkit_registry=toolkit_wrapper)
 
@@ -593,7 +593,7 @@ class TestRDKitToolkitWrapper:
     def test_get_sdf_coordinates(self):
         """Test RDKitToolkitWrapper for importing a single set of coordinates from a sdf file"""
         toolkit_wrapper = RDKitToolkitWrapper()
-        filename = get_data_filename('molecules/toluene.sdf')
+        filename = get_data_file_path('molecules/toluene.sdf')
         molecule = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule._conformers) == 1
         assert molecule._conformers[0].shape == (15, 3)
@@ -606,7 +606,7 @@ class TestRDKitToolkitWrapper:
         """Test RDKitToolkitWrapper for importing a single set of coordinates from a sdf file"""
         raise NotImplementedError
         toolkit_wrapper = RDKitToolkitWrapper()
-        filename = get_data_filename('molecules/toluene.sdf')
+        filename = get_data_file_path('molecules/toluene.sdf')
         molecule = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule._conformers) == 1
         assert molecule._conformers[0].shape == (15,3)
@@ -617,7 +617,7 @@ class TestRDKitToolkitWrapper:
     def test_get_pdb_coordinates(self):
         """Test RDKitToolkitWrapper for importing a single set of coordinates from a pdb file"""
         toolkit_wrapper = RDKitToolkitWrapper()
-        filename = get_data_filename('molecules/toluene.pdb')
+        filename = get_data_file_path('molecules/toluene.pdb')
         molecule = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule._conformers) == 1
         assert molecule._conformers[0].shape == (15,3)
@@ -628,7 +628,7 @@ class TestRDKitToolkitWrapper:
     def test_load_aromatic_pdb(self):
         """Test OpenEyeToolkitWrapper for importing molecule conformers"""
         toolkit_wrapper = RDKitToolkitWrapper()
-        filename = get_data_filename('molecules/toluene.pdb')
+        filename = get_data_file_path('molecules/toluene.pdb')
         molecule = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule._conformers) == 1
         assert molecule._conformers[0].shape == (15,3)

--- a/openforcefield/tests/test_topology.py
+++ b/openforcefield/tests/test_topology.py
@@ -20,7 +20,7 @@ import numpy as np
 from simtk import unit
 from openforcefield.utils import (BASIC_CHEMINFORMATICS_TOOLKITS, RDKIT_AVAILABLE, OPENEYE_AVAILABLE,
                                   RDKitToolkitWrapper, OpenEyeToolkitWrapper)
-from openforcefield.tests.utils import get_data_filename
+from openforcefield.tests.utils import get_data_file_path
 from openforcefield.topology import Topology, ValenceDict, ImproperDict, DuplicateUniqueMoleculeError
 from openforcefield.topology import Molecule
 
@@ -83,10 +83,10 @@ class TestTopology(TestCase):
         self.ethene_from_smiles = Molecule.from_smiles('C=C')
         self.propane_from_smiles = Molecule.from_smiles('CCC')
 
-        filename = get_data_filename('molecules/toluene.sdf')
+        filename = get_data_file_path('molecules/toluene.sdf')
         self.toluene_from_sdf = Molecule.from_file(filename)
         if OpenEyeToolkitWrapper.is_available():
-            filename = get_data_filename('molecules/toluene_charged.mol2')
+            filename = get_data_file_path('molecules/toluene_charged.mol2')
             # TODO: This will require openeye to load
             self.toluene_from_charged_mol2 = Molecule.from_file(filename)
         self.charged_methylamine_from_smiles = Molecule.from_smiles('[H]C([H])([H])[N+]([H])([H])[H]')
@@ -401,7 +401,7 @@ class TestTopology(TestCase):
     def test_from_openmm(self):
         """Test creation of an openforcefield Topology object from an OpenMM Topology and component molecules"""
         from simtk.openmm import app
-        pdbfile = app.PDBFile(get_data_filename('systems/packmol_boxes/cyclohexane_ethanol_0.4_0.6.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/packmol_boxes/cyclohexane_ethanol_0.4_0.6.pdb'))
 
         molecules = []
         molecules.append(Molecule.from_smiles('CCO'))
@@ -465,9 +465,9 @@ class TestTopology(TestCase):
     def test_from_openmm_duplicate_unique_mol(self):
         """Check that a DuplicateUniqueMoleculeError is raised if we try to pass in two indistinguishably unique mols"""
         from simtk.openmm import app
-        pdbfile = app.PDBFile(get_data_filename('systems/packmol_boxes/cyclohexane_ethanol_0.4_0.6.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/packmol_boxes/cyclohexane_ethanol_0.4_0.6.pdb'))
         #toolkit_wrapper = RDKitToolkitWrapper()
-        molecules = [ Molecule.from_file(get_data_filename(name)) for name in ('molecules/ethanol.mol2',
+        molecules = [ Molecule.from_file(get_data_file_path(name)) for name in ('molecules/ethanol.mol2',
                                                                                'molecules/ethanol_reordered.mol2',
                                                                                'molecules/cyclohexane.mol2')]
         with self.assertRaises(DuplicateUniqueMoleculeError) as context:
@@ -485,9 +485,9 @@ class TestTopology(TestCase):
         """Test Topology.chemical_environment_matches"""
         from simtk.openmm import app
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        pdbfile = app.PDBFile(get_data_filename('systems/packmol_boxes/cyclohexane_ethanol_0.4_0.6.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/packmol_boxes/cyclohexane_ethanol_0.4_0.6.pdb'))
         # toolkit_wrapper = RDKitToolkitWrapper()
-        molecules = [Molecule.from_file(get_data_filename(name)) for name in ('molecules/ethanol.mol2',
+        molecules = [Molecule.from_file(get_data_file_path(name)) for name in ('molecules/ethanol.mol2',
                                                                               'molecules/cyclohexane.mol2')]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         # Test for substructure match
@@ -507,9 +507,9 @@ class TestTopology(TestCase):
         """Test Topology.chemical_environment_matches"""
         from simtk.openmm import app
         toolkit_wrapper = RDKitToolkitWrapper()
-        pdbfile = app.PDBFile(get_data_filename('systems/packmol_boxes/cyclohexane_ethanol_0.4_0.6.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path('systems/packmol_boxes/cyclohexane_ethanol_0.4_0.6.pdb'))
         # toolkit_wrapper = RDKitToolkitWrapper()
-        #molecules = [Molecule.from_file(get_data_filename(name)) for name in ('molecules/ethanol.mol2',
+        #molecules = [Molecule.from_file(get_data_file_path(name)) for name in ('molecules/ethanol.mol2',
         #                                                                      'molecules/cyclohexane.mol2')]
         molecules = []
         molecules.append(Molecule.from_smiles('CCO'))

--- a/openforcefield/tests/test_utils.py
+++ b/openforcefield/tests/test_utils.py
@@ -70,10 +70,10 @@ def test_temporary_directory():
     assert not os.path.exists(tmp_dir), "Temporary directory was not automatically cleaned up."
     assert not os.path.exists(output_filename), "Temporary directory was not automatically cleaned up."
 
-def test_get_data_filename():
-    """Test get_data_filename()"""
-    from openforcefield.utils import get_data_filename
-    filename = get_data_filename('forcefield/tip3p.offxml')
+def test_get_data_file_path():
+    """Test get_data_file_path()"""
+    from openforcefield.utils import get_data_file_path
+    filename = get_data_file_path('forcefield/tip3p.offxml')
     assert os.path.exists(filename)
 
 

--- a/openforcefield/tests/test_utils_serialization.py
+++ b/openforcefield/tests/test_utils_serialization.py
@@ -138,8 +138,8 @@ class TestUtilsSMIRNOFFSerialization(TestUtilsSerialization):
         cls.thing = Thing('blorb', [1, 2, 3])
         # Create an example object holding the SMIRNOFF xmltodict dictionary representation
         import xmltodict
-        from openforcefield.utils import get_data_filename
-        filename = get_data_filename('forcefield/smirnoff99Frosst.offxml')
+        from openforcefield.utils import get_data_file_path
+        filename = get_data_file_path('forcefield/smirnoff99Frosst.offxml')
         with open(filename, 'r') as f:
             xml = f.read()
             dictionary = xmltodict.parse(xml)

--- a/openforcefield/tests/test_utils_structure.py
+++ b/openforcefield/tests/test_utils_structure.py
@@ -62,16 +62,16 @@ class TestUtilsStructure:
 @requires_openeye_mol2
 def test_merge_system():
     """Test merging of a system created from AMBER and another created from SMIRNOFF."""
-    from .utils import create_system_from_amber, get_amber_filepath, get_alkethoh_filepath
+    from .utils import create_system_from_amber, get_amber_file_path, get_alkethoh_file_path
 
     # Create System from AMBER
-    prmtop_filename, inpcrd_filename = get_amber_filepath('cyclohexane_ethanol_0.4_0.6')
+    prmtop_filename, inpcrd_filename = get_amber_file_path('cyclohexane_ethanol_0.4_0.6')
     system0, topology0, positions0 = create_system_from_amber(prmtop_filename, inpcrd_filename)
 
     # TODO:
     from openeye import oechem
     # Load simple OEMol
-    alkethoh_mol2_filepath = get_alkethoh_filepath('AlkEthOH_c100')[0]
+    alkethoh_mol2_filepath = get_alkethoh_file_path('AlkEthOH_c100')[0]
     ifs = oechem.oemolistream(alkethoh_mol2_filepath)
     mol = oechem.OEMol()
     flavor = oechem.OEIFlavor_Generic_Default | oechem.OEIFlavor_MOL2_Default | oechem.OEIFlavor_MOL2_Forcefield
@@ -99,7 +99,7 @@ def test_component_combination():
     """Test that a system still yields the same energy after rebuilding it out of its components
     """
     from simtk import openmm
-    from .utils import compare_system_energies, get_packmol_pdbfile
+    from .utils import compare_system_energies, get_packmol_pdb_file_path
 
     # We've had issues where subsequent instances of a molecule might have zero charges
     # Here we'll try to catch this (and also explicitly check the charges) by re-building
@@ -108,7 +108,7 @@ def test_component_combination():
     # Create an OpenMM System from mol2 files containing a cyclohexane-ethanol mixture.
     AlkEthOH_offxml_filename = utils.get_data_file_path('forcefield/Frosst_AlkEthOH.offxml')
     forcefield = ForceField(AlkEthOH_offxml_filename)
-    pdbfile = openmm.app.PDBFile(get_packmol_pdbfile('cyclohexane_ethanol_0.4_0.6'))
+    pdbfile = openmm.app.PDBFile(get_packmol_pdb_file_path('cyclohexane_ethanol_0.4_0.6'))
     sdf_file_paths = [utils.get_data_file_path(os.path.join('systems', 'monomers', name+'.sdf'))
                       for name in ('ethanol', 'cyclohexane')]
     molecules = [Molecule.from_file(file_path) for file_path in sdf_file_paths]

--- a/openforcefield/tests/test_utils_structure.py
+++ b/openforcefield/tests/test_utils_structure.py
@@ -53,7 +53,7 @@ class TestUtilsStructure:
 
     def test_protein_structure(self):
         from simtk.openmm import app
-        pdbfile = utils.get_data_filename('proteins/T4-protein.pdb')
+        pdbfile = utils.get_data_file_path('proteins/T4-protein.pdb')
         proteinpdb = app.PDBFile(pdbfile)
         protein_structure = structure.generateProteinStructure(proteinpdb)
         assert isinstance(protein_structure, parmed.structure.Structure)
@@ -80,7 +80,7 @@ def test_merge_system():
     oechem.OETriposAtomNames(mol)
 
     # Load forcefield file.
-    AlkEthOH_offxml_filename = utils.get_data_filename('forcefield/Frosst_AlkEthOH.offxml')
+    AlkEthOH_offxml_filename = utils.get_data_file_path('forcefield/Frosst_AlkEthOH.offxml')
     forcefield = ForceField(AlkEthOH_offxml_filename)
 
     # Create OpenMM System and Topology.
@@ -106,10 +106,10 @@ def test_component_combination():
     # a system out of its components
 
     # Create an OpenMM System from mol2 files containing a cyclohexane-ethanol mixture.
-    AlkEthOH_offxml_filename = utils.get_data_filename('forcefield/Frosst_AlkEthOH.offxml')
+    AlkEthOH_offxml_filename = utils.get_data_file_path('forcefield/Frosst_AlkEthOH.offxml')
     forcefield = ForceField(AlkEthOH_offxml_filename)
     pdbfile = openmm.app.PDBFile(get_packmol_pdbfile('cyclohexane_ethanol_0.4_0.6'))
-    sdf_file_paths = [utils.get_data_filename(os.path.join('systems', 'monomers', name+'.sdf'))
+    sdf_file_paths = [utils.get_data_file_path(os.path.join('systems', 'monomers', name+'.sdf'))
                       for name in ('ethanol', 'cyclohexane')]
     molecules = [Molecule.from_file(file_path) for file_path in sdf_file_paths]
     topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)

--- a/openforcefield/tests/utils.py
+++ b/openforcefield/tests/utils.py
@@ -24,7 +24,7 @@ import textwrap
 import numpy as np
 from simtk import unit, openmm
 
-from openforcefield.utils import get_data_filename
+from openforcefield.utils import get_data_file_path
 
 
 #=============================================================================================
@@ -49,8 +49,8 @@ def get_amber_filepath(prefix):
 
     """
     prefix = os.path.join('systems', 'amber', prefix)
-    prmtop_filepath = get_data_filename(prefix+'.prmtop')
-    inpcrd_filepath = get_data_filename(prefix+'.inpcrd')
+    prmtop_filepath = get_data_file_path(prefix+'.prmtop')
+    inpcrd_filepath = get_data_file_path(prefix+'.inpcrd')
     return prmtop_filepath, inpcrd_filepath
 
 
@@ -68,7 +68,7 @@ def get_packmol_pdbfile(prefix='cyclohexane_ethanol_0.4_0.6'):
         Absolute path to the PDB file
     """
     prefix = os.path.join('systems', 'packmol_boxes', prefix)
-    pdb_filename = get_data_filename(prefix+'.pdb')
+    pdb_filename = get_data_file_path(prefix+'.pdb')
     return pdb_filename
 
 
@@ -87,7 +87,7 @@ def get_monomer_mol2file(prefix='ethanol'):
     """
     # TODO: The mol2 files in this folder are not tripos mol2 files. Delete or convert them.
     prefix = os.path.join('systems', 'monomers', prefix)
-    mol2_filename = get_data_filename(prefix + '.mol2')
+    mol2_filename = get_data_file_path(prefix + '.mol2')
     return mol2_filename
 
 
@@ -96,7 +96,7 @@ def extract_compressed_molecules(tar_file_name, file_subpaths=None, filter_func=
         raise ValueError('Only one between file_subpaths and filter_func must be specified.')
 
     # Find the path of the tarfile with respect to the data/molecules/ folder.
-    molecules_dir_path = get_data_filename('molecules')
+    molecules_dir_path = get_data_file_path('molecules')
     tar_file_path = os.path.join(molecules_dir_path, tar_file_name)
     tar_root_dir_name = tar_file_name.split('.')[0]
 

--- a/openforcefield/tests/utils.py
+++ b/openforcefield/tests/utils.py
@@ -225,9 +225,9 @@ def create_system_from_amber(prmtop_file_path, inpcrd_file_path, *args, **kwargs
         Initial positions loaded from the inpcrd or restart file.
 
     """
-    prmtop_file = openmm.app.AmberPrmtopFile(prmtop_filepath)
+    prmtop_file = openmm.app.AmberPrmtopFile(prmtop_file_path)
     # AmberInpcrdFile parses also rst7 files.
-    inpcrd_file = openmm.app.AmberInpcrdFile(inpcrd_filepath)
+    inpcrd_file = openmm.app.AmberInpcrdFile(inpcrd_file_path)
     # Create system and update box vectors (if needed)
     system = prmtop_file.createSystem(*args, **kwargs)
     if inpcrd_file.boxVectors is not None:

--- a/openforcefield/tests/utils.py
+++ b/openforcefield/tests/utils.py
@@ -31,7 +31,7 @@ from openforcefield.utils import get_data_file_path
 # Shortcut functions to get file paths to test data.
 #=============================================================================================
 
-def get_amber_filepath(prefix):
+def get_amber_file_path(prefix):
     """Get AMBER prmtop and inpcrd test data filepaths.
 
     Parameters
@@ -54,7 +54,7 @@ def get_amber_filepath(prefix):
     return prmtop_filepath, inpcrd_filepath
 
 
-def get_packmol_pdbfile(prefix='cyclohexane_ethanol_0.4_0.6'):
+def get_packmol_pdb_file_path(prefix='cyclohexane_ethanol_0.4_0.6'):
     """Get PDB filename for a packmol-generated box
 
     Parameters
@@ -72,7 +72,7 @@ def get_packmol_pdbfile(prefix='cyclohexane_ethanol_0.4_0.6'):
     return pdb_filename
 
 
-def get_monomer_mol2file(prefix='ethanol'):
+def get_monomer_mol2_file_path(prefix='ethanol'):
     """Get absolute filepath for a mol2 file denoting a small molecule monomer in testdata
 
     Parameters
@@ -152,7 +152,7 @@ def extract_compressed_molecules(tar_file_name, file_subpaths=None, filter_func=
     return extracted_file_paths
 
 
-def get_alkethoh_filepath(alkethoh_name, get_amber=False):
+def get_alkethoh_file_path(alkethoh_name, get_amber=False):
     """Retrieve the mol2, top and crd files of a molecule in the AlkEthOH set.
 
     Parameters
@@ -187,7 +187,7 @@ def get_alkethoh_filepath(alkethoh_name, get_amber=False):
     return extract_compressed_molecules('AlkEthOH_tripos.tar.gz', file_subpaths=file_subpaths)
 
 
-def get_freesolv_filepath(freesolv_id, ff_version):
+def get_freesolv_file_path(freesolv_id, ff_version):
     file_base_name = 'mobley_' + freesolv_id
     mol2_file_subpath = os.path.join('mol2files_sybyl', file_base_name + '.mol2')
     xml_dir = 'xml_' + ff_version.replace('.', '_')
@@ -202,14 +202,14 @@ def get_freesolv_filepath(freesolv_id, ff_version):
 # Shortcut functions to create System objects from system files.
 #=============================================================================================
 
-def create_system_from_amber(prmtop_filepath, inpcrd_filepath, *args, **kwargs):
+def create_system_from_amber(prmtop_file_path, inpcrd_file_path, *args, **kwargs):
     """Create an OpenMM System and Topology from the AMBER files.
 
     Parameters
     ----------
-    prmtop_filepath : str
+    prmtop_file_path : str
         Path to the topology/parameter file in AMBER prmtop format.
-    inpcrd_filepath : str
+    inpcrd_file_path : str
         Path to the coordinates file in AMBER inpcrd or rst7 format.
     *args
     **kwargs
@@ -1238,7 +1238,7 @@ def compare_system_parameters(system1, system2, systems_labels=None,
 # Utility functions to compare SMIRNOFF and AMBER force fields.
 #=============================================================================================
 
-def compare_amber_smirnoff(prmtop_filepath, inpcrd_filepath, forcefield, molecule,
+def compare_amber_smirnoff(prmtop_file_path, inpcrd_file_path, forcefield, molecule,
                            check_parameters=True, check_energies=True, **kwargs):
     """
     Compare energies and parameters for OpenMM Systems/topologies created
@@ -1247,9 +1247,9 @@ def compare_amber_smirnoff(prmtop_filepath, inpcrd_filepath, forcefield, molecul
 
     Parameters
     ----------
-    prmtop_filepath : str
+    prmtop_file_path : str
         Path to the topology/parameter file in AMBER prmtop format
-    inpcrd_filepath : str
+    inpcrd_file_path : str
         Path to the coordinates file in AMBER inpcrd or rst7 format
     forcefield : ForceField
         Force field instance used to create the system to compare.

--- a/openforcefield/tests/utils.py
+++ b/openforcefield/tests/utils.py
@@ -1293,7 +1293,7 @@ def compare_amber_smirnoff(prmtop_file_path, inpcrd_file_path, forcefield, molec
     # Create System from AMBER files. By default, contrarily to ForceField,
     # systems from AMBER files are created with removeCMMotion=True
     amber_system, openmm_topology, positions = create_system_from_amber(
-        prmtop_filepath, inpcrd_filepath, removeCMMotion=False)
+        prmtop_file_path, inpcrd_file_path, removeCMMotion=False)
     box_vectors = amber_system.getDefaultPeriodicBoxVectors()
 
     # Create System from forcefield.

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -1916,7 +1916,7 @@ class FrozenMolecule(Serializable):
 
     def generate_conformers(self,
                             toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
-                            num_conformers=10,
+                            n_conformers=10,
                             clear_existing=True):
         """
         Generate conformers for this molecule using an underlying toolkit
@@ -1925,7 +1925,7 @@ class FrozenMolecule(Serializable):
         ----------
         toolkit_registry : openforcefield.utils.toolkits.ToolRegistry or openforcefield.utils.toolkits.ToolkitWrapper, optional, default=None
             :class:`ToolkitRegistry` or :class:`ToolkitWrapper` to use for SMILES-to-molecule conversion
-        num_conformers : int, default=1
+        n_conformers : int, default=1
             The maximum number of conformers to produce
         clear_existing : bool, default=True
             Whether to overwrite existing conformers for the molecule
@@ -1943,11 +1943,11 @@ class FrozenMolecule(Serializable):
 
         """
         if isinstance(toolkit_registry, ToolkitRegistry):
-            return toolkit_registry.call('generate_conformers', self, num_conformers=num_conformers,
+            return toolkit_registry.call('generate_conformers', self, n_conformers=n_conformers,
                                          clear_existing=clear_existing)
         elif isinstance(toolkit_registry, ToolkitWrapper):
             toolkit = toolkit_registry
-            return toolkit.generate_conformers(self, num_conformers=num_conformers, clear_existing=clear_existing)
+            return toolkit.generate_conformers(self, n_conformers=n_conformers, clear_existing=clear_existing)
         else:
             raise InvalidToolkitError(
                 'Invalid toolkit_registry passed to generate_conformers. Expected ToolkitRegistry or ToolkitWrapper. Got  {}'

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -1364,8 +1364,8 @@ class FrozenMolecule(Serializable):
 
     Create a molecule from a sdf file
 
-    >>> from openforcefield.utils import get_data_filename
-    >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+    >>> from openforcefield.utils import get_data_file_path
+    >>> sdf_filepath = get_data_file_path('molecules/ethanol.sdf')
     >>> molecule = FrozenMolecule.from_file(sdf_filepath)
 
     Convert to OpenEye OEMol object
@@ -1444,13 +1444,13 @@ class FrozenMolecule(Serializable):
         Create a molecule from a file that can be used to construct a molecule,
         using either a filename or file-like object:
 
-        >>> from openforcefield.utils import get_data_filename
-        >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+        >>> from openforcefield.utils import get_data_file_path
+        >>> sdf_filepath = get_data_file_path('molecules/ethanol.sdf')
         >>> molecule = FrozenMolecule(sdf_filepath)
         >>> molecule = FrozenMolecule(open(sdf_filepath, 'r'), file_format='sdf')
 
         >>> import gzip
-        >>> mol2_gz_filepath = get_data_filename('molecules/toluene.mol2.gz')
+        >>> mol2_gz_filepath = get_data_file_path('molecules/toluene.mol2.gz')
         >>> molecule = FrozenMolecule(gzip.GzipFile(mol2_gz_filepath, 'r'), file_format='mol2')
 
         Create a molecule from another molecule:
@@ -1807,8 +1807,8 @@ class FrozenMolecule(Serializable):
         Examples
         --------
 
-        >>> from openforcefield.utils import get_data_filename
-        >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+        >>> from openforcefield.utils import get_data_file_path
+        >>> sdf_filepath = get_data_file_path('molecules/ethanol.sdf')
         >>> molecule = Molecule(sdf_filepath)
         >>> smiles = molecule.to_smiles()
 
@@ -2788,8 +2788,8 @@ class FrozenMolecule(Serializable):
         Examples
         --------
 
-        >>> from openforcefield.utils import get_data_filename
-        >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+        >>> from openforcefield.utils import get_data_file_path
+        >>> sdf_filepath = get_data_file_path('molecules/ethanol.sdf')
         >>> molecule = Molecule(sdf_filepath)
         >>> iupac_name = molecule.to_iupac()
 
@@ -3055,8 +3055,8 @@ class FrozenMolecule(Serializable):
         Create a molecule from an RDKit molecule
 
         >>> from rdkit import Chem
-        >>> from openforcefield.tests.utils import get_data_filename
-        >>> rdmol = Chem.MolFromMolFile(get_data_filename('systems/monomers/ethanol.sdf'))
+        >>> from openforcefield.tests.utils import get_data_file_path
+        >>> rdmol = Chem.MolFromMolFile(get_data_file_path('systems/monomers/ethanol.sdf'))
         >>> molecule = Molecule.from_rdkit(rdmol)
 
         """
@@ -3086,8 +3086,8 @@ class FrozenMolecule(Serializable):
 
         Convert a molecule to RDKit
 
-        >>> from openforcefield.utils import get_data_filename
-        >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+        >>> from openforcefield.utils import get_data_file_path
+        >>> sdf_filepath = get_data_file_path('molecules/ethanol.sdf')
         >>> molecule = Molecule(sdf_filepath)
         >>> rdmol = molecule.to_rdkit()
 
@@ -3121,8 +3121,8 @@ class FrozenMolecule(Serializable):
         Create a Molecule from an OpenEye OEMol
 
         >>> from openeye import oechem
-        >>> from openforcefield.tests.utils import get_data_filename
-        >>> ifs = oechem.oemolistream(get_data_filename('systems/monomers/ethanol.mol2'))
+        >>> from openforcefield.tests.utils import get_data_file_path
+        >>> ifs = oechem.oemolistream(get_data_file_path('systems/monomers/ethanol.mol2'))
         >>> oemols = list(ifs.GetOEGraphMols())
         >>> molecule = Molecule.from_openeye(oemols[0])
 
@@ -3317,8 +3317,8 @@ class Molecule(FrozenMolecule):
 
     Create a molecule from an sdf file
 
-    >>> from openforcefield.utils import get_data_filename
-    >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+    >>> from openforcefield.utils import get_data_file_path
+    >>> sdf_filepath = get_data_file_path('molecules/ethanol.sdf')
     >>> molecule = Molecule(sdf_filepath)
 
     Convert to OpenEye OEMol object
@@ -3375,13 +3375,13 @@ class Molecule(FrozenMolecule):
         Create a molecule from a file that can be used to construct a molecule,
         using either a filename or file-like object:
 
-        >>> from openforcefield.utils import get_data_filename
-        >>> sdf_filepath = get_data_filename('molecules/ethanol.sdf')
+        >>> from openforcefield.utils import get_data_file_path
+        >>> sdf_filepath = get_data_file_path('molecules/ethanol.sdf')
         >>> molecule = Molecule(sdf_filepath)
         >>> molecule = Molecule(open(sdf_filepath, 'r'), file_format='sdf')
 
         >>> import gzip
-        >>> mol2_gz_filepath = get_data_filename('molecules/toluene.mol2.gz')
+        >>> mol2_gz_filepath = get_data_file_path('molecules/toluene.mol2.gz')
         >>> molecule = Molecule(gzip.GzipFile(mol2_gz_filepath, 'r'), file_format='mol2')
 
         Create a molecule from another molecule:

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -2886,8 +2886,8 @@ class FrozenMolecule(Serializable):
 
         Examples
         --------
-        >>> from openforcefield.tests.utils import get_monomer_mol2file
-        >>> mol2_filename = get_monomer_mol2file('cyclohexane')
+        >>> from openforcefield.tests.utils import get_monomer_mol2_file_path
+        >>> mol2_filename = get_monomer_mol2_file_path('cyclohexane')
         >>> molecule = Molecule.from_file(mol2_filename)
 
         """

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -895,8 +895,8 @@ class Topology(Serializable):
     Import some utilities
 
     >>> from simtk.openmm import app
-    >>> from openforcefield.tests.utils import get_data_file_path, get_packmol_pdbfile
-    >>> pdb_filepath = get_packmol_pdbfile('cyclohexane_ethanol_0.4_0.6')
+    >>> from openforcefield.tests.utils import get_data_file_path, get_packmol_pdb_file_path
+    >>> pdb_filepath = get_packmol_pdb_file_path('cyclohexane_ethanol_0.4_0.6')
     >>> monomer_names = ('cyclohexane', 'ethanol')
 
     Create a Topology object from a PDB file and sdf files defining the molecular contents

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -895,7 +895,7 @@ class Topology(Serializable):
     Import some utilities
 
     >>> from simtk.openmm import app
-    >>> from openforcefield.tests.utils import get_data_filename, get_packmol_pdbfile
+    >>> from openforcefield.tests.utils import get_data_file_path, get_packmol_pdbfile
     >>> pdb_filepath = get_packmol_pdbfile('cyclohexane_ethanol_0.4_0.6')
     >>> monomer_names = ('cyclohexane', 'ethanol')
 
@@ -903,7 +903,7 @@ class Topology(Serializable):
 
     >>> from openforcefield.topology import Molecule, Topology
     >>> pdbfile = app.PDBFile(pdb_filepath)
-    >>> sdf_filepaths = [get_data_filename(f'systems/monomers/{name}.sdf') for name in monomer_names]
+    >>> sdf_filepaths = [get_data_file_path(f'systems/monomers/{name}.sdf') for name in monomer_names]
     >>> unique_molecules = [Molecule.from_file(sdf_filepath) for sdf_filepath in sdf_filepaths]
     >>> topology = Topology.from_openmm(pdbfile.topology, unique_molecules=unique_molecules)
 

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -191,7 +191,7 @@ class ForceField:
                  parameter_handler_classes=None,
                  parameter_io_handler_classes=None,
                  disable_version_check=False,
-                 permit_cosmetic_attributes=False):
+                 allow_cosmetic_attributes=False):
         """Create a new :class:`ForceField` object from one or more SMIRNOFF parameter definition files.
 
         Parameters
@@ -213,7 +213,7 @@ class ForceField:
         disable_version_check : bool, optional, default=False
             If True, will disable checks against the current highest supported forcefield version.
             This option is primarily intended for forcefield development.
-        permit_cosmetic_attributes : bool, optional. Default = False
+        allow_cosmetic_attributes : bool, optional. Default = False
             Whether to retain non-spec kwargs from data sources.
 
         Examples
@@ -255,7 +255,7 @@ class ForceField:
             parameter_io_handler_classes)
 
         # Parse all sources containing SMIRNOFF parameter definitions
-        self.parse_sources(sources, permit_cosmetic_attributes=permit_cosmetic_attributes)
+        self.parse_sources(sources, allow_cosmetic_attributes=allow_cosmetic_attributes)
 
     def _initialize(self):
         """
@@ -503,7 +503,7 @@ class ForceField:
             raise Exception(
                 msg)  # TODO: Should we raise a more specific exception here?
 
-    def get_parameter_handler(self, tagname, handler_kwargs=None, permit_cosmetic_attributes=False):
+    def get_parameter_handler(self, tagname, handler_kwargs=None, allow_cosmetic_attributes=False):
         """Retrieve the parameter handlers associated with the provided tagname.
 
         If the parameter handler has not yet been instantiated, it will be created and returned.
@@ -518,7 +518,7 @@ class ForceField:
         handler_kwargs : dict, optional. Default = None
             Dict to be passed to the handler for construction or checking compatibility. If None, will be assumed
             to represent handler defaults.
-        permit_cosmetic_attributes : bool, optional. Default = False
+        allow_cosmetic_attributes : bool, optional. Default = False
             Whether to permit non-spec kwargs in smirnoff_data.
 
         Returns
@@ -544,7 +544,7 @@ class ForceField:
 
         # Initialize a new instance of this parameter handler class with the given kwargs
         new_handler = ph_class(**handler_kwargs,
-                               permit_cosmetic_attributes=permit_cosmetic_attributes)
+                               allow_cosmetic_attributes=allow_cosmetic_attributes)
 
         if tagname in self._parameter_handlers:
             # If a handler of this class already exists, ensure that the two handlers encode compatible science
@@ -601,7 +601,7 @@ class ForceField:
         return io_handler
 
 
-    def parse_sources(self, sources, permit_cosmetic_attributes=True):
+    def parse_sources(self, sources, allow_cosmetic_attributes=True):
         """Parse a SMIRNOFF force field definition.
 
         Parameters
@@ -614,7 +614,7 @@ class ForceField:
             If multiple files are specified, any top-level tags that are repeated will be merged if they are compatible,
             with files appearing later in the sequence resulting in parameters that have higher precedence.
             Support for multiple files is primarily intended to allow solvent parameters to be specified by listing them last in the sequence.
-        permit_cosmetic_attributes : bool, optional. Default = False
+        allow_cosmetic_attributes : bool, optional. Default = False
             Whether to permit non-spec kwargs present in the source.
 
         .. notes ::
@@ -634,7 +634,7 @@ class ForceField:
         for source in sources:
             smirnoff_data = self.parse_smirnoff_from_source(source)
             self._load_smirnoff_data(smirnoff_data,
-                                     permit_cosmetic_attributes=permit_cosmetic_attributes)
+                                     allow_cosmetic_attributes=allow_cosmetic_attributes)
 
 
     def _to_smirnoff_data(self, discard_cosmetic_attributes=True):
@@ -667,7 +667,7 @@ class ForceField:
         return smirnoff_dict
 
     # TODO: Should we call this "from_dict"?
-    def _load_smirnoff_data(self, smirnoff_data, permit_cosmetic_attributes=False):
+    def _load_smirnoff_data(self, smirnoff_data, allow_cosmetic_attributes=False):
         """
         Add parameters from a SMIRNOFF-format data structure to this ForceField.
 
@@ -675,7 +675,7 @@ class ForceField:
         ----------
         smirnoff_data : OrderedDict
             A representation of a SMIRNOFF-format data structure. Begins at top-level 'SMIRNOFF' key.
-        permit_cosmetic_attributes : bool, optional. Default = False
+        allow_cosmetic_attributes : bool, optional. Default = False
             Whether to permit non-spec kwargs in smirnoff_data.
         """
 
@@ -723,9 +723,9 @@ class ForceField:
             # compatibility if a handler for this parameter name already exists
             handler = self.get_parameter_handler(parameter_name,
                                                  section_dict,
-                                                 permit_cosmetic_attributes=permit_cosmetic_attributes)
+                                                 allow_cosmetic_attributes=allow_cosmetic_attributes)
             handler._add_parameters(section_dict,
-                                    permit_cosmetic_attributes=permit_cosmetic_attributes)
+                                    allow_cosmetic_attributes=allow_cosmetic_attributes)
 
 
 

--- a/openforcefield/typing/engines/smirnoff/io.py
+++ b/openforcefield/typing/engines/smirnoff/io.py
@@ -91,12 +91,12 @@ class ParameterIOHandler:
         pass
         #self._forcefield = forcefield
 
-    def parse_file(self, filename):
+    def parse_file(self, file_path):
         """
 
         Parameters
         ----------
-        filename
+        file_path
 
         Returns
         -------
@@ -118,14 +118,14 @@ class ParameterIOHandler:
         """
         pass
 
-    def to_file(self, filename, smirnoff_data):
+    def to_file(self, file_path, smirnoff_data):
         """
         Write the current forcefield parameter set to a file.
 
         Parameters
         ----------
-        filename : str
-            The filename to write to.
+        file_path : str
+            The path to the file to write to.
         smirnoff_data : dict
             A dictionary structured in compliance with the SMIRNOFF spec
 
@@ -245,26 +245,26 @@ class XMLParameterIOHandler(ParameterIOHandler):
         except ExpatError as e:
             raise ParseError(e)
 
-    def to_file(self, filename, smirnoff_data):
+    def to_file(self, file_path, smirnoff_data):
         """Write the current forcefield parameter set to a file, autodetecting the type from the extension.
 
         Parameters
         ----------
-        filename : str
-            The name of the file to be written.
+        file_path : str
+            The path to the file to be written.
             The `.offxml` file extension must be present.
         smirnoff_data : dict
             A dict structured in compliance with the SMIRNOFF data spec.
 
         """
         xml_string = self.to_string(smirnoff_data)
-        (basename, extension) = os.path.splitext(filename)
+        (basename, extension) = os.path.splitext(file_path)
         if extension == '.offxml':
-            with open(filename, 'wb') as of:
+            with open(file_path, 'wb') as of:
                 of.write(xml_string)
         else:
             msg = "Cannot export forcefield parameters to file '{}'\n".format(
-                filename)
+                file_path)
             msg += 'Export to extension {} not implemented yet.\n'.format(
                 extension)
             msg += "Supported choices are: ['.offxml']"

--- a/openforcefield/typing/engines/smirnoff/io.py
+++ b/openforcefield/typing/engines/smirnoff/io.py
@@ -28,7 +28,7 @@ import os
 import xmltodict
 
 from simtk import unit
-from openforcefield.utils.utils import get_data_filename
+from openforcefield.utils.utils import get_data_file_path
 
 
 #=============================================================================================
@@ -207,7 +207,7 @@ class XMLParameterIOHandler(ParameterIOHandler):
         # This handles nonlocal filenames
         try:
             # Check if the file exists in the data/forcefield directory
-            temp_file = get_data_filename(os.path.join('forcefield', source))
+            temp_file = get_data_file_path(os.path.join('forcefield', source))
             data = open(temp_file).read()
             smirnoff_data = self.parse_string(data)
             return smirnoff_data

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -319,7 +319,7 @@ class ParameterType:
 
     # TODO: Can we provide some shared tools for returning settable/gettable attributes, and checking unit-bearing attributes?
 
-    def __init__(self, smirks=None, permit_cosmetic_attributes=False, **kwargs):
+    def __init__(self, smirks=None, allow_cosmetic_attributes=False, **kwargs):
         """
         Create a ParameterType
 
@@ -327,7 +327,7 @@ class ParameterType:
         ----------
         smirks : str
             The SMIRKS match for the provided parameter type.
-        permit_cosmetic_attributes : bool optional. Default = False
+        allow_cosmetic_attributes : bool optional. Default = False
             Whether to permit non-spec kwargs ("cosmetic attributes"). If True, non-spec kwargs will be stored as
             an attribute of this parameter which can be accessed and written out. Otherwise an exception will
             be raised.
@@ -427,13 +427,13 @@ class ParameterType:
                 setattr(self, key, val)
 
             # Handle all unknown kwargs as cosmetic so we can write them back out
-            elif permit_cosmetic_attributes:
+            elif allow_cosmetic_attributes:
                 self._COSMETIC_ATTRIBS.append(key)
                 setattr(self, key, val)
             else:
                 raise SMIRNOFFSpecError("Unexpected kwarg {} passed to {} constructor. If this is "
                                         "a desired cosmetic attribute, consider setting "
-                                        "'permit_cosmetic_attributes=True'".format({key: val}, self.__class__))
+                                        "'allow_cosmetic_attributes=True'".format({key: val}, self.__class__))
 
     @property
     def smirks(self):
@@ -549,13 +549,13 @@ class ParameterHandler:
     _SMIRNOFF_VERSION_DEPRECATED = None  # if deprecated, the first SMIRNOFF version number it is no longer used
 
 
-    def __init__(self, permit_cosmetic_attributes=False, **kwargs):
+    def __init__(self, allow_cosmetic_attributes=False, **kwargs):
         """
         Initialize a ParameterHandler, optionally with a list of parameters and other kwargs.
 
         Parameters
         ----------
-        permit_cosmetic_attributes : bool, optional. Default = False
+        allow_cosmetic_attributes : bool, optional. Default = False
             Whether to permit non-spec kwargs. If True, non-spec kwargs will be stored as attributes of this object
             and can be accessed and modified. Otherwise an exception will be raised if a non-spec kwarg is encountered.
         **kwargs : dict
@@ -635,7 +635,7 @@ class ParameterHandler:
                 attr_name = '_' + key
                 # TODO: create @property.setter here if attrib requires unit
                 setattr(self, attr_name, val)
-            elif permit_cosmetic_attributes:
+            elif allow_cosmetic_attributes:
                 self._COSMETIC_ATTRIBS.append(key)
                 attr_name = '_' + key
                 setattr(self, attr_name, val)
@@ -643,10 +643,10 @@ class ParameterHandler:
             else:
                 raise SMIRNOFFSpecError("Incompatible kwarg {} passed to {} constructor. If this is "
                                         "a desired cosmetic attribute, consider setting "
-                                        "'permit_cosmetic_attributes=True'".format(key, self.__class__))
+                                        "'allow_cosmetic_attributes=True'".format(key, self.__class__))
 
 
-    def _add_parameters(self, section_dict, permit_cosmetic_attributes=False):
+    def _add_parameters(self, section_dict, allow_cosmetic_attributes=False):
         """
         Extend the ParameterList in this ParameterHandler using a SMIRNOFF data source.
 
@@ -654,7 +654,7 @@ class ParameterHandler:
         ----------
         section_dict : dict
             The dict representation of a SMIRNOFF data source containing parameters to att to this ParameterHandler
-        permit_cosmetic_attributes : bool, optional. Default = False
+        allow_cosmetic_attributes : bool, optional. Default = False
             Whether to allow non-spec fields in section_dict. If True, non-spec kwargs will be stored as an
             attribute of the parameter. If False, non-spec kwargs will raise an exception.
 
@@ -678,7 +678,7 @@ class ParameterHandler:
             for unitless_param_dict in val:
                 param_dict = attach_units(unitless_param_dict, attached_units)
                 new_parameter = self._INFOTYPE(**param_dict,
-                                               permit_cosmetic_attributes=permit_cosmetic_attributes)
+                                               allow_cosmetic_attributes=allow_cosmetic_attributes)
                 self._parameters.append(new_parameter)
 
     @property

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -2024,7 +2024,7 @@ class ToolkitAM1BCCHandler(ParameterHandler):
             # If the molecule wasn't assigned parameters from a manually-input charge_mol, calculate them here
             if not(charges_from_charge_mol):
                 toolkit_registry = kwargs.get('toolkit_registry', GLOBAL_TOOLKIT_REGISTRY)
-                temp_mol.generate_conformers(num_conformers=10, toolkit_registry=toolkit_registry)
+                temp_mol.generate_conformers(n_conformers=10, toolkit_registry=toolkit_registry)
                 #temp_mol.compute_partial_charges(quantum_chemical_method=self._quantum_chemical_method,
                 #                                 partial_charge_method=self._partial_charge_method)
                 temp_mol.compute_partial_charges_am1bcc(toolkit_registry=toolkit_registry)
@@ -2250,7 +2250,7 @@ class ChargeIncrementModelHandler(ParameterHandler):
 
             # If the molecule wasn't assigned parameters from a manually-input charge_mol, calculate them here
             if not(charges_from_charge_mol):
-                temp_mol.generate_conformers(num_conformers=10)
+                temp_mol.generate_conformers(n_conformers=10)
                 temp_mol.compute_partial_charges(quantum_chemical_method=self._quantum_chemical_method,
                                                  partial_charge_method=self._partial_charge_method)
 

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -1055,7 +1055,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         molecule = self.from_openeye(oemol)
         return molecule
 
-    def generate_conformers(self, molecule, num_conformers=1, clear_existing=True):
+    def generate_conformers(self, molecule, n_conformers=1, clear_existing=True):
         """
         Generate molecule conformers using OpenEye Omega. 
 
@@ -1071,7 +1071,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         ---------
         molecule : a :class:`Molecule` 
             The molecule to generate conformers for.
-        num_conformers : int, default=1
+        n_conformers : int, default=1
             The maximum number of conformers to generate.
         clear_existing : bool, default=True
             Whether to overwrite existing conformers for the molecule
@@ -1080,7 +1080,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         from openeye import oeomega
         oemol = self.to_openeye(molecule)
         omega = oeomega.OEOmega()
-        omega.SetMaxConfs(num_conformers)
+        omega.SetMaxConfs(n_conformers)
         omega.SetCanonOrder(False)
         omega.SetSampleHydrogens(True)
         omega.SetEnergyWindow(15.0)  #unit?
@@ -1723,7 +1723,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
         return molecule
 
-    def generate_conformers(self, molecule, num_conformers=1, clear_existing=True):
+    def generate_conformers(self, molecule, n_conformers=1, clear_existing=True):
         """
         Generate molecule conformers using RDKit. 
 
@@ -1738,7 +1738,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         ---------
         molecule : a :class:`Molecule` 
             The molecule to generate conformers for.
-        num_conformers : int, default=1
+        n_conformers : int, default=1
             Maximum number of conformers to generate.
         clear_existing : bool, default=True
             Whether to overwrite existing conformers for the molecule.
@@ -1750,7 +1750,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         # TODO: This generates way more conformations than omega, given the same nConfs and RMS threshold. Is there some way to set an energy cutoff as well?
         AllChem.EmbedMultipleConfs(
             rdmol,
-            numConfs=num_conformers,
+            numConfs=n_conformers,
             pruneRmsThresh=1.0,
             randomSeed=1,
             #params=AllChem.ETKDG()

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -397,8 +397,8 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         Load a mol2 file into an OpenFF ``Molecule`` object.
 
-        >>> from openforcefield.utils import get_data_filename
-        >>> mol2_file_path = get_data_filename('molecules/cyclohexane.mol2')
+        >>> from openforcefield.utils import get_data_file_path
+        >>> mol2_file_path = get_data_file_path('molecules/cyclohexane.mol2')
         >>> toolkit = OpenEyeToolkitWrapper()
         >>> molecule = toolkit.from_file(mol2_file_path, file_format='mol2')
 
@@ -678,8 +678,8 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         Create a Molecule from an OpenEye OEMol
 
         >>> from openeye import oechem
-        >>> from openforcefield.tests.utils import get_data_filename
-        >>> ifs = oechem.oemolistream(get_data_filename('systems/monomers/ethanol.mol2'))
+        >>> from openforcefield.tests.utils import get_data_file_path
+        >>> ifs = oechem.oemolistream(get_data_file_path('systems/monomers/ethanol.mol2'))
         >>> oemols = list(ifs.GetOEGraphMols())
 
         >>> toolkit_wrapper = OpenEyeToolkitWrapper()
@@ -1789,8 +1789,8 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         Create a molecule from an RDKit molecule
 
         >>> from rdkit import Chem
-        >>> from openforcefield.tests.utils import get_data_filename
-        >>> rdmol = Chem.MolFromMolFile(get_data_filename('systems/monomers/ethanol.sdf'))
+        >>> from openforcefield.tests.utils import get_data_file_path
+        >>> rdmol = Chem.MolFromMolFile(get_data_file_path('systems/monomers/ethanol.sdf'))
 
         >>> toolkit_wrapper = RDKitToolkitWrapper()
         >>> molecule = toolkit_wrapper.from_rdkit(rdmol)

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -1804,10 +1804,14 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
         # Sanitizing the molecule. We handle aromaticity and chirality manually.
         # This SanitizeMol(...) calls cleanUp, updatePropertyCache, symmetrizeSSSR,
-        # Kekulize, assignRadicals, setConjugation, and setHybridization.
+        # assignRadicals, setConjugation, and setHybridization.
         Chem.SanitizeMol(rdmol, (Chem.SANITIZE_ALL ^ Chem.SANITIZE_SETAROMATICITY ^
-                                 Chem.SANITIZE_ADJUSTHS ^ Chem.SANITIZE_CLEANUPCHIRALITY))
+                                 Chem.SANITIZE_ADJUSTHS ^ Chem.SANITIZE_CLEANUPCHIRALITY ^
+                                 Chem.SANITIZE_KEKULIZE))
         Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
+        # SetAromaticity set aromatic bonds to 1.5, but Molecule.bond_order is an
+        # integer (contrarily to fractional_bond_order) so we need the Kekule order.
+        Chem.Kekulize(rdmol)
 
         # Make sure the bond stereo tags are set before checking for
         # undefined stereo. RDKit can figure out bond stereo from other

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -1802,11 +1802,12 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         # Make a copy of the RDKit Mol as we'll need to change it (e.g. assign stereo).
         rdmol = Chem.Mol(rdmol)
 
-        # Sanitize the molecule. We handle aromaticity and chirality manually.
+        # Sanitizing the molecule. We handle aromaticity and chirality manually.
+        # This SanitizeMol(...) calls cleanUp, updatePropertyCache, symmetrizeSSSR,
+        # Kekulize, assignRadicals, setConjugation, and setHybridization.
         Chem.SanitizeMol(rdmol, (Chem.SANITIZE_ALL ^ Chem.SANITIZE_SETAROMATICITY ^
                                  Chem.SANITIZE_ADJUSTHS ^ Chem.SANITIZE_CLEANUPCHIRALITY))
         Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
-        Chem.Kekulize(rdmol)
 
         # Make sure the bond stereo tags are set before checking for
         # undefined stereo. RDKit can figure out bond stereo from other

--- a/openforcefield/utils/utils.py
+++ b/openforcefield/utils/utils.py
@@ -10,7 +10,7 @@ __all__ = [
     'all_subclasses',
     'temporary_cd',
     'temporary_directory',
-    'get_data_filename',
+    'get_data_file_path',
     'unit_to_string',
     'quantity_to_string',
     'string_to_unit',
@@ -103,7 +103,7 @@ def temporary_directory():
         shutil.rmtree(tmp_dir)
 
 
-def get_data_filename(relative_path):
+def get_data_file_path(relative_path):
     """Get the full path to one of the reference files in testsystems.
     In the source distribution, these files are in ``openforcefield/data/``,
     but on installation, they're moved to somewhere in the user's python

--- a/utilities/filter_molecule_sets/coordinates_for_DrugBank.py
+++ b/utilities/filter_molecule_sets/coordinates_for_DrugBank.py
@@ -35,7 +35,7 @@ def genConfs(c_mol, ofsff, ofsTri, index):
 
 flavor = oechem.OEIFlavor_Generic_Default | oechem.OEIFlavor_MOL2_Default | oechem.OEIFlavor_MOL2_Forcefield
 
-in_file = utils.get_data_filename('molecules/DrugBank_atyped.oeb')
+in_file = utils.get_data_file_path('molecules/DrugBank_atyped.oeb')
 ff_out = 'DrugBank_ff.mol2'
 tripos_out = 'DrugBank_tripos.mol2'
 failed_out = 'DrugBank_no3D.mol2'


### PR DESCRIPTION
A summary of the changes in this PR:
- I've documented better what `rdkit.SanitizeMol()` does and attempted to remove a second Kekulization. Let's see if tests still pass after #292.
- I've renamed the argument `.generate_conformers(..., num_conformers)` to `n_conformers` for consistency with other exposed attributes (e.g., `n_atoms`, `n_molecules`).
- I've removed `utils.structure.get_testdata_filename`, which was equivalent to `utils.get_data_filename`.
- I've added a couple of clarifications about naming conventions in the `docs/developing.rst` file.
- Most of this PR is about renaming things like `filename`/`filepath`/`pdbfile`/`outfile`/`mol2file` to `file_path`. Here is a more or less complete list
```
utils.get_data_filename -> get_data_file_path
utils.get_alkethoh_filepath -> get_alkethoh_file_path
utils.get_freesolv_filepath -> get_freesolv_file_path
utils.get_amber_filepath -> get_amber_file_path
utils.get_packmol_pdbfile -> get_packmol_pdb_file_path
utils.get_monomer_mol2file -> get_monomer_mol2_file_path
tests.utils.create_system_from_amber(prmtop_filepath, inpcrd_filepath -> create_system_from_amber(prmtop_file_path, inpcrd_file_path
tests.utils.compare_amber_smirnoff(prmtop_filepath, inpcrd_filepath -> compare_amber_smirnoff(prmtop_file_path, inpcrd_file_path
utils.structure.read_molecules(filename -> read_molecules(file_path
Molecule.from_file(filename, -> from_file(file_path,
Molecule.to_file(outfile, -> to_file(file_path,
ToolkitWrapper.from_file(filename, -> from_file(file_path,
ToolkitWrapper.to_file(molecule, outfile, outfile_format -> to_file(molecule, file_path, file_format
```
there is also
```
ParameterIOHandler.to_file(self, filename -> to_file(self, file_path
```
but I'll wait for #291 to be merged first since it touches the same lines of that PR.