### PR TITLE
Pin OpenEye toolkits to 2019

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,7 +91,7 @@ jobs:
         conda activate test
         if [[ "$RDKIT" == true ]]; then conda install rdkit; fi
         if [[ "$OPENEYE" == true ]]; then
-          conda install openeye-toolkits
+          conda install openeye-toolkits=2019
           python -c "from openeye import oechem; assert oechem.OEChemIsLicensed()"
         fi
         python -m pip install --no-deps .


### PR DESCRIPTION
@j-wags I know we are aiming to roll out compatibility with the new `2020.0.4` version of the OpenEye toolkits, but I would like to keep the master branch stable until then