### PR TITLE
Fix for Conversion From 0.2 to 0.3 SMIRNOFF Spec

### DIFF
--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -422,6 +422,17 @@ class TestForceField():
         assert 'cosmetic_element="why not?"' not in string_3
         assert 'parameterize_eval="blah=blah2"' not in string_3
 
+
+    def test_read_0_1_smirnoff(self):
+        """Test reading an 0.1 spec OFFXML file"""
+        ff = ForceField('test_forcefields/smirnoff99Frosst_reference_0_1_spec.offxml')
+
+
+    def test_read_0_2_smirnoff(self):
+        """Test reading an 0.2 spec OFFXML file"""
+        ff = ForceField('test_forcefields/smirnoff99Frosst_reference_0_2_spec.offxml')
+
+
     @pytest.mark.parametrize('file_path_extension', ['xml', 'XML', 'offxml', 'OFFXML'])
     @pytest.mark.parametrize('specified_format', [None, 'xml', 'XML', '.xml', '.XML',
                                                   'offxml', 'OFFXML', '.offxml', '.OFFXML',

--- a/openforcefield/utils/utils.py
+++ b/openforcefield/utils/utils.py
@@ -658,6 +658,11 @@ def convert_0_2_smirnoff_to_0_3(smirnoff_data_0_2):
     sections_not_to_version_0_3 = ['Author', 'Date', 'version', 'aromaticity_model']
     for l1_tag in smirnoff_data['SMIRNOFF'].keys():
         if l1_tag not in sections_not_to_version_0_3:
+
+            if smirnoff_data['SMIRNOFF'][l1_tag] is None:
+                # Handle empty entries, such as the ToolkitAM1BCC handler.
+                smirnoff_data['SMIRNOFF'][l1_tag] = {}
+
             smirnoff_data['SMIRNOFF'][l1_tag]['version'] = 0.3
 
     # Update top-level tag

--- a/openforcefield/utils/utils.py
+++ b/openforcefield/utils/utils.py
@@ -638,6 +638,20 @@ def convert_0_2_smirnoff_to_0_3(smirnoff_data_0_2):
     smirnoff_data_0_3
         Hierarchical dict representing a SMIRNOFF data structure according the the 0.3 spec
     """
+    # Legacy forcefields sometimes specify the NonbondedForce's sigma_unit value, but then provide
+    # atom size as rmin_half. Here we correct for this behavior by explicitly defining both as
+    # the same unit if either one is defined.
+    if 'vdW' in smirnoff_data_0_2['SMIRNOFF'].keys():
+        rmh_unit = smirnoff_data_0_2['SMIRNOFF']['vdW'].get('rmin_half_unit', None)
+        sig_unit = smirnoff_data_0_2['SMIRNOFF']['vdW'].get('sigma_unit', None)
+        if (rmh_unit is not None) and (sig_unit is None):
+            smirnoff_data_0_2['SMIRNOFF']['vdW']['sigma_unit'] = rmh_unit
+        elif (sig_unit is not None) and (rmh_unit is None):
+            smirnoff_data_0_2['SMIRNOFF']['vdW']['rmin_half_unit'] = sig_unit
+        # If both are None, or both are defined, don't overwrite anything
+        else:
+            pass
+
     # Recursively attach unit strings
     smirnoff_data = recursive_attach_unit_strings(smirnoff_data_0_2, {})
 


### PR DESCRIPTION
A small fix for an error raised when converting empty handler sections in 0.2 spec force field files to 0.3.