### PR TITLE
Allow Conformers with All Zero Positions for Molecules with One Atom

### DIFF
--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -814,7 +814,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
                                                     unit.angstrom)
                     off_atom_index = map_atoms[oe_id]
                     positions[off_atom_index, :] = off_atom_coords
-                if (positions == 0 * unit.angstrom).all():
+                if (positions == 0 * unit.angstrom).all() and n_atoms > 1:
                     continue
                 molecule.add_conformer(positions)
 


### PR DESCRIPTION
## Description
A proposed fix for [issue 305](https://github.com/openforcefield/openforcefield/issues/305) related an exception being raised when parameterizing ions.

The change now retains conformers which have all of their positions set to zero for 'molecules' which contain only single atoms.

## Status
- [x] Ready to go