### PR TITLE
Unpin py-cpuinfo and QCEngine in test env

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -14,7 +14,6 @@ dependencies:
   - nbval
   - codecov
   - coverage < 5.0
-  - py-cpuinfo <= 5 # Needed until https://github.com/MolSSI/QCEngine/issues/252 is resolved+released
   - numpy
   - networkx
   - ambertools
@@ -30,8 +29,4 @@ dependencies:
   - xmltodict
   - qcelemental
   - qcportal
-  - qcengine <= 0.14 # Remove this and py-cpuinfo pin above when there's a new release of QCEngine
-
-    # Pip-only installs
-  #- pip:
-
+  - qcengine


### PR DESCRIPTION
Looks like this was fixed in omnia but not here