### PR TITLE
Make OE re-percieve aromaticity in `to_openeye`

### DIFF
--- a/openforcefield/tests/test_molecule.py
+++ b/openforcefield/tests/test_molecule.py
@@ -708,9 +708,9 @@ class TestMolecule:
                               'DrugBank_3726', 'DrugBank_3844', 'DrugBank_3930', 'DrugBank_4161',
                               'DrugBank_4162', 'DrugBank_4778', 'DrugBank_4593', 'DrugBank_4959',
                               'DrugBank_5043', 'DrugBank_5076', 'DrugBank_5176', 'DrugBank_5418',
-                              'DrugBank_5737', 'DrugBank_5902', 'DrugBank_6304', 'DrugBank_6305',
-                              'DrugBank_6329', 'DrugBank_6355', 'DrugBank_6401', 'DrugBank_6509',
-                              'DrugBank_6531', 'DrugBank_6647',
+                              'DrugBank_5737', 'DrugBank_5902', 'DrugBank_6295', 'DrugBank_6304',
+                              'DrugBank_6305', 'DrugBank_6329', 'DrugBank_6355', 'DrugBank_6401',
+                              'DrugBank_6509', 'DrugBank_6531', 'DrugBank_6647',
 
                               # These test cases are allowed to fail.
                               'DrugBank_390', 'DrugBank_810', 'DrugBank_4316', 'DrugBank_4346',

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -1331,7 +1331,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         for atom in molecule.atoms:
             oeatom = oemol.NewAtom(atom.atomic_number)
             oeatom.SetFormalCharge(atom.formal_charge.value_in_unit(unit.elementary_charge)) # simtk.unit.Quantity(1, unit.elementary_charge)
-            oeatom.SetAromatic(atom.is_aromatic)
+            #oeatom.SetAromatic(atom.is_aromatic)
             oeatom.SetData('name', atom.name)
             oeatom.SetPartialCharge(float('nan'))
             oemol_atoms.append(oeatom)
@@ -1347,11 +1347,13 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             oebond = oemol.NewBond(oemol_atoms[atom1_index],
                                    oemol_atoms[atom2_index])
             oebond.SetOrder(bond.bond_order)
-            oebond.SetAromatic(bond.is_aromatic)
+            #oebond.SetAromatic(bond.is_aromatic)
             if not (bond.fractional_bond_order is None):
                 oebond.SetData('fractional_bond_order',
                                bond.fractional_bond_order)
             oemol_bonds.append(oebond)
+
+        oechem.OEAssignAromaticFlags(oemol, oechem.OEAroModel_MDL)
 
         # Set atom stereochemistry now that all connectivity is in place
         for atom, oeatom in zip(molecule.atoms, oemol_atoms):

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -1322,6 +1322,14 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         """
         from openeye import oechem
 
+        if hasattr(oechem, aromaticity_model):
+            oe_aro_model = getattr(oechem,
+                                   'OEAroModel_' + aromaticity_model)
+        else:
+            raise ValueError(
+                "Error: provided aromaticity model not recognized by oechem."
+            )
+
         oemol = oechem.OEMol()
         #if not(molecule.name is None):
         oemol.SetTitle(molecule.name)
@@ -1331,6 +1339,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         for atom in molecule.atoms:
             oeatom = oemol.NewAtom(atom.atomic_number)
             oeatom.SetFormalCharge(atom.formal_charge.value_in_unit(unit.elementary_charge)) # simtk.unit.Quantity(1, unit.elementary_charge)
+            # TODO: Do we want to provide _any_ pathway for Atom.is_aromatic to influence the OEMol?
             #oeatom.SetAromatic(atom.is_aromatic)
             oeatom.SetData('name', atom.name)
             oeatom.SetPartialCharge(float('nan'))
@@ -1347,13 +1356,14 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             oebond = oemol.NewBond(oemol_atoms[atom1_index],
                                    oemol_atoms[atom2_index])
             oebond.SetOrder(bond.bond_order)
+            # TODO: Do we want to provide _any_ pathway for Bond.is_aromatic to influence the OEMol?
             #oebond.SetAromatic(bond.is_aromatic)
             if not (bond.fractional_bond_order is None):
                 oebond.SetData('fractional_bond_order',
                                bond.fractional_bond_order)
             oemol_bonds.append(oebond)
 
-        oechem.OEAssignAromaticFlags(oemol, oechem.OEAroModel_MDL)
+        oechem.OEAssignAromaticFlags(oemol, oe_aro_model)
 
         # Set atom stereochemistry now that all connectivity is in place
         for atom, oeatom in zip(molecule.atoms, oemol_atoms):

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -1323,8 +1323,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         from openeye import oechem
 
         if hasattr(oechem, aromaticity_model):
-            oe_aro_model = getattr(oechem,
-                                   'OEAroModel_' + aromaticity_model)
+            oe_aro_model = getattr(oechem, aromaticity_model)
         else:
             raise ValueError(
                 "Error: provided aromaticity model not recognized by oechem."


### PR DESCRIPTION
Quick fix for #644 

The quick fix simply has Molecule.to_openeye disregard the OFFMol's existing is_aromatic flags and re-perceives them. In almost all cases, this should be fine.

For more details, see: https://github.com/openforcefield/openforcefield/issues/644#issuecomment-658422943