### PR TITLE
Mark protein param test as slow and shorten C3000 test

### DIFF
--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -1973,6 +1973,7 @@ class TestForceFieldParameterAssignment:
         # Ensure that all system energies are the same
         compare_system_energies(off_omm_system, amber_omm_system, positions, by_force_type=False)
 
+    @pytest.mark.slow
     @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(),
                         reason='Test requires OE toolkit to read mol2 files')
     @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)

--- a/openforcefield/tests/test_toolkits.py
+++ b/openforcefield/tests/test_toolkits.py
@@ -571,11 +571,11 @@ class TestOpenEyeToolkitWrapper:
         """Test OpenEyeToolkitWrapper substructure search when a large number hits are found"""
 
         tk = OpenEyeToolkitWrapper()
-        smiles = "C"*3000
+        smiles = "C"*600
         molecule = tk.from_smiles(smiles)
         query = "[C:1]~[C:2]"
         ret = molecule.chemical_environment_matches(query, toolkit_registry=tk)
-        assert len(ret) == 5998 
+        assert len(ret) == 1198 
         assert len(ret[0]) == 2
 
     def test_find_rotatable_bonds(self):


### PR DESCRIPTION
Following #491 

The new protein parameterization test is slow (like, >5 minutes), so I'm marking it as `slow`.  The C3000 also takes a while, so I'm changing it down to C600, which should still ensure that the max-SMARTS-matches increase is working.