### PR TITLE
Ignore DOI url tests

### DIFF
--- a/openforcefield/tests/test_examples.py
+++ b/openforcefield/tests/test_examples.py
@@ -132,6 +132,10 @@ def test_readme_links(readme_link):
                'Accept': 'application/xhtml+xml,text/html,application/xml;q=0.9,*/*;q=0.8',}
     request = Request(readme_link, headers=headers)
 
+    # Some DOI-based links are now behind DDoS protections, so skip them
+    if 'doi.org' in readme_link:
+        pytest.skip("DOI links are behind DDoS protection and do not resolve")
+
     # Try to connect 3 times, keeping track of exceptions so useful feedback can be provided.
     success = False
     exception= None


### PR DESCRIPTION
DOI.org is now protected behind cloudflare DDOS protection. This PR skips tests of DOI.org links. 