### PR TITLE
0.4.1 releasenotes

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -22,8 +22,8 @@ Bug fixes
 """""""""
 - `PR #351 <https://github.com/openforcefield/openforcefield/pull/351>`_: Fixes
   `Issue #344 <https://github.com/openforcefield/openforcefield/issues/344>`_,
-  in which :py:meth:`the main Molecule initializer <openforcefield.topology.molecule.FrozenMolecule.__init__>`
-  and several other Molecule-construction functions ignored or did not
+  in which the main :py:class:`Molecule() <openforcefield.topology.molecule.FrozenMolecule.__init__>`
+  constructor and several other Molecule-construction functions ignored or did not
   expose the ``allow_undefined_stereo`` keyword argument.
 - `PR #351 <https://github.com/openforcefield/openforcefield/pull/351>`_: Fixes
   a bug where a molecule which previously generated a SMILES using one cheminformatics toolkit
@@ -53,9 +53,13 @@ Bug fixes
 
 Code enhancements
 """""""""""""""""
-- `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: ``ParameterType`` was refactored to improve its
-  extensibility. It is now possible to create new parameter types by using the new descriptors ``ParameterAttribute`` and
-  ``IndexedParameterAttribute``.
+- `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_:
+  :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>`
+  was refactored to improve its extensibility. It is now possible to create new parameter
+  types by using the new descriptors
+  :py:class:`ParameterAttribute <openforcefield.typing.engines.smirnoff.parameters.ParameterAttribute>`
+  and
+  :py:class:`IndexedParameterAttribute <openforcefield.typing.engines.smirnoff.parameters.IndexedParameterAttribute>`.
 - `PR #357 <https://github.com/openforcefield/openforcefield/pull/357>`_: Addresses
   `Issue #356 <https://github.com/openforcefield/openforcefield/issues/356>`_ by raising
   an informative error message if a user attempts to load an OpenMM topology which
@@ -67,7 +71,7 @@ Force fields added
 - `PR #368 <https://github.com/openforcefield/openforcefield/pull/368>`_: Temporarily adds
   ``test_forcefields/smirnoff99frosst_experimental.offxml`` to address hierarchy problems, redundancies, SMIRKS
   pattern typos etc., as documented in `issue #367 <https://github.com/openforcefield/openforcefield/issues/367>`_.
-  Will ultimately be propagated to an updated forcefield in the `smirnoff99frosst` repo.
+  Will ultimately be propagated to an updated forcefield in the ``openforcefield/smirnoff99frosst`` repo.
 - `PR #371 <https://github.com/openforcefield/openforcefield/pull/371>`_: Adds
   ``test_forcefields/smirff99Frosst_reference_0_1_spec.offxml``, a SMIRNOFF 0.1 spec file enclosed by the legacy
   ``SMIRFF`` tag. This file is used in backwards-compatibility testing.

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -8,8 +8,22 @@ Releases follow the ``major.minor.micro`` scheme recommended by `PEP440 <https:/
 * ``micro`` increments represent bugfix releases or improvements in documentation
 
 
-Current development
--------------------
+0.4.1 - Bugfix Release
+----------------------
+
+This update fixes several toolkit bugs that have been reported by the community.
+Details of these bugfixes are provided below.
+
+It also refactors how
+:py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>`
+and
+:py:class:`ParameterHandler <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler>`
+store their attributes, by introducing
+:py:class:`ParameterAttribute <openforcefield.typing.engines.smirnoff.parameters.ParameterAttribute>`
+and
+:py:class:`IndexedParameterAttribute <openforcefield.typing.engines.smirnoff.parameters.IndexedParameterAttribute>`.
+These new attribute-handling classes provide a consistent backend which should simplify manipulation of parameters
+and implementation of new handlers.
 
 Bug fixes
 """""""""
@@ -27,7 +41,7 @@ Bug fixes
   :py:class:`ProperTorsionHandler <openforcefield.typing.engines.smirnoff.parameters.ProperTorsionHandler>`
   , and
   :py:class:`ImproperTorsionHandler <openforcefield.typing.engines.smirnoff.parameters.ImproperTorsionHandler>`
-  exposed non-functional indexed parameters that were removed from the spec in 0.4.0.
+  exposed non-functional indexed parameters that were removed from the SMIRNOFF 0.3 spec.
 - `PR #351 <https://github.com/openforcefield/openforcefield/pull/351>`_: Fixes
   `Issue #344 <https://github.com/openforcefield/openforcefield/issues/344>`_,
   in which the main :py:class:`FrozenMolecule <openforcefield.topology.FrozenMolecule>`

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -13,16 +13,18 @@ Current development
 
 API-breaking changes
 """"""""""""""""""""
-- `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Fixed a bug in the API where the two :py:class:`BondType <openforcefield.typing.engines.smirnoff.parameters.BondHandler.BondType>`
+- `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Fixed a
+  bug in the API where the two
+  :py:class:`BondType <openforcefield.typing.engines.smirnoff.parameters.BondHandler.BondType>`
   parameter attributes ``k`` and ``length`` were interpreted as indexed attributes.
-- `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Fixed a bug in the API that allowed setting indexed
-  attributes to single values instead of always lists.
+- `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Fixed a
+  bug in the API that allowed setting indexed attributes to single values instead of always lists.
 
 Bug fixes
 """""""""
 - `PR #351 <https://github.com/openforcefield/openforcefield/pull/351>`_: Fixes
   `Issue #344 <https://github.com/openforcefield/openforcefield/issues/344>`_,
