### PR TITLE
Added shim that allows us to use m2r components, but recommonmark mainly

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,9 +2,8 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = python -msphinx
-SPHINXPROJ    = openforcefield
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -313,20 +313,19 @@ texinfo_documents = [
 
 
 # workaround for m2r broken on sphinx >= 3.x
-#def monkeypatch(cls):
-#    """ decorator to monkey-patch methods """
-#    def decorator(f):
-#        method = f.__name__
-#        old_method = getattr(cls, method)
-#        setattr(cls, method, lambda self, *args, **kwargs: f(old_method, self, *args, **kwargs))
-#    return decorator
-#
-## workaround until https://github.com/miyakogi/m2r/pull/55 is merged
-#@monkeypatch(sphinx.registry.SphinxComponentRegistry)
-#def add_source_parser(_old_add_source_parser, self, *args, **kwargs):
-#    # signature is (parser: Type[Parser], **kwargs), but m2r expects
-#    # the removed (str, parser: Type[Parser], **kwargs).
-#    if isinstance(args[0], str):
-#        args = args[1:]
-#    return _old_add_source_parser(self, *args, **kwargs)
-#
+def monkeypatch(cls):
+    """ decorator to monkey-patch methods """
+    def decorator(f):
+        method = f.__name__
+        old_method = getattr(cls, method)
+        setattr(cls, method, lambda self, *args, **kwargs: f(old_method, self, *args, **kwargs))
+    return decorator
+
+# workaround until https://github.com/miyakogi/m2r/pull/55 is merged
+@monkeypatch(sphinx.registry.SphinxComponentRegistry)
+def add_source_parser(_old_add_source_parser, self, *args, **kwargs):
+    # signature is (parser: Type[Parser], **kwargs), but m2r expects
+    # the removed (str, parser: Type[Parser], **kwargs).
+    if isinstance(args[0], str):
+        args = args[1:]
+    return _old_add_source_parser(self, *args, **kwargs)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,13 +21,15 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('.'))
 
+import sphinx
+
 # bootstrap theme
 import sphinx_bootstrap_theme
 
 import openforcefield
 
-from recommonmark.transform import AutoStructify
-from m2r import MdInclude
+#from recommonmark.transform import AutoStructify
+#from m2r import MdInclude
 
 # -- General configuration ------------------------------------------------
 
@@ -49,7 +51,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
     'nbsphinx',
-    'recommonmark', # render markdown
+    #'recommonmark', # render markdown
+    'm2r', # render markdown
     ]
 
 autosummary_generate = True
@@ -293,17 +296,37 @@ texinfo_documents = [
 # m2r unmaintained, but has features that aren't easy to replicate in recommonmark
 # https://github.com/readthedocs/recommonmark/issues/191#issuecomment-622369992
 # credit: @orsinium
-def setup(app):
-    config = {
-        'auto_toc_tree_section': 'Contents',
-        'enable_eval_rst': True,
-    }
-    app.add_config_value('recommonmark_config', config, True)
-    app.add_transform(AutoStructify)
+#def setup(app):
+#    config = {
+#        'auto_toc_tree_section': 'Contents',
+#        'enable_eval_rst': True,
+#    }
+#    app.add_config_value('recommonmark_config', config, True)
+#    app.add_transform(AutoStructify)
+#
+#    # from m2r to make `mdinclude` work
+#    app.add_config_value('no_underscore_emphasis', False, 'env')
+#    app.add_config_value('m2r_parse_relative_links', True, 'env')
+#    app.add_config_value('m2r_anonymous_references', False, 'env')
+#    app.add_config_value('m2r_disable_inline_math', False, 'env')
+#    app.add_directive('mdinclude', MdInclude)
 
-    # from m2r to make `mdinclude` work
-    app.add_config_value('no_underscore_emphasis', False, 'env')
-    app.add_config_value('m2r_parse_relative_links', True, 'env')
-    app.add_config_value('m2r_anonymous_references', False, 'env')
-    app.add_config_value('m2r_disable_inline_math', False, 'env')
-    app.add_directive('mdinclude', MdInclude)
+
+# workaround for m2r broken on sphinx >= 3.x
+def monkeypatch(cls):
+    """ decorator to monkey-patch methods """
+    def decorator(f):
+        method = f.__name__
+        old_method = getattr(cls, method)
+        setattr(cls, method, lambda self, *args, **kwargs: f(old_method, self, *args, **kwargs))
+    return decorator
+
+# workaround until https://github.com/miyakogi/m2r/pull/55 is merged
+@monkeypatch(sphinx.registry.SphinxComponentRegistry)
+def add_source_parser(_old_add_source_parser, self, *args, **kwargs):
+    # signature is (parser: Type[Parser], **kwargs), but m2r expects
+    # the removed (str, parser: Type[Parser], **kwargs).
+    if isinstance(args[0], str):
+        args = args[1:]
+    return _old_add_source_parser(self, *args, **kwargs)
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -303,7 +303,7 @@ def setup(app):
 
     # from m2r to make `mdinclude` work
     app.add_config_value('no_underscore_emphasis', False, 'env')
-    app.add_config_value('m2r_parse_relative_links', False, 'env')
+    app.add_config_value('m2r_parse_relative_links', True, 'env')
     app.add_config_value('m2r_anonymous_references', False, 'env')
     app.add_config_value('m2r_disable_inline_math', False, 'env')
     app.add_directive('mdinclude', MdInclude)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,9 @@ import sphinx_bootstrap_theme
 
 import openforcefield
 
+from recommonmark.transform import AutoStructify
+from m2r import MdInclude
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -46,7 +49,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
     'nbsphinx',
-    'm2r', # render markdown
+    'recommonmark', # render markdown
     ]
 
 autosummary_generate = True
