### PR TITLE
Use org-wide oe license for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,9 +79,9 @@ jobs:
     - name: Decrypt OpenEye license
       shell: bash
       env:
-        ENC_OE_LICENSE: ${{ secrets.OE_LICENSE__EXP_JUN2020 }}
+        OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
       run: |
-        echo "${ENC_OE_LICENSE}" > ${OE_LICENSE}
+        echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
     - name: Prepare test environment
       shell: bash
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,7 +76,7 @@ jobs:
         conda update --quiet --all
         conda info --all
         conda list
-    - name: Decrypt OpenEye license
+    - name: Make oe_license.txt file from GH org secret "OE_LICENSE"
       shell: bash
       env:
         OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}


### PR DESCRIPTION
Looks like the previous OE license we were using expired. I'm updating this to use the new, org-wide license, which should be good for another year. 
