### PR TITLE
Pin sphinx 2.x.x since 3.x.x incompatible with m2r

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ import openforcefield
 #
 # Sphinx pin is because of m2r compatibility
 # https://github.com/openforcefield/openforcefield/pull/594
-needs_sphinx = '2'
+needs_sphinx = '2.4'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ import openforcefield
 #
 # Sphinx pin is because of m2r compatibility
 # https://github.com/openforcefield/openforcefield/pull/594
-needs_sphinx = '2.4.4'
+needs_sphinx = '2'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,9 @@ import openforcefield
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+# Sphinx pin is because of m2r compatibility
+# https://github.com/openforcefield/openforcefield/pull/594
+needs_sphinx = '2.4.4'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,6 +6,8 @@ channels:
 dependencies:
     # readthedocs dependencies
     - numpydoc
+    # Sphinx pin is because of m2r compatibility
+    # https://github.com/openforcefield/openforcefield/pull/594
     - sphinx ==2
     - nbsphinx
     - sphinx_bootstrap_theme

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
     # readthedocs dependencies
     - numpydoc
+    - sphinx ==2
     - nbsphinx
     - sphinx_bootstrap_theme
     - m2r >=0.2.1

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,9 +6,6 @@ channels:
 dependencies:
     # readthedocs dependencies
     - numpydoc
-    # Sphinx pin is because of m2r compatibility
-    # https://github.com/openforcefield/openforcefield/pull/594
-    - sphinx ==2
     - nbsphinx
     - sphinx_bootstrap_theme
     - m2r >=0.2.1


### PR DESCRIPTION
Per https://github.com/sphinx-doc/sphinx/issues/7420

Quick fix to get docs building again. I'll add making a more permanent fix to our task list. 