-  in which the main :py:class:`Molecule() <openforcefield.topology.molecule.FrozenMolecule.__init__>`
+  in which the main :py:class:`FrozenMolecule <openforcefield.topology.FrozenMolecule>`
   constructor and several other Molecule-construction functions ignored or did not
   expose the ``allow_undefined_stereo`` keyword argument.
 - `PR #351 <https://github.com/openforcefield/openforcefield/pull/351>`_: Fixes

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -73,16 +73,6 @@ Bug fixes
   Since developing a formal specification, the only acceptable top-level tag value in a SMIRNOFF data structure is
   ``SMIRNOFF``.
 
-Bug fixes
-"""""""""
-- `PR #371 <https://github.com/openforcefield/openforcefield/pull/371>`_: Fixes error when reading early SMIRNOFF 0.1
-  spec files enclosed by a top-level ``SMIRFF`` tag.
-
-.. note ::
-  The enclosing ``SMIRFF`` tag is present only in legacy files.
-  Since developing a formal specification, the only acceptable top-level tag value in a SMIRNOFF data structure is
-  ``SMIRNOFF``.
-
 Code enhancements
 """""""""""""""""
 - `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_:

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -41,7 +41,7 @@ Bug fixes
   :py:class:`ProperTorsionHandler <openforcefield.typing.engines.smirnoff.parameters.ProperTorsionHandler>`
   , and
   :py:class:`ImproperTorsionHandler <openforcefield.typing.engines.smirnoff.parameters.ImproperTorsionHandler>`
-  exposed non-functional indexed parameters that were removed from the SMIRNOFF 0.3 spec.
+  exposed non-functional indexed parameters.
 - `PR #351 <https://github.com/openforcefield/openforcefield/pull/351>`_: Fixes
   `Issue #344 <https://github.com/openforcefield/openforcefield/issues/344>`_,
   in which the main :py:class:`FrozenMolecule <openforcefield.topology.FrozenMolecule>`

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -13,15 +13,38 @@ Current development
 
 API-breaking changes
 """"""""""""""""""""
