### PR TITLE
Finalize 0.7.0 releasenotes

### DIFF
--- a/The-SMIRNOFF-force-field-format.md
+++ b/The-SMIRNOFF-force-field-format.md
@@ -492,7 +492,7 @@ can be replaced by a single parameter line by first defining the `fractional_bon
 ```
 This allows specification of the barrier height for e.g. bond orders 1 and 2 (single and double bonds), and then interpolation between those based on the partial/fractional bond order.
 Note that in actual usage partial/fractional bond order may never be exactly 1 or 2, or perhaps even near 2; these values only serve to define the slope of the line used for interpolation.
-In the example above, we replaced the two proper torsion terms (one single central bond (`-`) and one double central bond (`=`)) with a single term giving the barrier heights for bond order 1 and 2.
+In the example above, we replaced the two proper torsion terms (one single central bond (`-`) and one double central bond (`=`) with a single term giving the barrier heights for bond order 1 and 2.
 If there are cases where the fractional bond order is 1.5, this can correspond to e.g. an aromatic bond.
 When barrier heights for more than two integer bond orders are specified, (say, 1, 2, and 3), the interpolation lines are drawn between successive points as a piecewiese linear function.
 

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -7,8 +7,54 @@ Releases follow the ``major.minor.micro`` scheme recommended by `PEP440 <https:/
 * ``minor`` increments add features but do not break API compatibility
 * ``micro`` increments represent bugfix releases or improvements in documentation
 
-0.7.0 - Current development
----------------------------
+0.7.0 - Charge Increment Model, Proper Torsion interpolation, and new Molecule methods
+--------------------------------------------------------------------------------------
+
+This is a relatively large release, motivated by the idea that changing existing functionality is bad
+so we shouldn't do it too often, but when we do change things we should do it all at once.
+
+Here's a brief rundown of what changed, migration tips, and what to search below to find more details:
+
+* To provide more consistent partial charges for a given molecule, existing conformers are now disregarded by default
+  by ``compute_partial_charges``. Instead, new conformers are generated for use in semiempirical calculations.
+  Search for `use_conformers` below.
+* Formal charges are now always returned as ``simtk.unit.Quantity`` objects, with units of elementary charge.
+  To convert them to integers, ``from simtk import unit`` and
+  ``atom.formal_charge.value_in_unit(unit.elementary_charge)`` or
+  ``mol.total_charge.value_in_unit(unit.elementary_charge)``.
+  Search ``atom.formal_charge`` below.
+* The OpenFF Toolkit now automatically reads and writes partial charges in SDF. Search for
+  ``atom.dprop.PartialCharges`` below.
+* The OpenFF Toolkit now has different behavior for handling multi-molecule and multi-conformer SDF files. Search
+  ``multi-conformer`` below.
+* The OpenFF Toolkit now distinguishes between partial charges that are all-zero and partial charges that are unknown.
+  Search ``partial_charges = None`` below.
+* ``Topology.to_openmm`` now assigns unique atoms names by default. Search ``ensure_unique_atom_names`` below.
+* Molecule equality checks are now done by graph comparison instead of SMILES comparison.
+  Search ``Molecule.are_isomorphic`` below.
+* The ``ChemicalEnvironment`` module was almost entirely removed, as it is an outdated duplicate of some Chemper
+  functionality. Search ``ChemicalEnvironment`` below.
+* ``TopologyMolecule.topology_particle_start_index`` has been removed from the ``TopologyMolecule`` API, since atoms
+  and virtualsites are no longer contiguous in the ``Topology`` particle indexing system. Search
+  ``topology_particle_start_index`` below.
+* ``compute_wiberg_bond_orders`` has been renamed to ``assign_fractional_bond_orders``.
+
+There are also a number of new features, such as:
+
+* Support for ``ChargeIncrementModel`` sections in force fields.
+* Support for ``ProperTorsion`` ``k`` interpolation in force fields using fractional bond orders.
+* Support for AM1-Mulliken, Gasteiger, and other charge methods using the new ``assign_partial_charges`` methods.
+* Support for AM1-Wiberg bond order calculation using either the OpenEye or RDKit/AmberTools backends.
+* Initial (limited) interoperability with QCArchive, via ``Molecule.to_qcschema`` and ``from_qcschema``.
+* A ``Molecule.visualize`` method.
+* Several additional ``Molecule`` methods, including state enumeration and mapped SMILES creation.
+
+**Major Feature: Support for the SMIRNOFF ChargeIncrementModel tag**
+
+`The ChargeIncrementModel tag in the SMIRNOFF specification <https://open-forcefield-toolkit.readthedocs.io/en/latest/smirnoff.html#chargeincrementmodel-small-molecule-and-fragment-charges>`_.
+provides analagous functionality to AM1-BCC, except that instead of AM1-Mulliken charges, a number of different charge
+methods can be called, and instead of a fixed library of two-atom charge corrections, an arbitrary number of
+SMIRKS-based, N-atom charge corrections can be defined in the SMIRNOFF format.
 
 The initial implementation of the SMIRNOFF ``ChargeIncrementModel`` tag accepts keywords for ``version``,
 ``partial_charge_method``, and ``number_of_conformers``. ``partial_charge_method`` can be any string, and it is
@@ -48,6 +94,18 @@ In short, the first time a group of atoms becomes involved in a ``ChargeIncremen
 parameter "slot". Only another ``ChargeIncrement`` which applies to the exact same group of atoms (in any order) can
 take over the "slot", pushing the original ``ChargeIncrement`` out.
 
+**Major Feature: Support for ProperTorsion k value interpolation**
+
+Chaya Stern's work showed that we may be able to produce higher-quality proper torsion parameters by taking into
+account the "partial bond order" of the torsion's central bond. We now have the machinery to compute AM1-Wiberg
+partial bond orders for entire molecules using either ``OpenEyeToolkitWrapper``'s or ``AmberToolsToolkitWrapper``'s
+``assign_fractional_bond_orders`` methods. The thought is that, if some simple electron population analysis shows
+that a certain aromatic bond's order is 1.53, maybe rotations about that bond can be described well by interpolating
+53% of the way between the single and double bond k values.
+
+Full details of how to define a torsion-interpolating SMIRNOFF force fields are available in
+`the ProperTorsions section of the SMIRNOFF specification <https://open-forcefield-toolkit.readthedocs.io/en/latest/smirnoff.html#fractional-torsion-bond-orders>`_.
+
 Behavior changed
 """"""""""""""""
 - `PR #508 <https://github.com/openforcefield/openforcefield/pull/508>`_:
@@ -79,7 +137,7 @@ Behavior changed
   important distinction, since otherwise there is ambiguity around whether properties of one
   entry in a SDF are shared among several molecule blocks or not, or how to resolve conflicts if properties
   are defined differently for several "conformers" of chemically-identical species (More info
-  `here <https://docs.eyesopen.com/toolkits/python/oechemtk/oemol.html#dude-where-s-my-sd-data>`_.
+  `here <https://docs.eyesopen.com/toolkits/python/oechemtk/oemol.html#dude-where-s-my-sd-data>`_).
   If the user requests the OFF
   Toolkit to write a multi-conformer ``Molecule`` to SDF, only the first conformer will be written.
   For more fine-grained control of writing properties, conformers, and partial charges, consider
@@ -115,12 +173,9 @@ Behavior changed
   :py:meth:`Topology.add_molecule <openforcefield.topology.Topology.add_molecule>` now use the
   :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>` to match
   molecules.
-- `PR #544 <https://github.com/openforcefield/openforcefield/pull/544>`_: Raises
-  ``NotImplementedError`` when calling
-  :py:meth:`ParameterHandler.get_parameter   <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler.get_parameter>`,
-  which is not yet implemented, but would previously silently return ``None``.
 - `PR #551 <https://github.com/openforcefield/openforcefield/pull/551>`_: Implemented the
-  :py:meth:`ParameterHandler.get_parameter   <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler.get_parameter>` function.
+  :py:meth:`ParameterHandler.get_parameter <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler.get_parameter>`
+  function (would previously return ``None``).
 
 API-breaking changes
 """"""""""""""""""""
@@ -181,7 +236,7 @@ New features
   behavior, ``strict_n_conformers`` defaults to a value of ``False``.
 - `PR #471 <https://github.com/openforcefield/openforcefield/pull/471>`_: Adds
   keyword argument ``raise_exception_types`` (default: ``[Exception]``) to
-  :py:meth:`ToolkitRegistry.call <openforcefield.utils.toolkits.ToolkitRegistry.call>.
+  :py:meth:`ToolkitRegistry.call <openforcefield.utils.toolkits.ToolkitRegistry.call>`.
   The default value will provide the previous OpenFF Toolkit behavior, which is that the first ToolkitWrapper
   that can provide the requested method is called, and it either returns on success or raises an exception. This new
   keyword argument allows the ToolkitRegistry to *ignore* certain exceptions, but treat others as fatal.
@@ -194,30 +249,31 @@ New features
   :py:meth:`OpenEyeToolkitWrapper.get_tagged_smarts_connectivity <openforcefield.utils.toolkits.OpenEyeToolkitWrapper.get_tagged_smarts_connectivity>`,
   which allow the use of either toolkit for smirks/tagged smarts validation.
 - `PR #600 <https://github.com/openforcefield/openforcefield/pull/600>`_:
-  Adds :py:meth:`ForceField.__getitem__ <openforcefield.typing.engines.smirnoff.forcefield.ForceField.__getitem__>` to look up ``ParameterHandler`` objects based on their string names.
+  Adds :py:meth:`ForceField.__getitem__ <openforcefield.typing.engines.smirnoff.forcefield.ForceField.__getitem__>`
+  to look up ``ParameterHandler`` objects based on their string names.
 - `PR #508 <https://github.com/openforcefield/openforcefield/pull/508>`_:
   Adds :py:meth:`AmberToolsToolkitWrapper.assign_fractional_bond_orders <openforcefield.utils.toolkits.AmberToolsToolkitWrapper.assign_wiberg_bond_orders>`.
-- `PR #469 <https://github.com/openforcefield/openforcefield/pull/469>`_:
-  The :py:class:`Molecule <openforcefield.topology.Molecule>` adds
+- `PR #469 <https://github.com/openforcefield/openforcefield/pull/469>`_: The
+  :py:class:`Molecule <openforcefield.topology.Molecule>` class adds
   :py:meth:`Molecule.has_unique_atom_names <openforcefield.topology.Molecule.has_unique_atom_names>`
   and :py:meth:`Molecule.has_unique_atom_names <openforcefield.topology.Molecule.generate_unique_atom_names>`.
 - `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_:
-  The :py:class:`Molecule <openforcefield.topology.Molecule>` adds
+  The :py:class:`Molecule <openforcefield.topology.Molecule>` class adds
   :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>`
   and :py:meth:`Molecule.is_isomorphic_with <openforcefield.topology.Molecule.is_isomorphic_with>`
   and :py:meth:`Molecule.hill_formula <openforcefield.topology.Molecule.hill_formula>`
   and :py:meth:`Molecule.to_hill_formula <openforcefield.topology.Molecule.to_hill_formula>`
   and :py:meth:`Molecule.to_qcschema <openforcefield.topology.Molecule.to_qcschema>`
   and :py:meth:`Molecule.from_qcschema <openforcefield.topology.Molecule.from_qcschema>`
-      .. note::
-         The qcschema method accepts an extras dictionary which is passed into the validated qcelemental.models.Molecule
-         object.
   and :py:meth:`Molecule.from_mapped_smiles <openforcefield.topology.Molecule.from_mapped_smiles>`
   and :py:meth:`Molecule.from_pdb_and_smiles <openforcefield.topology.Molecule.from_pdb_and_smiles>`
   and :py:meth:`Molecule.canonical_order_atoms <openforcefield.topology.Molecule.canonical_order_atoms>`
   and :py:meth:`Molecule.remap <openforcefield.topology.Molecule.remap>`
+      .. note::
+         The to_qcschema method accepts an extras dictionary which is passed into the validated qcelemental.models.Molecule
+         object.
 - `PR #506 <https://github.com/openforcefield/openforcefield/pull/506>`_:
-   The :py:class:`Molecule <openforcefield.topology.Molecule>` adds
+  The :py:class:`Molecule <openforcefield.topology.Molecule>` class adds
   :py:meth:`Molecule.find_rotatable_bonds <openforcefield.topology.Molecule.find_rotatable_bonds>`
 - `PR #521 <https://github.com/openforcefield/openforcefield/pull/521>`_:
   Adds :py:meth:`Molecule.to_inchi <openforcefield.topology.Molecule.to_inchi>`
@@ -243,9 +299,9 @@ New features
   Adds ``test_forcefields/ion_charges.offxml``, giving `LibraryCharges` for monatomic ions.
 - `PR #543 <https://github.com/openforcefield/openforcefield/pull/543>`_:
   Adds 3 new methods to the :py:class:`Molecule <openforcefield.topology.Molecule>` which allow the enumeration of molecule
-  states these are :py:meth:`Molecule.enumerate_tautomers <openforcefield.topology.Molecule.enumerate_tautomers>`,
-  py:meth:`Molecule.enumerate_stereoisomers <openforcefield.topology.Molecule.enumerate_stereoisomers>`,
-  py:meth:`Molecule.enumerate_protomers <openforcefield.topology.Molecule.enumerate_protomers>`
+  states. These are :py:meth:`Molecule.enumerate_tautomers <openforcefield.topology.Molecule.enumerate_tautomers>`,
+  :py:meth:`Molecule.enumerate_stereoisomers <openforcefield.topology.Molecule.enumerate_stereoisomers>`,
+  :py:meth:`Molecule.enumerate_protomers <openforcefield.topology.Molecule.enumerate_protomers>`
       .. warning::
          Enumerate protomers is currently only available through the OpenEye toolkit.
 - `PR #573 <https://github.com/openforcefield/openforcefield/pull/573>`_:
@@ -256,39 +312,6 @@ New features
   Adds `return_topology` kwarg to
   :py:meth:`Forcefield.create_openmm_system <openforcefield.typing.engines.smirnoff.forcefield.ForceField.create_openmm_system>`,
   which returns the processed topology along with the system when ``True`` (default ``False``).
-
-Behavior changed
-""""""""""""""""
-- `PR #558 <https://github.com/openforcefield/openforcefield/pull/558>`_: The
-  :py:class`Topology <openforcefield.topology.Topology>`
-  particle indexing system now orders :py:class`TopologyVirtualSites <openforcefield.topology.TopologyVirtualSite>`
-  after all atoms.
-- `PR #469 <https://github.com/openforcefield/openforcefield/pull/469>`_:
-  When running :py:meth:`Topology.to_openmm <openforcefield.topology.Topology.to_openmm>`, unique atom names
-  are generated if the provided atom names are not unique (overriding any existing atom names). This
-  uniqueness extends only to atoms in the same molecule. To disable this behavior, set the kwarg
-  ``ensure_unique_atom_names=False``.
-- `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_:
-  The :py:meth:`Molecule.__eq__ <openforcefield.topology.Molecule.__eq__>` now uses the new
-  :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>` to perform the
-  similarity checking.
-- `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_:
-  The :py:meth:`Topology.from_openmm <openforcefield.topology.Topology.from_openmm>` and
-  :py:meth:`Topology.add_molecule <openforcefield.topology.Topology.add_molecule>` now use the
-  :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>` to match
-  molecules.
-- `PR #508 <https://github.com/openforcefield/openforcefield/pull/508>`_:
-  In order to provide the same results for the same chemical species, regardless of input
-  conformation, fractional bond order calculation methods now default to ignore input conformers
-  and generate a new conformer of the molecule before running semiempirical calculations.
-  Users can override this behavior by specifying the keyword argument
-  ``use_conformers=molecule.conformers``
-- `PR #544 <https://github.com/openforcefield/openforcefield/pull/544>`_: Raises
-  ``NotImplementedError`` when calling
-  :py:meth:`ParameterHandler.get_parameter   <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler.get_parameter>`,
-  which is not yet implemented, but would previously silently return ``None``.
-- `PR #551 <https://github.com/openforcefield/openforcefield/pull/551>`_: Implemented the
-  :py:meth:`ParameterHandler.get_parameter   <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler.get_parameter>` function.
 
 Tests added
 """""""""""
@@ -330,9 +353,9 @@ Tests added
   :py:meth:`Forcefield.create_openmm_system <openforcefield.typing.engines.smirnoff.forcefield.ForceField.create_openmm_system>`
   to check that a protein system can be created.
 - `PR #506 <https://github.com/openforcefield/openforcefield/pull/506>`_: Added a test for the molecule
-   identified in issue #513 as loosing aromaticity when converted to rdkit.
+  identified in issue #513 as losing aromaticity when converted to rdkit.
 - `PR #506 <https://github.com/openforcefield/openforcefield/pull/506>`_: Added a verity of toolkit dependent tests
-   for identifying rotatable bonds while ignoring the user requested types.
+  for identifying rotatable bonds while ignoring the user requested types.
 - `PR #521 <https://github.com/openforcefield/openforcefield/pull/521>`_: Added toolkit independent round-trip InChI
   tests which add coverage for :py:meth:`Molecule.to_inchi <openforcefield.topology.Molecule.to_inchi>` and
   :py:meth:`Molecule.from_inchi <openforcefield.topology.Molecule.from_inchi>`. Also added coverage for bad inputs and
@@ -376,17 +399,17 @@ Bugfixes
   We anticipate that this will reduce the number of times you need to
   type ``allow_undefined_stereo=True`` when processing molecules that do not actually contain stereochemistrty.
 - `Issue #513 <https://github.com/openforcefield/openforcefield/issues/513>`_: The
-   :py:meth:`Molecule.to_rdkit <openforcefield.topology.Molecule.to_rdkit>` now re-sets the aromaticity model
-   after sanitizing the molecule.
+  :py:meth:`Molecule.to_rdkit <openforcefield.topology.Molecule.to_rdkit>` now re-sets the aromaticity model
+  after sanitizing the molecule.
 - `Issue #500 <https://github.com/openforcefield/openforcefield/issues/500>`_: The
-   :py:meth:`Molecule.find_rotatable_bonds <openforcefield.topology.Molecule.find_rotatable_bonds>` has been added
-   which returns a list of rotatable :py:class:`Bond <openforcefield.topology.Bond>` instances for the molecule.
+  :py:meth:`Molecule.find_rotatable_bonds <openforcefield.topology.Molecule.find_rotatable_bonds>` has been added
+  which returns a list of rotatable :py:class:`Bond <openforcefield.topology.Bond>` instances for the molecule.
 - `Issue #491 <https://github.com/openforcefield/openforcefield/issues/491>`_: We can now parse large molecules without hitting a match limit cap.
 - `Issue #474 <https://github.com/openforcefield/openforcefield/issues/474>`_: We can now  convert molecules to InChI and
-   InChIKey and from InChI.
+  InChIKey and from InChI.
 - `Issue #523 <https://github.com/openforcefield/openforcefield/issues/523>`_: The
-   :py:meth:`Molecule.to_file <openforcefield.topology.Molecule.to_file>` can now correctly write to `MOL` files in
-   line with the support file type list.
+  :py:meth:`Molecule.to_file <openforcefield.topology.Molecule.to_file>` can now correctly write to `MOL` files in
+  line with the support file type list.
 - `Issue #568 <https://github.com/openforcefield/openforcefield/issues/568>`_: The
   :py:meth:`Molecule.to_file <openforcefield.topology.Molecule.to_file>` can now correctly write multi-model PDB files
   when using the RDKit backend toolkit.

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -257,7 +257,7 @@ New features
   :py:meth:`Molecule.has_unique_atom_names <openforcefield.topology.Molecule.has_unique_atom_names>`
   and :py:meth:`Molecule.has_unique_atom_names <openforcefield.topology.Molecule.generate_unique_atom_names>`.
 - `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_:
-  The :py:class:`Molecule <openforcefield.topology.Molecule>` class adds
+  Adds to the :py:class:`Molecule <openforcefield.topology.Molecule>` class
   :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>`
   and :py:meth:`Molecule.is_isomorphic_with <openforcefield.topology.Molecule.is_isomorphic_with>`
   and :py:meth:`Molecule.hill_formula <openforcefield.topology.Molecule.hill_formula>`

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -16,7 +16,7 @@ so we shouldn't do it too often, but when we do change things we should do it al
 Here's a brief rundown of what changed, migration tips, and what to search below to find more details:
 
 * To provide more consistent partial charges for a given molecule, existing conformers are now disregarded by default
-  by ``compute_partial_charges``. Instead, new conformers are generated for use in semiempirical calculations.
+  by ``Molecule.compute_partial_charges``. Instead, new conformers are generated for use in semiempirical calculations.
   Search for `use_conformers` below.
 * Formal charges are now always returned as ``simtk.unit.Quantity`` objects, with units of elementary charge.
   To convert them to integers, ``from simtk import unit`` and

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -98,8 +98,7 @@ take over the "slot", pushing the original ``ChargeIncrement`` out.
 
 Chaya Stern's work showed that we may be able to produce higher-quality proper torsion parameters by taking into
 account the "partial bond order" of the torsion's central bond. We now have the machinery to compute AM1-Wiberg
-partial bond orders for entire molecules using either ``OpenEyeToolkitWrapper``'s or ``AmberToolsToolkitWrapper``'s
-``assign_fractional_bond_orders`` methods. The thought is that, if some simple electron population analysis shows
+partial bond orders for entire molecules using the ``assign_fractional_bond_orders`` methods of either  ``OpenEyeToolkitWrapper`` or ``AmberToolsToolkitWrapper``. The thought is that, if some simple electron population analysis shows
 that a certain aromatic bond's order is 1.53, maybe rotations about that bond can be described well by interpolating
 53% of the way between the single and double bond k values.
 

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -17,7 +17,7 @@ Here's a brief rundown of what changed, migration tips, and what to search below
 
 * To provide more consistent partial charges for a given molecule, existing conformers are now disregarded by default
   by ``Molecule.compute_partial_charges``. Instead, new conformers are generated for use in semiempirical calculations.
-  Search for `use_conformers` below.
+  Search for ``use_conformers`` below.
 * Formal charges are now always returned as ``simtk.unit.Quantity`` objects, with units of elementary charge.
   To convert them to integers, ``from simtk import unit`` and
   ``atom.formal_charge.value_in_unit(unit.elementary_charge)`` or
@@ -110,7 +110,9 @@ Behavior changed
 """"""""""""""""
 - `PR #508 <https://github.com/openforcefield/openforcefield/pull/508>`_:
   In order to provide the same results for the same chemical species, regardless of input
-  conformation, ``assign_partial_charges``, ``compute_partial_charges_am1bcc``, and
+  conformation,
+  :py:class:`Molecule <openforcefield.topology.Molecule>`
+  ``assign_partial_charges``, ``compute_partial_charges_am1bcc``, and
   ``assign_fractional_bond_orders`` methods now default to ignore input conformers
   and generate new conformer(s) of the molecule before running semiempirical calculations.
   Users can override this behavior by specifying the keyword argument
@@ -119,7 +121,8 @@ Behavior changed
   `Issue #250 <https://github.com/openforcefield/openforcefield/issues/250>`_
   by adding support for partial charge I/O in SDF. The partial charges are stored as a property in the
   SDF molecule block under the tag ``<atom.dprop.PartialCharge>``.
-- `PR #281 <https://github.com/openforcefield/openforcefield/pull/281>`_: If an OFFMol's
+- `PR #281 <https://github.com/openforcefield/openforcefield/pull/281>`_: If a
+  :py:class:`Molecule <openforcefield.topology.Molecule>`'s
   ``partial_charges`` attribute is set to ``None`` (the default value), calling ``to_openeye`` will
   now produce a OE molecule with partial charges set to ``nan``. This would previously produce an OE
   molecule with partial charges of 0.0, which was a loss of information, since it wouldn't be clear
@@ -127,25 +130,30 @@ Behavior changed
   wrapper methods such as ``from_smiles`` and ``from_file`` now produce OFFMols with
   ``partial_charges = None`` when appropriate (previously these would produce OFFMols with
   all-zero charges, for the same reasoning as above).
-- `PR #281 <https://github.com/openforcefield/openforcefield/pull/281>`_: ``Molecule.to_rdkit``
+- `PR #281 <https://github.com/openforcefield/openforcefield/pull/281>`_:
+  :py:class:`Molecule <openforcefield.topology.Molecule>`
+  ``to_rdkit``
   now sets partial charges on the RDAtom's ``PartialCharges`` property (this was previously set
-  on the ``partial_charges`` property). If the OFFMol's partial_charges attribute is None, this property
+  on the ``partial_charges`` property). If the
+  :py:class:`Molecule <openforcefield.topology.Molecule>`'s partial_charges attribute is None, this property
   will not be defined on the RDAtoms.
 - `PR #281 <https://github.com/openforcefield/openforcefield/pull/281>`_:
