### PR TITLE
[WIP] Fix codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,15 +91,16 @@ script:
 - if [[ "$RDKIT" == true && "$OPENEYE" == true ]];
   then
     pytest --ignore=utilities --ignore=examples/deprecated --ignore=docs
-    --ignore=devtools --doctest-modules --nbval-lax --cov=openforcefield;
+    --ignore=devtools --doctest-modules --nbval-lax --cov=openforcefield
+    --cov-config=setup.cfg;
   elif [[ "$OPENEYE" == true ]];
   then
     pytest --ignore=utilities --ignore=examples/deprecated --ignore=docs
     --ignore=devtools --ignore=examples/check_dataset_parameter_coverage
-    --nbval-lax --cov=openforcefield;
+    --nbval-lax --cov=openforcefield --cov-config=setup.cfg;
   else
     pytest --ignore=utilities --ignore=examples/deprecated
-    --nbval-lax --cov=openforcefield;
+    --nbval-lax --cov=openforcefield --cov-config=setup.cfg;
   fi
 
 notifications:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+
+# Codecov configuration to make it a bit less noisy
+coverage:
+  status:
+    patch: false
+    project:
+      default:
+        threshold: 50%
+comment:
+  layout: "header"
+  require_changes: false
+  branches: null
+  behavior: default
+  flags: null
+  paths: null


### PR DESCRIPTION
Codecov has dropped by about 30% recently, as a result of changing some dependencies. This appears to be due to codecov now considering _the code within tests themselves_ to be included in the denominator for test coverage %. 

This PR is to find a way to either count the fact that those lines run _during the test itself_, or to remove them from the denominator.