-- `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Fixed a bug in the API where the two ``BondType``
+- `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Fixed a bug in the API where the two :py:class:`BondType <openforcefield.typing.engines.smirnoff.parameters.BondHandler.BondType>`
   parameter attributes ``k`` and ``length`` were interpreted as indexed attributes.
 - `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Fixed a bug in the API that allowed setting indexed
   attributes to single values instead of always lists.
 
 Bug fixes
 """""""""
-- `PR #371 <https://github.com/openforcefield/openforcefield/pull/371>`_: Fixes error when reading early SMIRNOFF 0.1
-  spec files enclosed by a top-level ``SMIRFF`` tag.
+- `PR #351 <https://github.com/openforcefield/openforcefield/pull/351>`_: Fixes
+  `Issue #344 <https://github.com/openforcefield/openforcefield/issues/344>`_,
+  in which :py:meth:`the main Molecule initializer <openforcefield.topology.molecule.FrozenMolecule.__init__>`
+  and several other Molecule-construction functions ignored or did not
+  expose the ``allow_undefined_stereo`` keyword argument.
+- `PR #351 <https://github.com/openforcefield/openforcefield/pull/351>`_: Fixes
+  a bug where a molecule which previously generated a SMILES using one cheminformatics toolkit
+  returns the same SMILES, even though a different toolkit (which would generate
+  a different SMILES for the molecule) is explicitly called.
+- `PR #354 <https://github.com/openforcefield/openforcefield/pull/354>`_: Fixes
+  the error message that is printed if an unexpected parameter attribute is found while loading
+  data into a :py:class:`ForceField <openforcefield.typing.engines.smirnoff.forcefield.ForceField>`
+  (now instructs users to specify ``allow_cosmetic_attributes`` instead of ``permit_cosmetic_attributes``)
+- `PR #364 <https://github.com/openforcefield/openforcefield/pull/364>`_: Fixes
+  `Issue #362 <https://github.com/openforcefield/openforcefield/issues/362>`_ by
+  modifying
+  :py:meth:`OpenEyeToolkitWrapper.from_smiles <openforcefield.utils.toolkits.OpenEyeToolkitWrapper.from_smiles>`
+  and
+  :py:meth:`RDKitToolkitWrapper.from_smiles <openforcefield.utils.toolkits.RDKitToolkitWrapper.from_smiles>`
+  to make implicit hydrogens explicit before molecule creation. These functions also
+  now raise an error if the optional keyword ``hydrogens_are_explicit=True`` but the
+  SMILES are interpreted by the backend cheminformatic toolkit as having implicit
+  hydrogens.
+- `PR #371 <https://github.com/openforcefield/openforcefield/pull/371>`_: Fixes
+  error when reading early SMIRNOFF 0.1 spec files enclosed by a top-level ``SMIRFF`` tag.
 
 .. note ::
   The enclosing ``SMIRFF`` tag is present only in legacy files.
@@ -33,6 +56,11 @@ Code enhancements
 - `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: ``ParameterType`` was refactored to improve its
   extensibility. It is now possible to create new parameter types by using the new descriptors ``ParameterAttribute`` and
   ``IndexedParameterAttribute``.
+- `PR #357 <https://github.com/openforcefield/openforcefield/pull/357>`_: Addresses
+  `Issue #356 <https://github.com/openforcefield/openforcefield/issues/356>`_ by raising
+  an informative error message if a user attempts to load an OpenMM topology which
+  is probably missing connectivity information.
+
 
 Force fields added
 """"""""""""""""""

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -16,12 +16,18 @@ Bug fixes
 - `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Fixed a
   bug where the two
   :py:class:`BondType <openforcefield.typing.engines.smirnoff.parameters.BondHandler.BondType>`
-  parameter attributes ``k`` and ``length`` were interpreted as indexed attributes.
+  parameter attributes ``k`` and ``length`` were treated as indexed attributes. (``k`` and
+  ``length`` values that correspond to specific bond orders will be indexed under
+  ``k_bondorder1``, ``k_bondorder2``, etc when implemented in the future)
 - `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Fixed a
