### PR TITLE
Add functionality to ignore/strip short-lived stereochemistry

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -10,9 +10,27 @@ Releases follow the ``major.minor.micro`` scheme recommended by `PEP440 <https:/
 0.7.1 - Current development
 ---------------------------
 
+
+Behavior changed
+""""""""""""""""
+- `PR #646 <https://github.com/openforcefield/openforcefield/pull/646>`_: Checking for molecule
+  equality (using thr ``==`` operator now disregards all pyrimidal nitrogen stereochemistry
+  by default. To re-enable, use
+  :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>`
+  with the ``strip_pyrimidal_n_atom_stereo=False`` keyword argument.
+- `PR #646 <https://github.com/openforcefield/openforcefield/pull/646>`_: Adds
+  an optional ``toolkit_registry`` keyword argument to
+  :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>`,
+  which identifies the toolkit that should be used to search for pyrimidal nitrogens.
+
+
 Bugfixes
 """"""""
-- `PR #634 <https://github.com/openforcefield/openforcefield/pull/634>`_: Fixes a bug in which calling 
+- `PR #646 <https://github.com/openforcefield/openforcefield/pull/646>`_: Fixes a bug where
+  :py:meth:`Molecule.chemical_environment_matches <openforcefield.topology.Molecule.chemical_environment_matches>`
+  was not able to accept a :py:class`ChemicalEnvironment <openforcefield.typing.chemistry.ChemicalEnvironment>` object
+  as a query.
+- `PR #634 <https://github.com/openforcefield/openforcefield/pull/634>`_: Fixes a bug in which calling
   :py:meth:`RDKitToolkitWrapper.from_file <openforcefield.utils.toolkits.RDKitToolkitWrapper.from_file>` directly
   would not load files correctly if passed lowercase `file_format`. Note that this bug did not occur when calling
   :`Molecule.from_file` <openforcefield.topology.molecule.Molecule.from_file>`.
@@ -26,8 +44,7 @@ Bugfixes
 New features
 """"""""""""
 - `PR #632 <https://github.com/openforcefield/openforcefield/pull/632>`_: Adds
-  :py:meth:`ForceField.registered_parameter_handlers 
-  <openforcefield.typing.engines.smirnoff.forcefield.ForceField.registered_parameter_handlers>`
+  :py:meth:`ForceField.registered_parameter_handlers <openforcefield.typing.engines.smirnoff.forcefield.ForceField.registered_parameter_handlers>`
 - `PR #614 <https://github.com/openforcefield/openforcefield/pull/614>`_: Adds 
   :py:meth:`ToolkitRegistry.deregister_toolkit <openforcefield.utils.toolkits.ToolkitRegistry.deregister_toolki>` 
   to de-register registered toolkits, which can include toolkit wrappers loaded into `GLOBAL_TOOLKIT_REGISTRY` by default.
@@ -38,6 +55,7 @@ New features
 - `PR #643 <https://github.com/openforcefield/openforcefield/pull/643>`_: Adds
   :py:func:`get_available_force_fields <openforcefield.typing.engines.smirnoff.forcefield.get_available_force_fields>`,
   which returns paths to the files of force fields available through entry point plugins.
+
 
 0.7.0 - Charge Increment Model, Proper Torsion interpolation, and new Molecule methods
 --------------------------------------------------------------------------------------

--- a/openforcefield/tests/test_molecule.py
+++ b/openforcefield/tests/test_molecule.py
@@ -1034,6 +1034,34 @@ class TestMolecule:
                                        atom_stereochemistry_matching=inputs['atom_stereochemistry_matching'],
                                        bond_stereochemistry_matching=inputs['bond_stereochemistry_matching'])[0] is inputs['result']
 
