### PR TITLE
Indexed attribute access

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -8,6 +8,18 @@ Releases follow the ``major.minor.micro`` scheme recommended by `PEP440 <https:/
 * ``micro`` increments represent bugfix releases or improvements in documentation
 
 
+Current Development
+-------------------
+
+New features
+""""""""""""
+
+- `PR #377 <https://github.com/openforcefield/openforcefield/pull/377>`_: Single indexed parameters in
+  :py:class:`ParameterHandler <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler>`
+  and :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>`
+  can now be get/set through normal attribute syntax on top of the list syntax.
+
+
 0.4.1 - Bugfix Release
 ----------------------
 

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -283,8 +283,6 @@ class TestParameterAttributeHandler:
         my_parameter.a1
         my_parameter.assert_getattr()
 
-        # TODO: Update docs of ParameterHandler and ParameterType
-
 
 #======================================================================
 # Test ParameterHandler

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -23,7 +23,7 @@ Class definitions to represent a molecular system and its chemical components
 
 import itertools
 
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from collections import OrderedDict
 
 from simtk import unit

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -398,7 +398,7 @@ class IndexedParameterAttribute(ParameterAttribute):
         return value
 
 
-class _ParameterAttributeInitializer:
+class _ParameterAttributeHandler:
     """A base class for ``ParameterType`` and ``ParameterHandler`` objects.
 
     Encapsulate shared code of ``ParameterType`` and ``ParameterHandler``.
@@ -845,7 +845,7 @@ class ParameterList(list):
 
 
 # TODO: Rename to better reflect role as parameter base class?
-class ParameterType(_ParameterAttributeInitializer):
+class ParameterType(_ParameterAttributeHandler):
     """
     Base class for SMIRNOFF parameter types.
 
@@ -1039,7 +1039,7 @@ class ParameterType(_ParameterAttributeInitializer):
 
 # TODO: Should we have a parameter handler registry?
 
-class ParameterHandler(_ParameterAttributeInitializer):
+class ParameterHandler(_ParameterAttributeHandler):
     """Base class for parameter handlers.
 
     Parameter handlers are configured with some global parameters for a

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -458,7 +458,7 @@ class _ParameterAttributeHandler:
     >>> ParameterTypeOrHandler(length=3.0*unit.nanometer)
     Traceback (most recent call last):
     ...
-    SMIRNOFFSpecError: <class '__main__.ParameterTypeOrHandler'> require the following missing parameters: ['k']. Defined kwargs are ['length']
+    openforcefield.typing.engines.smirnoff.parameters.SMIRNOFFSpecError: <class 'openforcefield.typing.engines.smirnoff.parameters.ParameterTypeOrHandler'> require the following missing parameters: ['k']. Defined kwargs are ['length']
 
     Each attribute can be made optional by specifying a default value,
     and you can attach a converter function by passing a callable as an
@@ -3027,4 +3027,5 @@ class GBSAParameterHandler(ParameterHandler):
 
 if __name__ == '__main__':
     import doctest
-    doctest.run_docstring_examples(ParameterType, globals())
+    doctest.testmod()
+    # doctest.run_docstring_examples(_ParameterAttributeHandler, globals())


### PR DESCRIPTION
Allow the possibility of getting/setting single indexed parameters through normal attribute syntax rather than only through the list. An example:
```python
>>> torsion_parameter_type.periodicity = [2, 5]
>>> torsion_parameter_type.periodicity2 = 6
>>> torsion_parameter_type.periodicity[0] = 1
>>> torsion_parameter_type.periodicity
[1, 6]
```