### PR TITLE
Fix incorrect suggestion in ParameterType init error (permit --> allow)

### DIFF
--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -433,7 +433,7 @@ class ParameterType:
             else:
                 raise SMIRNOFFSpecError(f"Unexpected kwarg ({key}: {val})  passed to {self.__class__} constructor. " 
                                         "If this is a desired cosmetic attribute, consider setting " 
-                                        "'permit_cosmetic_attributes=True'")
+                                        "'allow_cosmetic_attributes=True'")
 
     @property
     def smirks(self):


### PR DESCRIPTION
If an invalid parameter-level attribute was present in an OFFXML, the error message would incorrectly suggest that the user add the kwarg `permit_cosmetic_attributes=True`. This PR corrects the typo to read `allow_cosmetic_attributes=True`