+    def test_strip_atom_stereochemistry(self):
+        """Test the basic behavior of strip_atom_stereochemistry"""
+        mol = Molecule.from_smiles('CCC[N@@](C)CC')
+
+        assert mol.atoms[3].stereochemistry == 'S'
+        mol.strip_atom_stereochemistry(smarts='[N+0X3:1](-[*])(-[*])(-[*])')
+        assert mol.atoms[3].stereochemistry is None
+
+        mol = Molecule.from_smiles('CCC[N@@](C)CC')
+
+        assert mol.atoms[3].stereochemistry == 'S'
+        mol.strip_atom_stereochemistry(smarts='[N+0X3:1](-[*])(-[*])(-[*])')
+        assert mol.atoms[3].stereochemistry is None
+
+    def test_isomorphic_striped_stereochemistry(self):
+        """Test that the equality operator disregards an edge case of nitrogen stereocenters"""
+        mol1 = Molecule.from_smiles('CCC[N@](C)CC')
+        mol2 = Molecule.from_smiles('CCC[N@@](C)CC')
+
+        # Ensure default value is respected and order does not matter
+        assert Molecule.are_isomorphic(mol1, mol2, strip_pyrimidal_n_atom_stereo=True)
+        assert Molecule.are_isomorphic(mol1, mol2)
+        assert Molecule.are_isomorphic(mol2, mol1)
+
+        assert mol1 == mol2
+        assert Molecule.from_smiles('CCC[N@](C)CC') == Molecule.from_smiles('CCC[N@@](C)CC')
+
+
     def test_remap(self):
         """Test the remap function which should return a new molecule in the requested ordering"""
         # the order here is CCO

--- a/openforcefield/tests/test_molecule.py
+++ b/openforcefield/tests/test_molecule.py
@@ -1038,15 +1038,17 @@ class TestMolecule:
         """Test the basic behavior of strip_atom_stereochemistry"""
         mol = Molecule.from_smiles('CCC[N@@](C)CC')
 
-        assert mol.atoms[3].stereochemistry == 'S'
+        nitrogen_idx = [atom.molecule_atom_index for atom in mol.atoms if atom.element.symbol == 'N'][0]
+
+        assert mol.atoms[nitrogen_idx].stereochemistry == 'S'
         mol.strip_atom_stereochemistry(smarts='[N+0X3:1](-[*])(-[*])(-[*])')
-        assert mol.atoms[3].stereochemistry is None
+        assert mol.atoms[nitrogen_idx].stereochemistry is None
 
         mol = Molecule.from_smiles('CCC[N@@](C)CC')
 
-        assert mol.atoms[3].stereochemistry == 'S'
+        assert mol.atoms[nitrogen_idx].stereochemistry == 'S'
         mol.strip_atom_stereochemistry(smarts='[N+0X3:1](-[*])(-[*])(-[*])')
-        assert mol.atoms[3].stereochemistry is None
+        assert mol.atoms[nitrogen_idx].stereochemistry is None
 
     @pytest.mark.parametrize('mol_smiles',
         [

--- a/openforcefield/tests/test_molecule.py
+++ b/openforcefield/tests/test_molecule.py
@@ -1088,9 +1088,7 @@ class TestMolecule:
             strip_pyrimidal_n_atom_stereo=False,
             atom_stereochemistry_matching=True,
             bond_stereochemistry_matching=True,
-        )
-
-        'c1cnc[nH]1'
+        )[0]
 
     def test_remap(self):
         """Test the remap function which should return a new molecule in the requested ordering"""

