### PR TITLE
Switch RDKit channel to conda-forge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
 - conda activate test
 
 # Install RDKit
-- if [[ "$RDKIT" == true ]]; then conda install --yes -c rdkit rdkit; fi
+- if [[ "$RDKIT" == true ]]; then conda install --yes -c conda-forge rdkit; fi
 - if [[ "$RDKIT" == true ]]; then conda install --yes -c omnia ambermini; fi
 
 # Install OpenEye


### PR DESCRIPTION
Travis tests were failing due to a change in external dependencies, which made `create_conda_env.py` resolve to download an RDKit version from 2017. This PR changes the RDKit channel from `rdkit` to `conda-forge` and appears to correct this issue. 

Here is the partial output from one of the bad builds (https://travis-ci.org/openforcefield/openforcefield/jobs/605675364)
```
$ git clone --depth=50 https://github.com/openforcefield/openforcefield.git openforcefield/openforcefield

0.01s

Setting environment variables from repository settings

$ export encrypted_a4fdffb2b55a_key=[secure]

$ export encrypted_a4fdffb2b55a_iv=[secure]

$ export CODECOV_TOKEN=[secure]

$ export encrypted_4ea8671dd0e3_key=[secure]

$ export encrypted_4ea8671dd0e3_iv=[secure]

Setting environment variables from .travis.yml

$ export OE_LICENSE="$HOME/oe_license.txt"

$ export PYTHON_VER=3.6

$ export RDKIT=true

0.01s$ source ~/virtualenv/python3.6/bin/activate

$ python --version

Python 3.6.7

$ pip --version

pip 19.0.3 from /home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pip (python 3.6)
before_install.1

0.01s$ uname -a
before_install.2

0.02s$ df -h
before_install.3

0.01s$ ulimit -a
before_install.4

47.04s$ source devtools/travis-ci/before_install.sh
before_install.5

0.01s$ python -V
before_install.6

0.01s$ if [ "$TRAVIS_SECURE_ENV_VARS" == true ]; then openssl aes-256-cbc -K $encrypted_4ea8671dd0e3_key -iv $encrypted_4ea8671dd0e3_iv -in oe_license.txt.enc -out $OE_LICENSE -d; fi
before_install.7

0.00s$ if [[ "$OPENEYE" == true && "$TRAVIS_SECURE_ENV_VARS" == false ]]; then echo "OpenEye license will not be installed in forks."; fi
install.1

71.41s$ python devtools/scripts/create_conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/test_env.yaml
install.2

0.13s$ conda activate test
install.3

25.52s$ if [[ "$RDKIT" == true ]]; then conda install --yes -c rdkit rdkit; fi

Collecting package metadata (current_repodata.json): ...working... done

Solving environment: ...working... done

## Package Plan ##

  environment location: /home/travis/miniconda/envs/test

  added / updated specs:

    - rdkit

The following packages will be downloaded:

    package                    |            build

    ---------------------------|-----------------

    boost-1.63.0               |   py36h415b752_1        11.8 MB  rdkit

    cairo-1.16.0               |    hfb77d84_1002         1.5 MB  conda-forge

    fontconfig-2.13.1          |    h86ecdb6_1001         340 KB  conda-forge

    freetype-2.10.0            |       he983fc9_1         884 KB  conda-forge

    gettext-0.19.8.1           |    hc5be6a0_1002         3.6 MB  conda-forge

    glib-2.58.3                |    h6f030ca_1002         3.3 MB  conda-forge

    libpng-1.6.37              |       hed695b0_0         343 KB  conda-forge

    libtiff-4.1.0              |       hfc65ed5_0         595 KB  conda-forge

    libuuid-2.32.1             |    h14c3975_1000          26 KB  conda-forge

    libxcb-1.13                |    h14c3975_1002         396 KB  conda-forge

    olefile-0.46               |             py_0          31 KB  conda-forge

    pcre-8.43                  |       he1b5a44_0         257 KB  conda-forge

    pillow-6.2.1               |   py36h6b7be26_0         639 KB  conda-forge

    pixman-0.38.0              |    h516909a_1003         594 KB  conda-forge

    pthread-stubs-0.4          |    h14c3975_1001           5 KB  conda-forge

    rdkit-2017.09.1            |           py36_1        19.7 MB  rdkit

    xorg-kbproto-1.0.7         |    h14c3975_1002          26 KB  conda-forge

    xorg-libice-1.0.10         |       h516909a_0          57 KB  conda-forge

    xorg-libsm-1.2.3           |    h84519dc_1000          25 KB  conda-forge

    xorg-libx11-1.6.9          |       h516909a_0         918 KB  conda-forge

    xorg-libxau-1.0.9          |       h14c3975_0          13 KB  conda-forge

    xorg-libxdmcp-1.1.3        |       h516909a_0          18 KB  conda-forge

    xorg-libxext-1.3.4         |       h516909a_0          51 KB  conda-forge

    xorg-libxrender-0.9.10     |    h516909a_1002          31 KB  conda-forge

    xorg-renderproto-0.11.1    |    h14c3975_1002           8 KB  conda-forge

    xorg-xextproto-7.3.0       |    h14c3975_1002          27 KB  conda-forge

    xorg-xproto-7.0.31         |    h14c3975_1007          72 KB  conda-forge

    zstd-1.4.3                 |       h3b9ef0a_0         935 KB  conda-forge

    ------------------------------------------------------------

                                           Total:        46.1 MB

The following NEW packages will be INSTALLED:

  boost              rdkit/linux-64::boost-1.63.0-py36h415b752_1

  cairo              conda-forge/linux-64::cairo-1.16.0-hfb77d84_1002

  fontconfig         conda-forge/linux-64::fontconfig-2.13.1-h86ecdb6_1001

  freetype           conda-forge/linux-64::freetype-2.10.0-he983fc9_1

  gettext            conda-forge/linux-64::gettext-0.19.8.1-hc5be6a0_1002

  glib               conda-forge/linux-64::glib-2.58.3-h6f030ca_1002

  icu                conda-forge/linux-64::icu-64.2-he1b5a44_1

  libiconv           conda-forge/linux-64::libiconv-1.15-h516909a_1005

  libpng             conda-forge/linux-64::libpng-1.6.37-hed695b0_0

  libtiff            conda-forge/linux-64::libtiff-4.1.0-hfc65ed5_0

  libuuid            conda-forge/linux-64::libuuid-2.32.1-h14c3975_1000

  libxcb             conda-forge/linux-64::libxcb-1.13-h14c3975_1002

  libxml2            conda-forge/linux-64::libxml2-2.9.10-hee79883_0

  lz4-c              conda-forge/linux-64::lz4-c-1.8.3-he1b5a44_1001

  olefile            conda-forge/noarch::olefile-0.46-py_0

  pcre               conda-forge/linux-64::pcre-8.43-he1b5a44_0

  pillow             conda-forge/linux-64::pillow-6.2.1-py36h6b7be26_0

  pixman             conda-forge/linux-64::pixman-0.38.0-h516909a_1003

  pthread-stubs      conda-forge/linux-64::pthread-stubs-0.4-h14c3975_1001

  rdkit              rdkit/linux-64::rdkit-2017.09.1-py36_1

  xorg-kbproto       conda-forge/linux-64::xorg-kbproto-1.0.7-h14c3975_1002

  xorg-libice        conda-forge/linux-64::xorg-libice-1.0.10-h516909a_0

  xorg-libsm         conda-forge/linux-64::xorg-libsm-1.2.3-h84519dc_1000

  xorg-libx11        conda-forge/linux-64::xorg-libx11-1.6.9-h516909a_0

  xorg-libxau        conda-forge/linux-64::xorg-libxau-1.0.9-h14c3975_0

  xorg-libxdmcp      conda-forge/linux-64::xorg-libxdmcp-1.1.3-h516909a_0

  xorg-libxext       conda-forge/linux-64::xorg-libxext-1.3.4-h516909a_0

  xorg-libxrender    conda-forge/linux-64::xorg-libxrender-0.9.10-h516909a_1002

  xorg-renderproto   conda-forge/linux-64::xorg-renderproto-0.11.1-h14c3975_1002

  xorg-xextproto     conda-forge/linux-64::xorg-xextproto-7.3.0-h14c3975_1002

  xorg-xproto        conda-forge/linux-64::xorg-xproto-7.0.31-h14c3975_1007

  zstd               conda-forge/linux-64::zstd-1.4.3-h3b9ef0a_0

Downloading and Extracting Packages

xorg-libice-1.0.10   | 57 KB     | ########## | 100% 

gettext-0.19.8.1     | 3.6 MB    | ########## | 100% 

xorg-libxext-1.3.4   | 51 KB     | ########## | 100% 

libtiff-4.1.0        | 595 KB    | ########## | 100% 

xorg-xextproto-7.3.0 | 27 KB     | ########## | 100% 

zstd-1.4.3           | 935 KB    | ########## | 100% 

pcre-8.43            | 257 KB    | ########## | 100% 

glib-2.58.3          | 3.3 MB    | ########## | 100% 

xorg-libxdmcp-1.1.3  | 18 KB     | ########## | 100% 

libpng-1.6.37        | 343 KB    | ########## | 100% 

libuuid-2.32.1       | 26 KB     | ########## | 100% 

xorg-libxau-1.0.9    | 13 KB     | ########## | 100% 

boost-1.63.0         | 11.8 MB   | ########## | 100% 

xorg-renderproto-0.1 | 8 KB      | ########## | 100% 

libxcb-1.13          | 396 KB    | ########## | 100% 

fontconfig-2.13.1    | 340 KB    | ########## | 100% 

pillow-6.2.1         | 639 KB    | ########## | 100% 

cairo-1.16.0         | 1.5 MB    | ########## | 100% 

xorg-xproto-7.0.31   | 72 KB     | ########## | 100% 

xorg-libsm-1.2.3     | 25 KB     | ########## | 100% 

xorg-libxrender-0.9. | 31 KB     | ########## | 100% 

xorg-kbproto-1.0.7   | 26 KB     | ########## | 100% 

xorg-libx11-1.6.9    | 918 KB    | ########## | 100% 

olefile-0.46         | 31 KB     | ########## | 100% 

freetype-2.10.0      | 884 KB    | ########## | 100% 

rdkit-2017.09.1      | 19.7 MB   | ########## | 100% 

pixman-0.38.0        | 594 KB    | ########## | 100% 

pthread-stubs-0.4    | 5 KB      | ########## | 100% 

Preparing transaction: ...working... done

Verifying transaction: ...working... done

Executing transaction: ...working... done
install.4

14.73s$ if [[ "$RDKIT" == true ]]; then conda install --yes -c omnia ambermini; fi
install.5

0.00s$ if [[ "$OPENEYE" == true ]]; then conda install -c openeye openeye-toolkits; fi
install.6

0.56s$ python setup.py develop --no-deps
```