-  Enforce the behavior during SDF I/O that a SDF may contain multiple MOLECULES, but that the OFF Toolkit
-  DOES NOT assume that it contains multiple CONFORMERS of the same molecule. This is an
+  Enforce the behavior during SDF I/O that a SDF may contain multiple
+  `molecules`, but that the OFF Toolkit
+  does not assume that it contains multiple `conformers of the same molecule`. This is an
   important distinction, since otherwise there is ambiguity around whether properties of one
   entry in a SDF are shared among several molecule blocks or not, or how to resolve conflicts if properties
   are defined differently for several "conformers" of chemically-identical species (More info
   `here <https://docs.eyesopen.com/toolkits/python/oechemtk/oemol.html#dude-where-s-my-sd-data>`_).
-  If the user requests the OFF
-  Toolkit to write a multi-conformer ``Molecule`` to SDF, only the first conformer will be written.
+  If the user requests the OFF Toolkit to write a multi-conformer
+  :py:class:`Molecule <openforcefield.topology.Molecule>` to SDF, only the first conformer will be written.
   For more fine-grained control of writing properties, conformers, and partial charges, consider
   using ``Molecule.to_rdkit`` or ``Molecule.to_openeye`` and using the functionality offered by
   those packages.
 - `PR #281 <https://github.com/openforcefield/openforcefield/pull/281>`_: Due to different
   constraints placed on the data types allowed by external toolkits, we make our best effort to