@@ -285,3 +288,22 @@ texinfo_documents = [
      author, 'openforcefield', 'One line description of project.',
      'Miscellaneous'),
 ]
+
+# workaround for using m2r only for mdinclude and recommonmark for everything else
+# m2r unmaintained, but has features that aren't easy to replicate in recommonmark
+# https://github.com/readthedocs/recommonmark/issues/191#issuecomment-622369992
+# credit: @orsinium
+def setup(app):
+    config = {
+        'auto_toc_tree_section': 'Contents',
+        'enable_eval_rst': True,
+    }
+    app.add_config_value('recommonmark_config', config, True)
+    app.add_transform(AutoStructify)
+
+    # from m2r to make `mdinclude` work
+    app.add_config_value('no_underscore_emphasis', False, 'env')
+    app.add_config_value('m2r_parse_relative_links', False, 'env')
+    app.add_config_value('m2r_anonymous_references', False, 'env')
+    app.add_config_value('m2r_disable_inline_math', False, 'env')
+    app.add_directive('mdinclude', MdInclude)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -313,20 +313,20 @@ texinfo_documents = [
 
 
 # workaround for m2r broken on sphinx >= 3.x
-def monkeypatch(cls):
-    """ decorator to monkey-patch methods """
-    def decorator(f):
-        method = f.__name__
-        old_method = getattr(cls, method)
-        setattr(cls, method, lambda self, *args, **kwargs: f(old_method, self, *args, **kwargs))
-    return decorator
-
-# workaround until https://github.com/miyakogi/m2r/pull/55 is merged
-@monkeypatch(sphinx.registry.SphinxComponentRegistry)
-def add_source_parser(_old_add_source_parser, self, *args, **kwargs):
-    # signature is (parser: Type[Parser], **kwargs), but m2r expects
-    # the removed (str, parser: Type[Parser], **kwargs).
-    if isinstance(args[0], str):
-        args = args[1:]
-    return _old_add_source_parser(self, *args, **kwargs)
-
+#def monkeypatch(cls):
+#    """ decorator to monkey-patch methods """
+#    def decorator(f):
+#        method = f.__name__
+#        old_method = getattr(cls, method)
+#        setattr(cls, method, lambda self, *args, **kwargs: f(old_method, self, *args, **kwargs))
+#    return decorator
+#
+## workaround until https://github.com/miyakogi/m2r/pull/55 is merged
+#@monkeypatch(sphinx.registry.SphinxComponentRegistry)
+#def add_source_parser(_old_add_source_parser, self, *args, **kwargs):
+#    # signature is (parser: Type[Parser], **kwargs), but m2r expects
+#    # the removed (str, parser: Type[Parser], **kwargs).
+#    if isinstance(args[0], str):
+#        args = args[1:]
+#    return _old_add_source_parser(self, *args, **kwargs)
+#

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,6 +8,7 @@ dependencies:
     - numpydoc
     - nbsphinx
     - sphinx_bootstrap_theme
+    - sphinx ==2.4
     - m2r >=0.2.1
     - testpath ==0.3.1
     # conda build dependencies

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,7 +8,6 @@ dependencies:
     - numpydoc
     - nbsphinx
     - sphinx_bootstrap_theme
-    - sphinx ==2.4
     - m2r >=0.2.1
     - testpath ==0.3.1
     # conda build dependencies

--- a/docs/readthedocs.yml
+++ b/docs/readthedocs.yml
@@ -1,5 +1,6 @@
+version: 2
+
 conda:
-   file: environment.yml
+   environment: environment.yml
 python:
-   setup_py_install: true
    version: 3.5


### PR DESCRIPTION
Addresses #598 

This PR fixes the doc build, which uses Sphinx 3.x.  `m2r`, which we used for markdown handling, appears unmaintained and fails when building the docs under this version of Sphinx.

I used [this approach](https://github.com/readthedocs/recommonmark/issues/191#issuecomment-622369992) to use the components we need from `m2r` (`.. mdinclude::` directive), but `recommonmark` for everything else.

I would like a second set of eyes on the built docs to ensure everything is being generated as expected.

Also made some changes to makefile in line with latest sphinx (3.x) config generation. This may not necessarily be desirable; review requested.

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [x] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
