### PR TITLE
Add note about maintaining py36 to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ branches:
 
 matrix:
   include:
+  # The maintainer of a downstream project has requested that 
+  # we maintain py36 compatibility until at least Feb 2022.
+  # Contact Jeff Wagner or Yutong Zhao if this is an issue.
+
   # Test osx with RDKit
   - os: osx
     language: generic


### PR DESCRIPTION
This PR puts a comment in our `.travis.yml` file to not remove the py36 builds until at least Feb 2022. 

@proteneer, a downstream user of OFFTK, has requested that we maintain py36 compatibility for at least the next two years. I don't see a problem with this, especially since there are probably several more silent downstream users that would benefit from this guarantee. I don't know of any enhancements in python>37 that would greatly improve our workflow, so I think a 2-year guarantee is fine. Are there any objections?