-  preserve ``offmol.properties`` when converting molecules to other packages, but users should be aware that
+  preserve :py:class:`Molecule <openforcefield.topology.Molecule>`
+  ``properties`` when converting molecules to other packages, but users should be aware that
   no guarantee of data integrity is made. The only data format for keys and values in the property dict that
   we will try to support through a roundtrip to another toolkit's Molecule object is ``string``.
 - `PR #574 <https://github.com/openforcefield/openforcefield/pull/574>`_: Removed check that all
@@ -156,8 +164,8 @@ Behavior changed
 - `PR #597 <https://github.com/openforcefield/openforcefield/pull/597>`_: Energy-minimized sample systems
   with Parsley 1.1.0.
 - `PR #558 <https://github.com/openforcefield/openforcefield/pull/558>`_: The
-  :py:class`Topology <openforcefield.topology.Topology>`
-  particle indexing system now orders :py:class`TopologyVirtualSites <openforcefield.topology.TopologyVirtualSite>`
+  :py:class:`Topology <openforcefield.topology.Topology>`
+  particle indexing system now orders :py:class:`TopologyVirtualSites <openforcefield.topology.TopologyVirtualSite>`
   after all atoms.
 - `PR #469 <https://github.com/openforcefield/openforcefield/pull/469>`_:
   When running :py:meth:`Topology.to_openmm <openforcefield.topology.Topology.to_openmm>`, unique atom names
