### PR TITLE
Implement ForceField.__getitem__ override

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -86,6 +86,8 @@ API-breaking changes
 
 New features
 """"""""""""
+- `PR #600 <https://github.com/openforcefield/openforcefield/pull/600>`_:
+  Adds :py:meth:`ForceField.__getitem__ <openforcefield.typing.engines.smirnoff.forcefield.ForceField.__getitem__>` to look up ``ParameterHandler`` objects based on their string names.
 - `PR #508 <https://github.com/openforcefield/openforcefield/pull/508>`_:
   Adds :py:meth:`AmberToolsToolkitWrapper.assign_fractional_bond_orders <openforcefield.utils.toolkits.AmberToolsToolkitWrapper.assign_wiberg_bond_orders>`.
 - `PR #469 <https://github.com/openforcefield/openforcefield/pull/469>`_:

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -1125,6 +1125,8 @@ class TestForceField():
         bonds = forcefield['Bonds']
         with pytest.raises(NotImplementedError):
             forcefield[bonds]
+        with pytest.raises(NotImplementedError):
+            forcefield[type(bonds)]
         
 class TestForceFieldChargeAssignment:
 

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -1110,13 +1110,14 @@ class TestForceField():
 
         assert handlers_before == handlers_after
 
-    def test_unregistered_parameter_handler_lookup(self):
+    @pytest.mark.parametrize('unregistered_handler', ['LibraryCharges', 'foobar'])
+    def test_unregistered_parameter_handler_lookup(self, unregistered_handler):
         """Ensure __getitem__ lookups do not register new handlers"""
         forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
-        unregistered_handler = 'LibraryCharges'
 
         assert unregistered_handler not in forcefield._parameter_handlers
-        forcefield[unregistered_handler]
+        with pytest.raises(KeyError, match=unregistered_handler):
+            forcefield[unregistered_handler]
         assert unregistered_handler not in forcefield._parameter_handlers
 
     def test_lookup_parameter_handler_object(self):

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -1255,5 +1255,7 @@ class ForceField:
         if isinstance(val, str):
             if val in self._parameter_handlers:
                 return self.get_parameter_handler(val)
+            else:
+                raise KeyError(f"Parameter handler with name '{val}' not found.")
         elif isinstance(val, ParameterHandler) or issubclass(val, ParameterHandler):
             raise NotImplementedError

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -1246,3 +1246,11 @@ class ForceField:
             msg += "Known parameter handler class tags are {}".format(self._parameter_handler_classes.keys())
             raise KeyError(msg)
         return ph_class
+
+    def __getitem__(self, val):
+        """Syntax sugar for lookikng up a ParameterHandler."""
+        if isinstance(val, str):
+            if val in self._parameter_handlers:
+                return self.get_parameter_handler(val)
+        elif isinstance(val, ParameterHandler):
+            raise NotImplementedError

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -1248,9 +1248,12 @@ class ForceField:
         return ph_class
 
     def __getitem__(self, val):
-        """Syntax sugar for lookikng up a ParameterHandler."""
+        """
+        Syntax sugar for lookikng up a ParameterHandler. Note that only
+        string-based lookups are currently supported.
+        """
         if isinstance(val, str):
             if val in self._parameter_handlers:
                 return self.get_parameter_handler(val)
-        elif isinstance(val, ParameterHandler):
+        elif isinstance(val, ParameterHandler) or issubclass(val, ParameterHandler):
             raise NotImplementedError


### PR DESCRIPTION
Implements #599. I tried to cover everything I could think of here and implement @j-wags's suggestions. I'm not implementing `ParameterHandler.__getitem__` for now.

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
