### PR TITLE
bugfix for cb6 parameterization issue

### DIFF
--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -2378,6 +2378,7 @@ class ToolkitAM1BCCHandler(ParameterHandler):
 
         from networkx.algorithms.isomorphism import GraphMatcher
         import simtk.unit
+        import copy
         # Define the node/edge attributes that we will use to match the atoms/bonds during molecule comparison
         node_match_func = lambda x, y: ((x['atomic_number'] == y['atomic_number']) and
                                         (x['stereochemistry'] == y['stereochemistry']) and
@@ -2405,7 +2406,7 @@ class ToolkitAM1BCCHandler(ParameterHandler):
 
                 # Get the partial charges
                 # Make a copy of the charge molecule's charges array (this way it's the right shape)
-                temp_mol_charges = simtk.unit.Quantity(charge_mol.partial_charges)
+                temp_mol_charges = copy.deepcopy(simtk.unit.Quantity(charge_mol.partial_charges))
                 for charge_idx, ref_idx in topology_atom_map.items():
                     temp_mol_charges[ref_idx] = charge_mol.partial_charges[charge_idx]
                 molecule.partial_charges = temp_mol_charges


### PR DESCRIPTION
@slochower and @SimonBoothroyd 's work has been held up by a bug that I still totally don't understand, but was caused by code where we intended to make a copy of simtk.unit.Quantity-wrapped object, but instead wound up with a second reference to the original. Generally, I think there's a neighborhood of unexpected behavior/problems arising from my incomplete understanding of Quantity and its behavior. I hope that refactoring in Pint will make some of these relationships clearer.