@@ -165,13 +173,13 @@ Behavior changed
   uniqueness extends only to atoms in the same molecule. To disable this behavior, set the kwarg
   ``ensure_unique_atom_names=False``.
 - `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_:
-  The :py:meth:`Molecule.__eq__ <openforcefield.topology.Molecule.__eq__>` now uses the new
+  :py:meth:`Molecule.__eq__ <openforcefield.topology.Molecule.__eq__>` now uses the new
   :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>` to perform the
   similarity checking.
 - `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_:
   The :py:meth:`Topology.from_openmm <openforcefield.topology.Topology.from_openmm>` and
-  :py:meth:`Topology.add_molecule <openforcefield.topology.Topology.add_molecule>` now use the
-  :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>` to match
+  :py:meth:`Topology.add_molecule <openforcefield.topology.Topology.add_molecule>` methods now use the
+  :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>` method to match
   molecules.
 - `PR #551 <https://github.com/openforcefield/openforcefield/pull/551>`_: Implemented the
   :py:meth:`ParameterHandler.get_parameter <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler.get_parameter>`
@@ -215,8 +223,8 @@ API-breaking changes
   ``Molecule.compute_wiberg_bond_orders`` is now
   :py:meth:`Molecule.assign_fractional_bond_orders <openforcefield.topology.Molecule.assign_fractional_bond_orders>`.
 - `PR #595 <https://github.com/openforcefield/openforcefield/pull/595>`_: Removed functions
