### PR TITLE
Store IOError message from attribute, not str method

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -19,6 +19,9 @@ Bugfixes
 - `PR #631 <https://github.com/openforcefield/openforcefield/pull/631>`_: Fixes a bug in which calling
   :py:meth:`openforcefield.utils.utils.utils.unit_to_string <openforcefield.utils.utils.unit_to_string>` returned
   ``None`` when the unit is dimensionless. Now ``"dimensionless"`` is returned.
+- `PR #630 <https://github.com/openforcefield/openforcefield/pull/630>`_: Closes issue `Issue #629 
+  <https://github.com/openforcefield/openforcefield/issues/629>`_ in which the wrong exception is raised when
+  attempting to instantiate a ``ForceField`` from an unparsable string.
 
 New features
 """"""""""""

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -617,6 +617,12 @@ class TestForceField():
         assert len(forcefield._parameter_handlers['ImproperTorsions']._parameters) == 4
         assert len(forcefield._parameter_handlers['vdW']._parameters) == 35
 
+    def test_load_bad_string(self):
+        with pytest.raises(IOError) as exception_info:
+            ForceField('1234')
+        assert 'Source 1234 could not be read.' in str(exception_info.value)
+        assert 'syntax error' in str(exception_info.value)
+
     @pytest.mark.skip(reason='Needs to be updated for 0.2.0 syntax')
     def test_create_forcefield_from_file_list(self):
         # These offxml files are located in package data path, which is automatically installed and searched

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -970,14 +970,14 @@ class ForceField:
                 smirnoff_data = parameter_io_handler.parse_file(source)
                 return smirnoff_data
             except ParseError as e:
-                exception_msg = str(e)
+                exception_msg = e.msg
             except (FileNotFoundError, OSError):
                 # If this is not a file path or a file handle, attempt parsing as a string.
                 try:
                     smirnoff_data = parameter_io_handler.parse_string(source)
                     return smirnoff_data
                 except ParseError as e:
-                    exception_msg = str(e)
+                    exception_msg = e.msg
 
         # If we haven't returned by now, the parsing was unsuccessful
         valid_formats = [

--- a/openforcefield/typing/engines/smirnoff/io.py
+++ b/openforcefield/typing/engines/smirnoff/io.py
@@ -204,7 +204,7 @@ class XMLParameterIOHandler(ParameterIOHandler):
             smirnoff_data = xmltodict.parse(data, attr_prefix='')
             return smirnoff_data
         except ExpatError as e:
-            raise ParseError(e)
+            raise ParseError(str(e))
 
     def to_file(self, file_path, smirnoff_data):
         """Write the current forcefield parameter set to a file.


### PR DESCRIPTION
#629 
- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
