### PR TITLE
[WIP] Bond parameter interpolation based on Wiberg bond orders

### DIFF
--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -1875,7 +1875,7 @@ class BondHandler(ParameterHandler):
             if bond.fractional_bond_order is None:
                 [k, length] = [bond_params.k, bond_params.length]
             else:
-                # Interpolate using fractional bond orders
+                # TODO: Interpolate using fractional bond orders
                 # TODO: Do we really want to allow per-bond specification of interpolation schemes?
                 order = bond.fractional_bond_order
                 if self.fractional_bondorder_interpolation == 'interpolate-linear':


### PR DESCRIPTION
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)

- [ ] Add a test force field with a `<Bonds version="0.3" potential="harmonic" fractional_bondorder_method="Wiberg" fractional_bondorder_interpolation="linear">` element
- [ ] Add functionality to use user-specified WBO instead of default (e.g. AM1)
- [ ] Fractional bond order getter from molecule, and/or individual bonds? Already present for Bond objects. Data type return for molecule level getter?
- [ ] How to handle Wiberg values outside interpolation k_bondorder1-->k_bondorder2 interval?
- [ ] Add tests for fractional bond orders in the interval, and out of the interval.
- [ ] How to implement functionality in `label_parameters`, e.g. return the functional form or do an explicit evaluation (calculating WBOs if not present).
- [ ] How to/Should we allow mixed sections, where nonfractional and fractional are used concurrently
- [ ] Make sure simple garbage inputs do not pass tests:
         - [ ] k_bo1 and k_bo3 but not k_bo2
- [ ] Ensure that bond object order is consistent between isomorphic molecules during parameterization (needs a working isomorphic function e.g. from Josh Horton's #472 PR)

