### PR TITLE
Eliminate navigation sidebar because it takes up too much room

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,6 +139,9 @@ html_logo = "_static/openforcefield.png"
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.
 html_theme_options = {
+    # Disable the sidebar, since it takes up too much space
+    'nosidebar': True,
+
     # Navigation bar title. (Default: ``project`` value)
     'navbar_title': "Open Force Field Toolkit",
 


### PR DESCRIPTION
Fixes https://github.com/openforcefield/openforcefield/issues/307

This PR eliminates the navigation sidebar because (1) it takes up too much space, causing readability issues, and (2) is unnecessary.

Tired:
![image](https://user-images.githubusercontent.com/3656088/67729650-219c5f80-f9af-11e9-87e1-7c4bdc8f6ed9.png)

Wired:
![image](https://user-images.githubusercontent.com/3656088/67729705-62947400-f9af-11e9-8370-35dcec3ad734.png)
