### PR TITLE
Fix logic error in ForceField initializer

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -28,6 +28,10 @@ Bugfixes
   having :py:meth:`OpenEyeToolkitWrapper.compute_partial_charges_am1bcc <openforcefield.utils.toolkits.OpenEyeToolkitWrapper.compute_partial_charges_am1bcc>`
   fall back to using standard AM1-BCC if AM1-BCC ELF10 charge generation raises
   an error about "trans COOH conformers"
+- `PR #399 <https://github.com/openforcefield/openforcefield/pull/399>`_: Fixes
+  issue where
+  :py:class:`ForceField <openforcefield.typing.engines.smirnoff.forcefield.ForceField>`
+  constructor would ignore ``parameter_handler_classes`` kwarg.
 
 
 0.4.1 - Bugfix Release

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -309,7 +309,7 @@ class TestForceField():
         from openforcefield.typing.engines.smirnoff import BondHandler
         forcefield = ForceField(parameter_handler_classes=[BondHandler])
 
-        # Should find BondHandler, since it's a default class
+        # Should find BondHandler, since we registered it
         forcefield.get_parameter_handler('Bonds')
 
         # Shouldn't find AngleHandler, since we didn't allow that to be registered

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -292,8 +292,32 @@ if RDKitToolkitWrapper.is_available() and AmberToolsToolkitWrapper.is_available(
 class TestForceField():
     """Test the ForceField class"""
 
-    def test_create_forcefield_from_file(self):
+    def test_create_forcefield_no_args(self):
         """Test empty constructor"""
+        forcefield = ForceField()
+
+        # Should find BondHandler and AngleHandler, since they're default classes
+        forcefield.get_parameter_handler('Bonds')
+        forcefield.get_parameter_handler('Angles')
+
+        # Shouldn't find InvalidKey handler, since it doesn't exist
+        with pytest.raises(KeyError) as excinfo:
+            forcefield.get_parameter_handler('InvalidKey')
+
+    def test_create_forcefield_custom_handler_classes(self):
+        """Test constructor given specific classes to register"""
+        from openforcefield.typing.engines.smirnoff import BondHandler
+        forcefield = ForceField(parameter_handler_classes=[BondHandler])
+
+        # Should find BondHandler, since it's a default class
+        forcefield.get_parameter_handler('Bonds')
+
+        # Shouldn't find AngleHandler, since we didn't allow that to be registered
+        with pytest.raises(KeyError) as excinfo:
+            forcefield.get_parameter_handler('Angles')
+
+    def test_create_forcefield_from_file(self):
+        """Test basic file loading in constructor"""
         forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
         assert len(forcefield._parameter_handlers['Bonds']._parameters) == 87
         assert len(forcefield._parameter_handlers['Angles']._parameters) == 38

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -275,8 +275,8 @@ class ForceField:
         # otherwise, we can't define two different ParameterHandler subclasses to compare for a new type of energy term
         # since both will try to register themselves for the same XML tag and an Exception will be raised.
         if parameter_handler_classes is None:
-            parameter_handlers = all_subclasses(ParameterHandler)
-        self._register_parameter_handler_classes(parameter_handlers)
+            parameter_handler_classes = all_subclasses(ParameterHandler)
+        self._register_parameter_handler_classes(parameter_handler_classes)
 
         # Register all ParameterIOHandler objects that will process serialized parameter representations
         if parameter_io_handler_classes is None:


### PR DESCRIPTION
- [x] Fixes logic error reported by @SimonBoothroyd that prevents `parameter_handler_classes` provided to `ForceField` constructor from being used. 
- [x] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [x] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)

- [x] Ready for review