-  :py:meth:`temporary_directory <openforcefield.utils.utils.temporary_directory>` and
-  :py:meth:`temporary_cd <openforcefield.utils.utils.temporary_cd>` and replaced their behavior with
+  ``openforcefield.utils.utils.temporary_directory`` and
+  ``openforcefield.utils.utils.temporary_cd`` and replaced their behavior with
   ``tempfile.TemporaryDirectory()``.
 
 New features

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -295,7 +295,7 @@ New features
            if no map is supplied all atoms will be mapped in the order they appear in the
            :py:class:`Molecule <openforcefield.topology.Molecule>`.
 - `PR #563 <https://github.com/openforcefield/openforcefield/pull/563>`_:
-  Adds ``test_forcefields/ion_charges.offxml``, giving `LibraryCharges` for monatomic ions.
+  Adds ``test_forcefields/ion_charges.offxml``, giving ``LibraryCharges`` for monatomic ions.
 - `PR #543 <https://github.com/openforcefield/openforcefield/pull/543>`_:
   Adds 3 new methods to the :py:class:`Molecule <openforcefield.topology.Molecule>` which allow the enumeration of molecule
   states. These are :py:meth:`Molecule.enumerate_tautomers <openforcefield.topology.Molecule.enumerate_tautomers>`,

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -96,7 +96,8 @@ take over the "slot", pushing the original ``ChargeIncrement`` out.
 
 **Major Feature: Support for ProperTorsion k value interpolation**
 
