### PR TITLE
Write multi-conformer PDBS with RDKit

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -55,12 +55,12 @@ Behavior changed
 API-breaking changes
 """"""""""""""""""""
 - `PR #558 <https://github.com/openforcefield/openforcefield/pull/558>`_: Removes
-  ``TopologyMolecule.topology_particle_start_index``, since the :py:class`Topology <openforcefield.topology.Topology>`
+  ``TopologyMolecule.topology_particle_start_index``, since the :py:class:`Topology <openforcefield.topology.Topology>`
   particle indexing system now orders :py:class`TopologyVirtualSites <openforcefield.topology.TopologyVirtualSite>`
   after all atoms.
-  :py:meth`TopologyMolecule.topology_atom_start_index <openforcefield.topology.TopologyMolecule.topology_atom_start_index>`
+  :py:meth:`TopologyMolecule.topology_atom_start_index <openforcefield.topology.TopologyMolecule.topology_atom_start_index>`
   and
-  :py:meth`TopologyMolecule.topology_virtual_site_start_index <openforcefield.topology.TopologyMolecule.topology_virtual_site_start_index>`
+  :py:meth:`TopologyMolecule.topology_virtual_site_start_index <openforcefield.topology.TopologyMolecule.topology_virtual_site_start_index>`
   are still available to access the appropriate values in the respective topology indexing systems.
 - `PR #508 <https://github.com/openforcefield/openforcefield/pull/508>`_:
   ``OpenEyeToolkitWrapper.compute_wiberg_bond_orders`` is now
@@ -211,6 +211,8 @@ Tests added
   for monatomic ions in ``test_forcefields/ion_charges.offxml``.
 - `PR #543 <https://github.com/openforcefield/openforcefield/pull/543>`_: Added tests to assure that state enumeration can
   correctly find molecules tautomers, stereoisomers and protomers when possible.
+- `PR #543 <https://github.com/openforcefield/openforcefield/pull/579>`_: Adds regression tests to ensure RDKit can be
+  be used to write multi-model PDB files.
 
 
 Bugfixes
@@ -248,8 +250,11 @@ Bugfixes
 - `Issue #474 <https://github.com/openforcefield/openforcefield/issues/474>`_: We can now  convert molecules to InChI and
    InChIKey and from InChI.
 - `Issue #523 <https://github.com/openforcefield/openforcefield/issues/523>`_: The
-   :py:meth: `Molecule.to_file <openforcefield.topology.Molecule.to_file>` can now correctly write to `MOL` files in
+   :py:meth:`Molecule.to_file <openforcefield.topology.Molecule.to_file>` can now correctly write to `MOL` files in
    line with the support file type list.
+- `Issue #568 <https://github.com/openforcefield/openforcefield/issues/568>`_: The
+  :py:meth:`Molecule.to_file <openforcefield.topology.Molecule.to_file>` can now correctly write multi-model PDB files
+  when using the RDKit backend toolkit.
 
 Example added
 """""""""""""

--- a/openforcefield/tests/test_toolkits.py
+++ b/openforcefield/tests/test_toolkits.py
@@ -541,6 +541,8 @@ class TestOpenEyeToolkitWrapper:
         Test OpenEyeToolkitWrapper for writing a multiconformer molecule to SDF. The OFF toolkit should only
         save the first conformer.
         """
+        from io import StringIO
+
         toolkit_wrapper = OpenEyeToolkitWrapper()
         filename = get_data_file_path('molecules/ethanol.sdf')
         ethanol = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
@@ -548,8 +550,9 @@ class TestOpenEyeToolkitWrapper:
         ethanol.properties['test_prop'] = 'test_value'
         new_conf = ethanol.conformers[0] + (np.ones(ethanol.conformers[0].shape) * unit.angstrom)
         ethanol.add_conformer(new_conf)
-        ethanol.to_file('temp.sdf', 'sdf', toolkit_registry=toolkit_wrapper)
-        data = open('temp.sdf').read()
+        sio = StringIO()
+        ethanol.to_file(sio, 'sdf', toolkit_registry=toolkit_wrapper)
+        data = sio.getvalue()
         # In SD format, each molecule ends with "$$$$"
         assert data.count('$$$$') == 1
         # A basic SDF for ethanol would be 27 lines, though the properties add three more
@@ -1382,6 +1385,8 @@ class TestRDKitToolkitWrapper:
         Test RDKitToolkitWrapper for writing a multiconformer molecule to SDF. The OFF toolkit should only
         save the first conformer
         """
+        from io import StringIO
+
         toolkit_wrapper = RDKitToolkitWrapper()
         filename = get_data_file_path('molecules/ethanol.sdf')
         ethanol = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
@@ -1389,8 +1394,9 @@ class TestRDKitToolkitWrapper:
         ethanol.properties['test_prop'] = 'test_value'
         new_conf = ethanol.conformers[0] + (np.ones(ethanol.conformers[0].shape) * unit.angstrom)
         ethanol.add_conformer(new_conf)
-        ethanol.to_file('temp.sdf', 'sdf', toolkit_registry=toolkit_wrapper)
-        data = open('temp.sdf').read()
+        sio = StringIO()
+        ethanol.to_file(sio, 'sdf', toolkit_registry=toolkit_wrapper)
+        data = sio.getvalue()
         # In SD format, each molecule ends with "$$$$"
         assert data.count('$$$$') == 1
         # A basic SDF for ethanol would be 27 lines, though the properties add three more
@@ -1401,6 +1407,27 @@ class TestRDKitToolkitWrapper:
         assert str(ethanol.conformers[0][0][0].value_in_unit(unit.angstrom))[:5] in data
         # Ensure the SECOND conformer's first atom's X coordinate is NOT in the file
         assert str(ethanol.conformers[1][0][0].in_units_of(unit.angstrom))[:5] not in data
+
+    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    def test_write_milticonformer_pdb(self):
+        """
+        Make sure RDKit can write multi conformer PDB files.
+        """
+        from io import StringIO
+
+        toolkit = RDKitToolkitWrapper()
+        # load up a multiconformer pdb file and condense down the conformers
+        molecules = Molecule.from_file(get_data_file_path('molecules/butane_multi.sdf'), toolkit_registry=toolkit)
+        butane = molecules.pop(0)
+        for mol in molecules:
+            butane.add_conformer(mol.conformers[0])
+        assert butane.n_conformers == 7
+        sio = StringIO()
+        butane.to_file(sio, 'pdb', toolkit_registry=toolkit)
+        # we need to make sure each conformer is wrote to the file
+        pdb = sio.getvalue()
+        for i in range(1, 8):
+            assert f'MODEL        {i}' in pdb
 
     # Unskip this when we implement PDB-reading support for RDKitToolkitWrapper
     @pytest.mark.skip

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -2752,7 +2752,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
                     x, y, z = conformer[atom_idx, :].value_in_unit(unit.angstrom)
                     rdmol_conformer.SetAtomPosition(atom_idx,
                                                     Geometry.Point3D(x, y, z))
-                rdmol.AddConformer(rdmol_conformer)
+                rdmol.AddConformer(rdmol_conformer, assignId=True)
 
         # Retain charges, if present
         if not (molecule._partial_charges is None):


### PR DESCRIPTION
- [X] Fix #568 
- [X] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [x] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)

This should fix RDKit and allow it to write multi-conformer PDB files, also added a test for this.