--- a/openforcefield/tests/test_toolkits.py
+++ b/openforcefield/tests/test_toolkits.py
@@ -85,6 +85,7 @@ rdkit_inchi_stereochemistry_lost = ['DrugBank_5414', 'DrugBank_2955', 'DrugBank_
 rdkit_inchi_isomorphic_fails = ['DrugBank_178', 'DrugBank_246', 'DrugBank_5847', 'DrugBank_700', 'DrugBank_1564',
                                 'DrugBank_1700', 'DrugBank_4662', 'DrugBank_2052', 'DrugBank_2077', 'DrugBank_2082',
                                 'DrugBank_2210', 'DrugBank_2642']
+rdkit_inchi_roundtrip_mangled = ['DrugBank_2684']
 #=============================================================================================
 # TESTS
 #=============================================================================================
@@ -1282,6 +1283,13 @@ class TestRDKitToolkitWrapper:
         else:
             print(molecule.name)
             mol2 = molecule.from_inchi(inchi, toolkit_registry=toolkit)
+
+            # Some molecules are mangled by being round-tripped to/from InChI
+            if molecule.name in rdkit_inchi_roundtrip_mangled:
+                with pytest.raises(AssertionError):
+                    mol2.to_rdkit()
+                return
+
             # compare the full molecule excluding the properties dictionary
             # turn of the bond order matching as this could move in the aromatic rings
             if molecule.name in rdkit_inchi_isomorphic_fails:

--- a/openforcefield/tests/test_toolkits.py
+++ b/openforcefield/tests/test_toolkits.py
@@ -86,6 +86,7 @@ rdkit_inchi_isomorphic_fails = ['DrugBank_178', 'DrugBank_246', 'DrugBank_5847',
                                 'DrugBank_1700', 'DrugBank_4662', 'DrugBank_2052', 'DrugBank_2077', 'DrugBank_2082',
                                 'DrugBank_2210', 'DrugBank_2642']
 rdkit_inchi_roundtrip_mangled = ['DrugBank_2684']
+
 #=============================================================================================
 # TESTS
 #=============================================================================================
@@ -418,9 +419,9 @@ class TestOpenEyeToolkitWrapper:
                 # Some molecules graphs change during the round trip testing
                 # we test quite strict isomorphism here
                 with pytest.raises(AssertionError):
-                    assert molecule.is_isomorphic_with(mol2, bond_order_matching=False)
+                    assert molecule.is_isomorphic_with(mol2, bond_order_matching=False, toolkit_registry=toolkit)
             else:
-                assert molecule.is_isomorphic_with(mol2, bond_order_matching=False)
+                assert molecule.is_isomorphic_with(mol2, bond_order_matching=False, toolkit_registry=toolkit)
 
     @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
     def test_get_sdf_coordinates(self):
@@ -1296,9 +1297,9 @@ class TestRDKitToolkitWrapper:
                 # Some molecules graphs change during the round trip testing
                 # we test quite strict isomorphism here
                 with pytest.raises(AssertionError):
-                    assert molecule.is_isomorphic_with(mol2, bond_order_matching=False)
+                    assert molecule.is_isomorphic_with(mol2, bond_order_matching=False, toolkit_registry=toolkit)
             else:
-                assert molecule.is_isomorphic_with(mol2, bond_order_matching=False)
+                assert molecule.is_isomorphic_with(mol2, bond_order_matching=False, toolkit_registry=toolkit)
 
     @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
     def test_smiles_charged(self):

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -1621,6 +1621,26 @@ class FrozenMolecule(Serializable):
         if not self.has_unique_atom_names:
             self.generate_unique_atom_names()
 
+    def strip_atom_stereochemistry(self, smarts, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+        """Delete stereochemistry information for certain atoms. This method can be used to "normalize"
+        molecules imported from different cheminformatics toolkits, which differ in which atom centers are
+        considered stereogenic.
+
+        Parameters
+        ----------
+        smarts: str or ChemicalEnvironment
+            Tagged SMARTS with a single atom with index 1. Any matches for this atom will have any assigned
+            stereocheistry information removed.
+        toolkit_registry : a :class:`ToolkitRegistry` or :class:`ToolkitWrapper` object, optional, default=GLOBAL_TOOLKIT_REGISTRY
+            :class:`ToolkitRegistry` or :class:`ToolkitWrapper` to use for I/O operations
+
+        """
+        matches = self.chemical_environment_matches(smarts)
+
+
+
+
+
     ####################################################################################################
     # Safe serialization
     ####################################################################################################
@@ -2120,7 +2140,8 @@ class FrozenMolecule(Serializable):
             formal_charge_matching=True,
             bond_order_matching=True,
             atom_stereochemistry_matching=True,
-            bond_stereochemistry_matching=True
+            bond_stereochemistry_matching=True,
+            ignore_atom_stereocenters=None
     ):
         """
         Determines whether the two molecules are isomorphic by comparing their graph representations and the chosen
@@ -2224,8 +2245,8 @@ class FrozenMolecule(Serializable):
             else:
                 raise NotImplementedError(f'The input type {type(data)} is not supported,'
                                           f'please supply an openforcefield.topology.molecule.Molecule,'
-                                          f'openforcefield.topology.topology.TopologyMolecule or networkx representaion '
-                                          f'of the molecule.')
+                                          f'openforcefield.topology.topology.TopologyMolecule or networkx '
+                                          f'representation of the molecule.')
 
         mol1_netx = to_networkx(mol1)
         mol2_netx = to_networkx(mol2)

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -3312,8 +3312,8 @@ class FrozenMolecule(Serializable):
         """
         # Resolve to SMIRKS if needed
         # TODO: Update this to use updated ChemicalEnvironment API
-        if hasattr(query, 'asSMIRKS'):
-            smirks = query.asSMIRKS()
+        if hasattr(query, 'smirks'):
+            smirks = query.smirks
         elif type(query) == str:
             smirks = query
         else:

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -2145,6 +2145,7 @@ class FrozenMolecule(Serializable):
             atom_stereochemistry_matching=True,
             bond_stereochemistry_matching=True,
             strip_pyrimidal_n_atom_stereo=True,
+            toolkit_registry=GLOBAL_TOOLKIT_REGISTRY
     ):
         """
         Determines whether the two molecules are isomorphic by comparing their graph representations and the chosen
@@ -2181,6 +2182,15 @@ class FrozenMolecule(Serializable):
         bond_stereochemistry_matching : bool, default=True, optional
             If ``False``, bonds' stereochemistry is ignored for the
             purpose of determining equality.
+
+        strip_pyrimidal_n_atom_stereo: bool, default=True, optional
+            If ``True``, any stereochemistry defined around pyrimidal
+            nitrogen stereocenters will be disregarded in the isomorphism
+            check.
+
+        toolkit_registry : openforcefield.utils.toolkits.ToolkitRegistry or openforcefield.utils.toolkits.ToolkitWrapper, optional, default=None
+            :class:`ToolkitRegistry` or :class:`ToolkitWrapper` to use for
+            removing stereochemistry from pyrimidal nitrogens.
 
         Returns
         -------
@@ -2244,14 +2254,14 @@ class FrozenMolecule(Serializable):
                 if strip_pyrimidal_n_atom_stereo:
                     # Make a copy of the molecule so we don't modify the original
                     data = deepcopy(data)
-                    data.strip_atom_stereochemistry(SMARTS)
+                    data.strip_atom_stereochemistry(SMARTS, toolkit_registry=toolkit_registry)
                 return data.to_networkx()
             elif isinstance(data, TopologyMolecule):
                 # TopologyMolecule class instance
                 if strip_pyrimidal_n_atom_stereo:
                     # Make a copy of the molecule so we don't modify the original
                     ref_mol = deepcopy(data.reference_molecule)
-                    ref_mol.strip_atom_stereochemistry(SMARTS)
+                    ref_mol.strip_atom_stereochemistry(SMARTS, toolkit_registry=toolkit_registry)
                 return ref_mol.to_networkx()
             elif isinstance(data, nx.Graph):
                 return data
@@ -2315,6 +2325,15 @@ class FrozenMolecule(Serializable):
             If ``False``, bonds' stereochemistry is ignored for the
             purpose of determining equality.
 
+        strip_pyrimidal_n_atom_stereo: bool, default=True, optional
+            If ``True``, any stereochemistry defined around pyrimidal
+            nitrogen stereocenters will be disregarded in the isomorphism
+            check.
+
+        toolkit_registry : openforcefield.utils.toolkits.ToolkitRegistry or openforcefield.utils.toolkits.ToolkitWrapper, optional, default=None
+            :class:`ToolkitRegistry` or :class:`ToolkitWrapper` to use for
+            removing stereochemistry from pyrimidal nitrogens.
+
         Returns
         -------
         isomorphic : bool
@@ -2326,7 +2345,8 @@ class FrozenMolecule(Serializable):
                                        bond_order_matching=kwargs.get('bond_order_matching', True),
                                        atom_stereochemistry_matching=kwargs.get('atom_stereochemistry_matching', True),
                                        bond_stereochemistry_matching=kwargs.get('bond_stereochemistry_matching', True),
-                                       strip_pyrimidal_n_atom_stereo=kwargs.get('strip_pyrimidal_n_atom_stereo', True))[0]
+                                       strip_pyrimidal_n_atom_stereo=kwargs.get('strip_pyrimidal_n_atom_stereo', True),
+                                       toolkit_registry=kwargs.get('toolkit_registry', GLOBAL_TOOLKIT_REGISTRY))[0]
 
     def generate_conformers(self,
                             toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -2193,6 +2193,8 @@ class FrozenMolecule(Serializable):
             [Dict[int,int]] ordered by mol1 indexing {mol1_index: mol2_index}
             If molecules are not isomorphic given input arguments, will return None instead of dict.
         """