-Chaya Stern's work showed that we may be able to produce higher-quality proper torsion parameters by taking into
+`Chaya Stern's work <https://chayast.github.io/fragmenter-manuscript/>`_
+showed that we may be able to produce higher-quality proper torsion parameters by taking into
 account the "partial bond order" of the torsion's central bond. We now have the machinery to compute AM1-Wiberg
 partial bond orders for entire molecules using the ``assign_fractional_bond_orders`` methods of either  ``OpenEyeToolkitWrapper`` or ``AmberToolsToolkitWrapper``. The thought is that, if some simple electron population analysis shows
 that a certain aromatic bond's order is 1.53, maybe rotations about that bond can be described well by interpolating
@@ -148,9 +149,9 @@ Behavior changed
   no guarantee of data integrity is made. The only data format for keys and values in the property dict that
   we will try to support through a roundtrip to another toolkit's Molecule object is ``string``.
 - `PR #574 <https://github.com/openforcefield/openforcefield/pull/574>`_: Removed check that all
-  partial charges are zero after assignment by `quacpac` when AM1BCC used for charge assignment.
+  partial charges are zero after assignment by ``quacpac`` when AM1BCC used for charge assignment.
   This check fails erroneously for cases in which the partial charge assignments are correctly all zero,
-  such as for ``N#N``. It is also an unnecessary check given that `quacpac` will reliably indicate when
+  such as for ``N#N``. It is also an unnecessary check given that ``quacpac`` will reliably indicate when
   it has failed to assign charges.
 - `PR #597 <https://github.com/openforcefield/openforcefield/pull/597>`_: Energy-minimized sample systems
   with Parsley 1.1.0.
