### PR TITLE
Fix #314 - correct units in tip3p.offxml

### DIFF
--- a/openforcefield/data/test_forcefields/tip3p.offxml
+++ b/openforcefield/data/test_forcefields/tip3p.offxml
@@ -7,7 +7,7 @@
   <Author>J. D. Chodera, MSKCC; A. Rizzi, Weill Cornell; C. C. Bannan, UC Irvine</Author>
 
   <!-- SMIRNOFF file implementing TIP3P water model. -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstroms" cutoff="9.0" cutoff_unit="angstroms" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="nanometers" epsilon_unit="kilojoules_per_mole" switch_width="1.0" switch_width_unit="angstroms" cutoff="9.0" cutoff_unit="angstroms" long_range_dispersion="isotropic">
     <!-- TIP3P water oxygen with charge override -->
     <!-- WARNING: charges are not supported yet (see issue openforcefield#25), and they are currently here only for documentation -->
     <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" id="n1" sigma="0.31507524065751241" epsilon="0.635968" charge="-0.834"/>

--- a/openforcefield/data/test_forcefields/tip3p.offxml
+++ b/openforcefield/data/test_forcefields/tip3p.offxml
@@ -3,11 +3,11 @@
 <SMIRNOFF version="0.2" aromaticity_model="OEAroModel_MDL">
 
   <!-- SMIRks Native Open Force Field (SMIRNOFF) file -->
-  <Date>2019-04-04</Date>
+  <Date>2019-05-17</Date>
   <Author>J. D. Chodera, MSKCC; A. Rizzi, Weill Cornell; C. C. Bannan, UC Irvine</Author>
 
   <!-- SMIRNOFF file implementing TIP3P water model. -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="nanometers" epsilon_unit="kilojoules_per_mole" switch_width="1.0" switch_width_unit="angstroms" cutoff="9.0" cutoff_unit="angstroms" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="nanometers" epsilon_unit="kilojoules_per_mole" switch_width="1.0" switch_width_unit="angstroms" cutoff="9.0" cutoff_unit="angstroms" method="cutoff">
     <!-- TIP3P water oxygen with charge override -->
     <!-- WARNING: charges are not supported yet (see issue openforcefield#25), and they are currently here only for documentation -->
     <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" id="n1" sigma="0.31507524065751241" epsilon="0.635968" charge="-0.834"/>


### PR DESCRIPTION
- [x] closes #314 

Even after the changes, this file remains nonfunctional because of the `charge` attribute of its `<Atom>` parameters (this isn't part of the 0.2 SMIRNOFF spec). However, I support merging this now, so that we fix the bookkeeping in case we ever resuscitate this file.