+        mol1 = deepcopy(mol1)
+        mol2 = deepcopy(mol2)
 
         # Do a quick hill formula check first
         if Molecule.to_hill_formula(mol1) != Molecule.to_hill_formula(mol2):


### PR DESCRIPTION
Differences in tertiary nitrogen stereochemistry shouldn't be important in parameterization. This PR will add methods to strip this information or disregard it in certain contexts. 
<img width="200" alt="Screen Shot 2020-07-17 at 10 48 06 AM" src="https://user-images.githubusercontent.com/16329175/87815764-0e6e4000-c81b-11ea-8e2f-70a80dbcf302.png">

The information about the nitrogen "stereocenter" in the above molecule SHOULD be stored (becuase otherwise we'll fail OEMol->OFFMol->OEMol roundtrips), but it SHOULD NOT be considered significant by the `__eq__` operator.

So, I propose that we add `Molecule.strip_atom_stereochemistry(smarts)`, which expects a SMARTS tagging a single atom, and will remove it stereo info (if set). So, the case above could be handled by `offmol.strip_atom_stereo('[N+0X3:1](-[*])(-[*])(-[*])')`. This SMARTS should only tag a single atom (can check this using `ChemicalEnvironment.validate`). Any atom indices found by running `ToolkitRegistry.call('find_smarts_matches', ...)` on this molecule should have their stereochemical information cleared, for example using `offmol.atoms[idx].stereochemistry=None`.

We should add a new kwarg to `Molecule.are/is_isomorphic` called `strip_pyrimidal_n_atom_stereo=True`. If `True`, we make a COPY of the molecules and strip N stereo information from the copies. Since the `__eq__` operator just calls these methods, our `__eq__` operator will therefore disregard tertiary N stereo.

Tests for this should compare two OFFMols made from SMILES and ensure that 
```
Molecule.from_smiles('CCC[N@](C)CC') == Molecule.from_smiles('CCC[N@@](C)CC')
```
 but that the same test FAILS if we explicitly call `is/are_isomorphic` with `strip_n_atom_stereo=False`.

We should test that this method DOES NOT mangle:
* _Quaternary_ N+1s (with 4 distinct heavy substituents) should be disregarded
* Aromatic tertiary N+1s (like the NH in [histidine's sidechain ring](https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/Histidin_-_Histidine.svg/1200px-Histidin_-_Histidine.svg.png)). Though these are planar so there shouldn't be stereo info to strip, so we may not be able to test this. 


**Additional context**
We could make a kwarg to `create_openmm_system` to say `tertiary_nitrogen_stereochemistry_is_distinguishing`, but this would add a lot of complexity and it doesn't seem like a lot of users would desire that. 