@@ -215,7 +216,7 @@ API-breaking changes
   :py:meth:`Molecule.assign_fractional_bond_orders <openforcefield.topology.Molecule.assign_fractional_bond_orders>`.
 - `PR #595 <https://github.com/openforcefield/openforcefield/pull/595>`_: Removed functions
   :py:meth:`temporary_directory <openforcefield.utils.utils.temporary_directory>` and
-  :py:meth:`temporary_cd <openforcefield.utils.utils.temporary_cd>` and replaced their behavoir with
+  :py:meth:`temporary_cd <openforcefield.utils.utils.temporary_cd>` and replaced their behavior with
   ``tempfile.TemporaryDirectory()``.
 
 New features
@@ -297,7 +298,7 @@ New features
 - `PR #563 <https://github.com/openforcefield/openforcefield/pull/563>`_:
   Adds ``test_forcefields/ion_charges.offxml``, giving ``LibraryCharges`` for monatomic ions.
 - `PR #543 <https://github.com/openforcefield/openforcefield/pull/543>`_:
-  Adds 3 new methods to the :py:class:`Molecule <openforcefield.topology.Molecule>` which allow the enumeration of molecule
+  Adds 3 new methods to the :py:class:`Molecule <openforcefield.topology.Molecule>` class which allow the enumeration of molecule
   states. These are :py:meth:`Molecule.enumerate_tautomers <openforcefield.topology.Molecule.enumerate_tautomers>`,
   :py:meth:`Molecule.enumerate_stereoisomers <openforcefield.topology.Molecule.enumerate_stereoisomers>`,
   :py:meth:`Molecule.enumerate_protomers <openforcefield.topology.Molecule.enumerate_protomers>`
@@ -369,7 +370,7 @@ Tests added
 - `PR #579 <https://github.com/openforcefield/openforcefield/pull/579>`_: Adds regression tests to ensure RDKit can be
   be used to write multi-model PDB files.
 - `PR #582 <https://github.com/openforcefield/openforcefield/pull/582>`_: Added fractional bond order interpolation tests,
-  tests for `ValidatedDict <openforcefield.utils.collections.ValidatedDict>`
+  tests for :py:class:`ValidatedDict <openforcefield.utils.collections.ValidatedDict>`.
 
 
 Bugfixes
@@ -407,8 +408,8 @@ Bugfixes
 - `Issue #474 <https://github.com/openforcefield/openforcefield/issues/474>`_: We can now  convert molecules to InChI and
   InChIKey and from InChI.
 - `Issue #523 <https://github.com/openforcefield/openforcefield/issues/523>`_: The
-  :py:meth:`Molecule.to_file <openforcefield.topology.Molecule.to_file>` can now correctly write to `MOL` files in
-  line with the support file type list.
+  :py:meth:`Molecule.to_file <openforcefield.topology.Molecule.to_file>` method can now correctly write to ``MOL``
+  files, in line with the supported file type list.
 - `Issue #568 <https://github.com/openforcefield/openforcefield/issues/568>`_: The
   :py:meth:`Molecule.to_file <openforcefield.topology.Molecule.to_file>` can now correctly write multi-model PDB files
   when using the RDKit backend toolkit.

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -13,30 +13,30 @@ Releases follow the ``major.minor.micro`` scheme recommended by `PEP440 <https:/
 This is a relatively large release, motivated by the idea that changing existing functionality is bad
 so we shouldn't do it too often, but when we do change things we should do it all at once.
 
-Here's a brief rundown of what changed, migration tips, and what to search below to find more details:
+Here's a brief rundown of what changed, migration tips, and how to find more details in the full release notes below:
 
 * To provide more consistent partial charges for a given molecule, existing conformers are now disregarded by default
-  by ``Molecule.compute_partial_charges``. Instead, new conformers are generated for use in semiempirical calculations.
-  Search for ``use_conformers`` below.
+  by ``Molecule.assign_partial_charges``. Instead, new conformers are generated for use in semiempirical calculations.
+  Search for ``use_conformers``.
 * Formal charges are now always returned as ``simtk.unit.Quantity`` objects, with units of elementary charge.
-  To convert them to integers, ``from simtk import unit`` and
+  To convert them to integers, use ``from simtk import unit`` and
   ``atom.formal_charge.value_in_unit(unit.elementary_charge)`` or
   ``mol.total_charge.value_in_unit(unit.elementary_charge)``.
-  Search ``atom.formal_charge`` below.
+  Search ``atom.formal_charge``.
 * The OpenFF Toolkit now automatically reads and writes partial charges in SDF files. Search for
-  ``atom.dprop.PartialCharges`` below.
+  ``atom.dprop.PartialCharges``.
 * The OpenFF Toolkit now has different behavior for handling multi-molecule and multi-conformer SDF files. Search
-  ``multi-conformer`` below.
+  ``multi-conformer``.
 * The OpenFF Toolkit now distinguishes between partial charges that are all-zero and partial charges that are unknown.
-  Search ``partial_charges = None`` below.
-* ``Topology.to_openmm`` now assigns unique atoms names by default. Search ``ensure_unique_atom_names`` below.
+  Search ``partial_charges = None``.
+* ``Topology.to_openmm`` now assigns unique atoms names by default. Search ``ensure_unique_atom_names``.
 * Molecule equality checks are now done by graph comparison instead of SMILES comparison.
-  Search ``Molecule.are_isomorphic`` below.
+  Search ``Molecule.are_isomorphic``.
 * The ``ChemicalEnvironment`` module was almost entirely removed, as it is an outdated duplicate of some Chemper
-  functionality. Search ``ChemicalEnvironment`` below.
+  functionality. Search ``ChemicalEnvironment``.
 * ``TopologyMolecule.topology_particle_start_index`` has been removed from the ``TopologyMolecule`` API, since atoms
   and virtualsites are no longer contiguous in the ``Topology`` particle indexing system. Search
-  ``topology_particle_start_index`` below.
+  ``topology_particle_start_index``.
 * ``compute_wiberg_bond_orders`` has been renamed to ``assign_fractional_bond_orders``.
 
 There are also a number of new features, such as:
@@ -44,14 +44,15 @@ There are also a number of new features, such as:
 * Support for ``ChargeIncrementModel`` sections in force fields.
 * Support for ``ProperTorsion`` ``k`` interpolation in force fields using fractional bond orders.
 * Support for AM1-Mulliken, Gasteiger, and other charge methods using the new ``assign_partial_charges`` methods.
-* Support for AM1-Wiberg bond order calculation using either the OpenEye or RDKit/AmberTools backends.
+* Support for AM1-Wiberg bond order calculation using either the OpenEye or RDKit/AmberTools backends and the
+  ``assign_fractional_bond_orders`` methods.
 * Initial (limited) interoperability with QCArchive, via ``Molecule.to_qcschema`` and ``from_qcschema``.
 * A ``Molecule.visualize`` method.
 * Several additional ``Molecule`` methods, including state enumeration and mapped SMILES creation.
 
 **Major Feature: Support for the SMIRNOFF ChargeIncrementModel tag**
 
-`The ChargeIncrementModel tag in the SMIRNOFF specification <https://open-forcefield-toolkit.readthedocs.io/en/latest/smirnoff.html#chargeincrementmodel-small-molecule-and-fragment-charges>`_.
+`The ChargeIncrementModel tag in the SMIRNOFF specification <https://open-forcefield-toolkit.readthedocs.io/en/latest/smirnoff.html#chargeincrementmodel-small-molecule-and-fragment-charges>`_
 provides analagous functionality to AM1-BCC, except that instead of AM1-Mulliken charges, a number of different charge
 methods can be called, and instead of a fixed library of two-atom charge corrections, an arbitrary number of
 SMIRKS-based, N-atom charge corrections can be defined in the SMIRNOFF format.
