### PR TITLE
Rerun omega without stereo requirement if initial conf gen failed

### DIFF
--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -926,13 +926,13 @@ class TestForceField():
 
         assert serialized_1 == serialized_2
 
+        @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='Test requires RDKit toolkit')
+        def test_parameterize_ethanol_different_reference_ordering_rdkit(self):
+            """
+            Test parameterizing the same PDB, using reference mol2s that have different atom orderings.
+            The results of both should be identical.
+            """
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='Test requires RDKit toolkit')
-    def test_parameterize_ethanol_different_reference_ordering_rdkit(self):
-        """
-        Test parameterizing the same PDB, using reference mol2s that have different atom orderings.
-        The results of both should be identical.
-        """
         from simtk.openmm import app
         from simtk.openmm import XmlSerializer
 
@@ -965,6 +965,41 @@ class TestForceField():
 
         assert serialized_1 == serialized_2
 
+
+    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='Test requires RDKit toolkit')
+    def test_parameterize_mol_missing_stereo_rdkit(self):
+        """
+        Test parameterizing the same PDB, using reference mol2s that have different atom orderings.
+        The results of both should be identical.
+        """
+
+        from openforcefield.topology import Molecule, Topology
+        from openforcefield.typing.engines.smirnoff import ForceField
+        toolkit_registry = ToolkitRegistry(toolkit_precedence=[RDKitToolkitWrapper, AmberToolsToolkitWrapper])
+
+        molecule = Molecule.from_smiles('CC1CCC(=O)O1', allow_undefined_stereo=True)
+        topology = Topology.from_molecules([molecule])
+
+        force_field = ForceField('test_forcefields/smirnoff99Frosst.offxml')
+        force_field.create_openmm_system(topology, toolkit_registry=toolkit_registry)
+
+
+    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='Test requires OpenEye toolkit')
+    def test_parameterize_mol_missing_stereo_openeye(self):
+        """
+        Test parameterizing the same PDB, using reference mol2s that have different atom orderings.
+        The results of both should be identical.
+        """
+
+        from openforcefield.topology import Molecule, Topology
+        from openforcefield.typing.engines.smirnoff import ForceField
+        toolkit_registry = ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper])
+
+        molecule = Molecule.from_smiles('CC1CCC(=O)O1', allow_undefined_stereo=True)
+        topology = Topology.from_molecules([molecule])
+
+        force_field = ForceField('test_forcefields/smirnoff99Frosst.offxml')
+        force_field.create_openmm_system(topology, toolkit_registry=toolkit_registry)
 
     @pytest.mark.skip(reason="We will not support going directly to ParmEd for now."
                              "We will instead feed OpenMM System objects to ParmEd "

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -926,12 +926,12 @@ class TestForceField():
 
         assert serialized_1 == serialized_2
 
-        @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='Test requires RDKit toolkit')
-        def test_parameterize_ethanol_different_reference_ordering_rdkit(self):
-            """
-            Test parameterizing the same PDB, using reference mol2s that have different atom orderings.
-            The results of both should be identical.
-            """
+    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='Test requires RDKit toolkit')
+    def test_parameterize_ethanol_different_reference_ordering_rdkit(self):
+        """
+        Test parameterizing the same PDB, using reference mol2s that have different atom orderings.
+        The results of both should be identical.
+        """
 
         from simtk.openmm import app
         from simtk.openmm import XmlSerializer
@@ -969,8 +969,7 @@ class TestForceField():
     @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='Test requires RDKit toolkit')
     def test_parameterize_mol_missing_stereo_rdkit(self):
         """
-        Test parameterizing the same PDB, using reference mol2s that have different atom orderings.
-        The results of both should be identical.
+        Test parameterizing a molecule with undefined stereochemsity using the RDKit/AmberTools backend.
         """
 
         from openforcefield.topology import Molecule, Topology
@@ -987,8 +986,7 @@ class TestForceField():
     @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='Test requires OpenEye toolkit')
     def test_parameterize_mol_missing_stereo_openeye(self):
         """
-        Test parameterizing the same PDB, using reference mol2s that have different atom orderings.
-        The results of both should be identical.
+        Test parameterizing a molecule with undefined stereochemsity using the OpenEye backend.
         """
 
         from openforcefield.topology import Molecule, Topology

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -1159,7 +1159,11 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         status = omega(oemol)
 
         if status is False:
-            raise Exception("OpenEye Omega conformer generation failed")
+            omega.SetStrictStereo(False)
+            new_status = omega(oemol)
+            if new_status is False:
+                raise Exception("OpenEye Omega conformer generation failed")
+
 
         molecule2 = self.from_openeye(oemol, allow_undefined_stereo=True)
 


### PR DESCRIPTION
- [x] Fix #515 
- [x] Fix #382 
- [x] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)

If people have an OFFMol with undefined stereo, they should be able to just parameterize it. 

I could add a warning for when the stereo requirement is relaxed, but we have enough warnings.