### PR TITLE
Fix #344

### DIFF
--- a/openforcefield/tests/test_molecule.py
+++ b/openforcefield/tests/test_molecule.py
@@ -306,12 +306,6 @@ class TestMolecule:
     @pytest.mark.parametrize('molecule', mini_drug_bank())
     def test_to_from_rdkit(self, molecule):
         """Test that conversion/creation of a molecule to and from an RDKit rdmol is consistent.
-
-        This tests creating an OpenFF Molecule from an RDKit Mol both
-        through __init__() and from_rdkit(). However, __init__() doesn't
-        have an allow_undefined_stereo argument yet, so in that case, we
-        check for equality only for the from_rdkit() molecule.
-
         """
         # import pickle
         from openforcefield.utils.toolkits import UndefinedStereochemistryError

--- a/openforcefield/tests/test_toolkits.py
+++ b/openforcefield/tests/test_toolkits.py
@@ -64,9 +64,12 @@ class TestOpenEyeToolkitWrapper:
                                                 ]:
             if raises_exception:
                 with pytest.raises(UndefinedStereochemistryError) as context:
-                    molecule = Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
+                    Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
+                Molecule.from_smiles(smiles,
+                                     toolkit_registry=toolkit_wrapper,
+                                     allow_undefined_stereo=True)
             else:
-                molecule = Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
+                Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
 
     # TODO: test_smiles_round_trip
 
@@ -450,6 +453,9 @@ class TestRDKitToolkitWrapper:
         if exception_regex is not None:
             with pytest.raises(UndefinedStereochemistryError, match=exception_regex):
                 Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
+            Molecule.from_smiles(smiles,
+                                 toolkit_registry=toolkit_wrapper,
+                                 allow_undefined_stereo=True)
         else:
             Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
 

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -1834,7 +1834,10 @@ class FrozenMolecule(Serializable):
         return smiles
 
     @staticmethod
-    def from_smiles(smiles, hydrogens_are_explicit=False, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def from_smiles(smiles,
+                    hydrogens_are_explicit=False,
+                    toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+                    allow_undefined_stereo=False):
         """
         Construct a Molecule from a SMILES representation
 
@@ -1846,6 +1849,10 @@ class FrozenMolecule(Serializable):
             If False, the cheminformatics toolkit will perform hydrogen addition
         toolkit_registry : openforcefield.utils.toolkits.ToolRegistry or openforcefield.utils.toolkits.ToolkitWrapper, optional, default=None
             :class:`ToolkitRegistry` or :class:`ToolkitWrapper` to use for SMILES-to-molecule conversion
+        allow_undefined_stereo : bool, default=False
+            Whether to accept SMILES with undefined stereochemistry. If False,
+            an exception will be raised if a SMILES with undefined stereochemistry
+            is passed into this function.
 
         Returns
         -------
@@ -1858,10 +1865,16 @@ class FrozenMolecule(Serializable):
 
         """
         if isinstance(toolkit_registry, ToolkitRegistry):
-            return toolkit_registry.call('from_smiles', smiles)
+            return toolkit_registry.call('from_smiles',
+                                         smiles,
+                                         hydrogens_are_explicit=hydrogens_are_explicit,
+                                         allow_undefined_stereo=allow_undefined_stereo)
         elif isinstance(toolkit_registry, ToolkitWrapper):
             toolkit = toolkit_registry
-            return toolkit.from_smiles(smiles, hydrogens_are_explicit=hydrogens_are_explicit)
+            return toolkit.from_smiles(smiles,
+                                       hydrogens_are_explicit=hydrogens_are_explicit,
+                                       allow_undefined_stereo=allow_undefined_stereo
+                                       )
         else:
             raise Exception(
                 'Invalid toolkit_registry passed to from_smiles. Expected ToolkitRegistry or ToolkitWrapper. Got  {}'

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -1514,7 +1514,7 @@ class FrozenMolecule(Serializable):
             # Check through the toolkit registry to find a compatible wrapper for loading
             if not loaded:
                 try:
-                    result = toolkit_registry.call('from_object', other)
+                    result = toolkit_registry.call('from_object', other, allow_undefined_stereo=allow_undefined_stereo)
                 except NotImplementedError:
                     pass
                 else:

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -1835,7 +1835,7 @@ class FrozenMolecule(Serializable):
         func_qualname = to_smiles_method.__qualname__
 
         # Check to see if a SMILES for this molecule was already cached using this method
-        if func_qualname in self._cached_smiles.keys():
+        if func_qualname in self._cached_smiles:
             return self._cached_smiles[func_qualname]
         else:
             smiles = to_smiles_method(self)

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -1062,7 +1062,8 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
                 raise Exception(
                     "Addition of explicit hydrogens failed in from_openeye")
         # TODO: Add allow_undefined_stereo to this function, and pass to from_openeye?
-        molecule = self.from_openeye(oemol)
+        molecule = self.from_openeye(oemol,
+                                     allow_undefined_stereo=allow_undefined_stereo)
         return molecule
 
     def generate_conformers(self, molecule, n_conformers=1, clear_existing=True):

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -2902,7 +2902,8 @@ class ToolkitRegistry:
 
     def resolve(self, method_name):
         """
-        Resolve the requested method name by checking all registered toolkits in order of precedence for one that provides the requested method.
+        Resolve the requested method name by checking all registered toolkits in
+        order of precedence for one that provides the requested method.
 
         Parameters
         ----------


### PR DESCRIPTION
* Fixes #344 
* adds `allow_undefined_stereo` kwargs to `Molecule.from_smiles` and `Molecule.from_object`
* refactors test_molecule `test_to_from_openeye` and `test_to_from_rdkit` to be more explicit and test a wider range of behavior. 
* refactors test_toolkits `test_smiles_missing_stereochemistry` to test a wider range of behavior.