@@ -135,7 +136,7 @@ Behavior changed
   ``to_rdkit``
   now sets partial charges on the RDAtom's ``PartialCharges`` property (this was previously set
   on the ``partial_charges`` property). If the
-  :py:class:`Molecule <openforcefield.topology.Molecule>`'s partial_charges attribute is None, this property
+  :py:class:`Molecule <openforcefield.topology.Molecule>`'s partial_charges attribute is ``None``, this property
   will not be defined on the RDAtoms.
 - `PR #281 <https://github.com/openforcefield/openforcefield/pull/281>`_:
   Enforce the behavior during SDF I/O that a SDF may contain multiple
@@ -234,10 +235,10 @@ New features
   by implementing support for the
   ``ChargeIncrementModel`` tag in the `SMIRNOFF specification <https://open-forcefield-toolkit.readthedocs.io/en/latest/smirnoff.html#chargeincrementmodel-small-molecule-and-fragment-charges>`_.
 - `PR #471 <https://github.com/openforcefield/openforcefield/pull/471>`_: Implements
-  ``Molecule.compute_partial_charges``, which calls one of the newly-implemented
-  ``OpenEyeToolkitWrapper.compute_partial_charges``, and
-  ``AmberToolsToolkitWrapper.compute_partial_charges``. ``strict_n_conformers`` is a
-  optional boolean parameter indicating whether an ``IncorrectNumConformersError`` should be raised if an invalid
+  ``Molecule.assign_partial_charges``, which calls one of the newly-implemented
+  ``OpenEyeToolkitWrapper.assign_partial_charges``, and
+  ``AmberToolsToolkitWrapper.assign_partial_charges``. ``strict_n_conformers`` is a
+  optional boolean keyword argument indicating whether an ``IncorrectNumConformersError`` should be raised if an invalid
   number of conformers is supplied during partial charge calculation. For example, if two conformers are
   supplied, but ``partial_charge_method="AM1BCC"`` is also set, then there is no clear use for
   the second conformer. The previous behavior in this case was to raise a warning, and to preserve that

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -23,7 +23,7 @@ Here's a brief rundown of what changed, migration tips, and what to search below
   ``atom.formal_charge.value_in_unit(unit.elementary_charge)`` or
   ``mol.total_charge.value_in_unit(unit.elementary_charge)``.
   Search ``atom.formal_charge`` below.
-* The OpenFF Toolkit now automatically reads and writes partial charges in SDF. Search for
+* The OpenFF Toolkit now automatically reads and writes partial charges in SDF files. Search for
   ``atom.dprop.PartialCharges`` below.
 * The OpenFF Toolkit now has different behavior for handling multi-molecule and multi-conformer SDF files. Search
   ``multi-conformer`` below.


### PR DESCRIPTION
Since our RTD builds aren't connecting API links, we probably don't need to round those out this time. I've made some minor edits to previous releasenotes, and added a migration guide and summary section at the top.

Happy to take feedback. Will unilaterally merge around 2 PM Pacific Sunday.