### PR TITLE
Return dimensionless from string_to_unit instead of None

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -16,6 +16,9 @@ Bugfixes
   :py:meth:`RDKitToolkitWrapper.from_file <openforcefield.utils.toolkits.RDKitToolkitWrapper.from_file>` directly
   would not load files correctly if passed lowercase `file_format`. Note that this bug did not occur when calling
   :`Molecule.from_file` <openforcefield.topology.molecule.Molecule.from_file>`.
+- `PR #631 <https://github.com/openforcefield/openforcefield/pull/631>`_: Fixes a bug in which calling
+  :py:meth:`openforcefield.utils.utils.utils.unit_to_string <openforcefield.utils.utils.unit_to_string>` returned
+  ``None`` when the unit is dimensionless. Now ``"dimensionless"`` is returned.
 
 New features
 """"""""""""

--- a/openforcefield/tests/test_utils.py
+++ b/openforcefield/tests/test_utils.py
@@ -71,3 +71,11 @@ def test_ast_eval(unit_string, expected_unit):
     ast_root_node = ast.parse(unit_string, mode='eval').body
     parsed_units = _ast_eval(ast_root_node)
     assert parsed_units == expected_unit
+
+def test_dimensionless_units():
+    assert utils.string_to_unit('dimensionless') == unit.dimensionless
+
+    unit_string = utils.unit_to_string(unit.dimensionless)
+    unit_value = utils.string_to_unit(unit_string)
+
+    assert unit_value == unit.dimensionless

--- a/openforcefield/utils/utils.py
+++ b/openforcefield/utils/utils.py
@@ -146,6 +146,8 @@ def unit_to_string(input_unit):
         The serialized unit.
     """
 
+    if input_unit == unit.dimensionless:
+        return "dimensionless"
 
     # Decompose output_unit into a tuples of (base_dimension_unit, exponent)
     unit_string = None


### PR DESCRIPTION
Fixes #392, although there are still some related gotchas due to OpenMM not explicitly storing dimensionless units as a unit

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [x] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
