### PR TITLE
Add registered_parameter_handlers property to ForceField

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -17,6 +17,12 @@ Bugfixes
   would not load files correctly if passed lowercase `file_format`. Note that this bug did not occur when calling
   :`Molecule.from_file` <openforcefield.topology.molecule.Molecule.from_file>`.
 
+New features
+""""""""""""
+- `PR #632 <https://github.com/openforcefield/openforcefield/pull/632>`_: Adds
+  :py:meth:`ForceField.registered_parameter_handlers 
+  <openforcefield.typing.engines.smirnoff.forcefield.ForceField.registered_parameter_handlers>`
+
 0.7.0 - Charge Increment Model, Proper Torsion interpolation, and new Molecule methods
 --------------------------------------------------------------------------------------
 

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -1211,6 +1211,26 @@ class TestForceField():
                 forcefield.get_parameter_handler('Electrostatics', {}).method = electrostatics_method
                 omm_system = forcefield.create_openmm_system(topology)
 
+    def test_registered_parameter_handlers(self):
+        """Test registered_parameter_handlers property"""
+        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
+        registered_handlers = forcefield.registered_parameter_handlers
+
+        expected_handlers = [
+            'Bonds',
+            'Angles',
+            'ProperTorsions',
+            'ImproperTorsions',
+            'vdW',
+            'Electrostatics',
+            'ToolkitAM1BCC',
+        ]
+
+        for expected_handler in expected_handlers:
+            assert expected_handler in registered_handlers
+
+        assert 'LibraryChrages' not in registered_handlers
+
     def test_parameter_handler_lookup(self):
         """Ensure __getitem__ lookups work"""
         forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -556,6 +556,19 @@ class ForceField:
                     self._parameter_io_handlers[io_format]))
         self._parameter_io_handlers[io_format] = parameter_io_handler
 
+    @property
+    def registered_parameter_handlers(self):
+        """
+        Return the list of registered parameter handlers by name
+
+        .. warning :: This API is experimental and subject to change.
+
+        Returns
+        -------
+            registered_parameter_handlers: iterable of names of ParameterHandler objects in this ForceField
+
+        """
+        return [*self._parameter_handlers.keys()]
 
     # TODO: Do we want to make this optional?
 


### PR DESCRIPTION
Resolves https://github.com/openforcefield/openforcefield/issues/369 and makes it I don't have to do `for handler_name in ff._parameter_handlers.keys(): ...` when trying to splice out individual `ParameterHandler` objects in a force field that was passed to the system

There is a potentially-more-elegant solution proposed in the issue; this is the easier approach

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
