### PR TITLE
Print additional informative valence info when parameters are missing

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -18,6 +18,8 @@ New features
   :py:class:`ParameterHandler <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler>`
   and :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>`
   can now be get/set through normal attribute syntax on top of the list syntax.
+- `PR #394 <https://github.com/openforcefield/openforcefield/pull/394>`_: Include element and atom name
+  in error output when there are missing valence parameters during molecule parameterization.
 
 
 0.4.1 - Bugfix Release

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -1638,12 +1638,12 @@ class ParameterHandler(_ParameterAttributeHandler):
 
         if len(unassigned_terms) > 0:
             unassigned_str = ''
-            for x in unassigned_terms:
-                unassigned_str += '\n- ' + str(x)
+            for unassigned_tuple in unassigned_terms:
+                unassigned_str += '\n- Topology indices ' + str(unassigned_tuple)
                 unassigned_str += ': names and elements '
 
                 # Pull and add additional helpful info on missing terms
-                for atom_idx in x:
+                for atom_idx in unassigned_tuple:
                     matched = False
                     for atoms in valence_terms:
                         for a in atoms:

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -1637,9 +1637,22 @@ class ParameterHandler(_ParameterAttributeHandler):
         err_msg = ""
 
         if len(unassigned_terms) > 0:
-            unassigned_str = '\n- '.join([str(x) for x in unassigned_terms])
+            unassigned_str = ''
+            for x in unassigned_terms:
+                unassigned_str += '\n- ' + str(x)
+                unassigned_str += ': names and elements '
+
+                # Pull and add additional helpful info on missing terms
+                for atom_idx in x:
+                    matched = False
+                    for atoms in valence_terms:
+                        for a in atoms:
+                            if a.topology_atom_index == atom_idx:
+                                unassigned_str += '(%s %s), ' % (a.atom.name, a.atom.element.symbol)
+                                matched = True
+                        if matched: break
             err_msg += ("{parameter_handler} was not able to find parameters for the following valence terms:\n"
-                        "- {unassigned_str}").format(parameter_handler=cls.__name__,
+                        "{unassigned_str}").format(parameter_handler=cls.__name__,
                                                      unassigned_str=unassigned_str)
         if len(not_found_terms) > 0:
             if err_msg != "":


### PR DESCRIPTION
- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [x] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)

Addresses issue #388 , at least partially: Prints atom names involved (if present) and elements involved in errors relating to missing valence parameters.

Doesn't affect docstrings or tests (cosmetic only), but if you like this track, @j-wags , I will happily update the changelog.