### PR TITLE
Fix bad string case when calling RDKitToolkitWrapper.from_file directly

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -7,6 +7,16 @@ Releases follow the ``major.minor.micro`` scheme recommended by `PEP440 <https:/
 * ``minor`` increments add features but do not break API compatibility
 * ``micro`` increments represent bugfix releases or improvements in documentation
 
+0.7.1 - Current development
+---------------------------
+
+Bugfixes
+""""""""
+- `PR #634 <https://github.com/openforcefield/openforcefield/pull/634>`_: Fixes a bug in which calling 
+  :py:meth:`RDKitToolkitWrapper.from_file <openforcefield.utils.toolkits.RDKitToolkitWrapper.from_file>` directly
+  would not load files correctly if passed lowercase `file_format`. Note that this bug did not occur when calling
+  :`Molecule.from_file` <openforcefield.topology.molecule.Molecule.from_file>`.
+
 0.7.0 - Charge Increment Model, Proper Torsion interpolation, and new Molecule methods
 --------------------------------------------------------------------------------------
 

--- a/openforcefield/tests/test_toolkits.py
+++ b/openforcefield/tests/test_toolkits.py
@@ -468,6 +468,21 @@ class TestOpenEyeToolkitWrapper:
                                    [0.027170, 0.027170, 0.027170, 0.027170, -0.108680])
 
     @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    def test_file_extension_case(self):
+        """
+        Test round-trips of some file extensions when called directly from the toolkit wrappers,
+        including lower- and uppercase file extensions. Note that this test does not ensure
+        accuracy, it only tests that reading/writing without raising an exception.
+        """
+        mols_in = OpenEyeToolkitWrapper().from_file(file_path=get_data_file_path('molecules/ethanol.sdf'), file_format='sdf')
+
+        assert len(mols_in) > 0
+
+        mols_in = OpenEyeToolkitWrapper().from_file(file_path=get_data_file_path('molecules/ethanol.sdf'), file_format='SDF')
+
+        assert len(mols_in) > 0
+
+    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
     def test_write_sdf_charges(self):
         """Test OpenEyeToolkitWrapper for writing partial charges to a sdf file"""
         from io import StringIO
@@ -1395,7 +1410,22 @@ class TestRDKitToolkitWrapper:
         assert molecule2.partial_charges is None
 
         assert molecule2.to_smiles(toolkit_registry=toolkit_wrapper) == expected_output_smiles
-        
+
+    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    def test_file_extension_case(self):
+        """
+        Test round-trips of some file extensions when called directly from the toolkit wrappers,
+        including lower- and uppercase file extensions. Note that this test does not ensure
+        accuracy, it only tests that reading/writing without raising an exception.
+        """
+        mols_in = RDKitToolkitWrapper().from_file(file_path=get_data_file_path('molecules/ethanol.sdf'), file_format='sdf')
+
+        assert len(mols_in) > 0
+
+        mols_in = RDKitToolkitWrapper().from_file(file_path=get_data_file_path('molecules/ethanol.sdf'), file_format='SDF')
+
+        assert len(mols_in) > 0
+
     @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
     def test_get_sdf_coordinates(self):
         """Test RDKitToolkitWrapper for importing a single set of coordinates from a sdf file"""

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -2363,6 +2363,9 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
         """
         from rdkit import Chem
+
+        file_format = file_format.upper()
+
         mols = list()
         if (file_format == 'MOL') or (file_format == 'SDF'):
             for rdmol in Chem.SupplierFromFilename(file_path, removeHs=False, sanitize=False, strictParsing=True):

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -676,7 +676,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         from openeye import oechem
         oemol = self.to_openeye(molecule)
         ofs = oechem.oemolostream(file_path)
-        openeye_format = getattr(oechem, 'OEFormat_' + file_format)
+        openeye_format = getattr(oechem, 'OEFormat_' + file_format.upper())
         ofs.SetFormat(openeye_format)
 
         # OFFTK strictly treats SDF as a single-conformer format.


### PR DESCRIPTION
Fixes #628, although this is pretty localized to the edge case of calling `RDKitToolkitWrapper.from_file` since normally  you'd want to do `Molecule.from_file(...)`

Pushing as separate commits to show (if it works the same as locally) that the bug only impacted the RDKit wrapper, since `OpenEyeToolkitWrapper.from_file` doesn't use `file_format` at all.

- [X] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
