### PR TITLE
Skip cron jobs on forks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   test:
+    if: (github.event_name == 'schedule' && github.repository == 'openforcefield/openforcefield') || (github.event_name != 'schedule')
     name: Test on ${{ matrix.cfg.os }}, Python ${{ matrix.python-version }}, RDKit=${{ matrix.cfg.rdkit }}, OpenEye=${{ matrix.cfg.openeye }}
     runs-on: ${{ matrix.cfg.os }}
     strategy:


### PR DESCRIPTION
Fixes #612, copied from https://github.community/t/do-not-run-cron-workflows-in-forks/17636