-  bug that allowed setting indexed attributes to single values instead of always lists.
-- `PR #370 <https://github.com/openforcefield/openforcefield/pull/370>`_: Fixed a bug in the API where ``BondHandler``,
-  ``ProperTorsionHandler``, and ``ImroperTorsionHandler`` exposed indexed parameters that were removed from the spec in
-  0.4.0.
+  bug that allowed setting indexed attributes to single values instead of strictly lists.
+- `PR #370 <https://github.com/openforcefield/openforcefield/pull/370>`_: Fixed a
+  bug in the API where
+  :py:class:`BondHandler <openforcefield.typing.engines.smirnoff.parameters.BondHandler>`,
+  :py:class:`ProperTorsionHandler <openforcefield.typing.engines.smirnoff.parameters.ProperTorsionHandler>`
+  , and
+  :py:class:`ImproperTorsionHandler <openforcefield.typing.engines.smirnoff.parameters.ImproperTorsionHandler>`
+  exposed non-functional indexed parameters that were removed from the spec in 0.4.0.
 - `PR #351 <https://github.com/openforcefield/openforcefield/pull/351>`_: Fixes
   `Issue #344 <https://github.com/openforcefield/openforcefield/issues/344>`_,
   in which the main :py:class:`FrozenMolecule <openforcefield.topology.FrozenMolecule>`

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -11,17 +11,14 @@ Releases follow the ``major.minor.micro`` scheme recommended by `PEP440 <https:/
 Current development
 -------------------
 
-API-breaking changes
-""""""""""""""""""""
+Bug fixes
+"""""""""
 - `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Fixed a
-  bug in the API where the two
+  bug where the two
   :py:class:`BondType <openforcefield.typing.engines.smirnoff.parameters.BondHandler.BondType>`
   parameter attributes ``k`` and ``length`` were interpreted as indexed attributes.
 - `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Fixed a
-  bug in the API that allowed setting indexed attributes to single values instead of always lists.
-
-Bug fixes
-"""""""""
+  bug that allowed setting indexed attributes to single values instead of always lists.
 - `PR #351 <https://github.com/openforcefield/openforcefield/pull/351>`_: Fixes
   `Issue #344 <https://github.com/openforcefield/openforcefield/issues/344>`_,
   in which the main :py:class:`FrozenMolecule <openforcefield.topology.FrozenMolecule>`

--- a/docs/typing.rst
+++ b/docs/typing.rst
@@ -96,3 +96,18 @@ Parameter I/O Handlers
 
     ParameterIOHandler
     XMLParameterIOHandler
+
+
+
+Parameter Attributes
+~~~~~~~~~~~~~~~~~~~~
+
+``ParameterAttribute`` and ``IndexedParameterAttribute`` provide a standard backend for ParameterHandler and Parameter attributes, while also enforcing validation of types and units.
+
+.. currentmodule:: openforcefield.typing.engines.smirnoff.parameters
+.. autosummary::
+    :nosignatures:
+    :toctree: api/generated/
+
+    ParameterAttribute
+    IndexedParameterAttribute

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -429,7 +429,7 @@ class TestForceField():
 
 
     def test_read_0_1_smirff(self):
-        """Test reading an 0.1 spec OFFXML file"""
+        """Test reading an 0.1 spec OFFXML file, enclosed by the legacy "SMIRFF" tag"""
         ff = ForceField('test_forcefields/smirff99Frosst_reference_0_1_spec.offxml')
 
 

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -149,7 +149,7 @@ class ParameterAttribute:
         setting the attribute.
 
     Examples
-    -------
+    --------
 
     Create a parameter type with an optional and a required attribute.
 

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -22,6 +22,8 @@ __all__ = [
     'ParameterList',
     'ParameterType',
     'ParameterHandler',
+    'ParameterAttribute',
+    'IndexedParameterAttribute',
     'ConstraintHandler',
     'BondHandler',
     'AngleHandler',


### PR DESCRIPTION
Docs branch built at: https://open-forcefield-toolkit.readthedocs.io/en/041-releasenotes/releasehistory.html

- [x] #371 merged
- [x] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
