### PR TITLE
[OpenEye] Add option to compute AM1 ELF10 partial charges

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -31,6 +31,10 @@ New features
 - `PR #614 <https://github.com/openforcefield/openforcefield/pull/614>`_: Adds 
   :py:meth:`ToolkitRegistry.deregister_toolkit <openforcefield.utils.toolkits.ToolkitRegistry.deregister_toolki>` 
   to de-register registered toolkits, which can include toolkit wrappers loaded into `GLOBAL_TOOLKIT_REGISTRY` by default.
+- `PR #656 <https://github.com/openforcefield/openforcefield/pull/656>`_: Adds
+  a new allowed `am1elf10` option to the OpenEye implementation of
+  :py:meth:`assign_partial_charges <openforcefield.utils.toolkits.OpenEyeToolkitWrapper.assign_partial_charges>` which
+  calculates the average partial charges at the AM1 level of theory using conformers selected using the ELF10 method.
 
 0.7.0 - Charge Increment Model, Proper Torsion interpolation, and new Molecule methods
 --------------------------------------------------------------------------------------

--- a/openforcefield/tests/test_toolkits.py
+++ b/openforcefield/tests/test_toolkits.py
@@ -750,7 +750,7 @@ class TestOpenEyeToolkitWrapper:
 
 
     @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
-    @pytest.mark.parametrize("partial_charge_method", ['am1bcc', 'am1-mulliken', 'gasteiger'])
+    @pytest.mark.parametrize("partial_charge_method", ['am1bcc', 'am1elf10', 'am1-mulliken', 'gasteiger'])
     def test_assign_partial_charges_neutral(self, partial_charge_method):
         """Test OpenEyeToolkitWrapper assign_partial_charges()"""
         from openforcefield.tests.test_forcefield import create_ethanol
@@ -788,7 +788,7 @@ class TestOpenEyeToolkitWrapper:
             assert abs(pc1 - pc2) > 1.e-5 * unit.elementary_charge
 
     @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
-    @pytest.mark.parametrize("partial_charge_method", ['am1bcc', 'am1-mulliken', 'gasteiger'])
+    @pytest.mark.parametrize("partial_charge_method", ['am1bcc', 'am1elf10', 'am1-mulliken', 'gasteiger'])
     def test_assign_partial_charges_net_charge(self, partial_charge_method):
         """
         Test OpenEyeToolkitWrapper assign_partial_charges() on a molecule with net charge.

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -1850,6 +1850,11 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
                                                        'max_confs': 1,
                                                        'rec_confs': 1,
                                                        },
+                                    'am1elf10': {'oe_charge_method': oequacpac.OEELFCharges(oequacpac.OEAM1Charges(optimize=True, symmetrize=True), 10),
+                                                 'min_confs': 1,
+                                                 'max_confs': None,
+                                                 'rec_confs': 500,
+                                                },
                                     'am1bccelf10': {'oe_charge_method': oequacpac.OEAM1BCCELF10Charges,
                                                   'min_confs': 1,
                                                   'max_confs': None,
@@ -1905,16 +1910,24 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             symmetrize = False
             quacpac_status = oequacpac.OEAssignCharges(oemol, charge_method['oe_charge_method'](optimize, symmetrize))
         else:
-            quacpac_status = oequacpac.OEAssignCharges(oemol, charge_method['oe_charge_method']())
+            oe_charge_method = charge_method['oe_charge_method']
+
+            if callable(oe_charge_method):
+                oe_charge_method = oe_charge_method()
+
+            quacpac_status = oequacpac.OEAssignCharges(oemol, oe_charge_method)
 
         oechem.OEThrow.SetOutputStream(oechem.oeerr)  # restoring to original state
         # This logic handles errors encountered in #34, which can occur when using ELF10 conformer selection
         if not quacpac_status:
+
+            oe_charge_engine = oequacpac.OEAM1Charges if partial_charge_method == "am1elf10" else oequacpac.OEAM1BCCCharges
+
             if "SelectElfPop: issue with removing trans COOH conformers" in (errfs.str().decode("UTF-8")):
-                logger.warning("Warning: OEAM1BCCELF10 charge assignment failed due to a known bug (toolkit issue "
-                               "#346). Downgrading to OEAM1BCC charge assignment for this molecule. More information"
-                               "is available at https://github.com/openforcefield/openforcefield/issues/346")
-                quacpac_status = oequacpac.OEAssignCharges(oemol, oequacpac.OEAM1BCCCharges())
+                logger.warning(f"Warning: charge assignment involving ELF10 conformer selection failed due to a known bug (toolkit issue "
+                               f"#346). Downgrading to {oe_charge_engine.__name__} charge assignment for this molecule. More information"
+                               f"is available at https://github.com/openforcefield/openforcefield/issues/346")
+                quacpac_status = oequacpac.OEAssignCharges(oemol, oe_charge_engine())
 
         if quacpac_status is False:
             raise ChargeCalculationError(f'Unable to assign charges: {errfs.str().decode("UTF-8")}')


### PR DESCRIPTION
- [X] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [x] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)

This PR adds a new `am1elf10` option to the OpenEye implementation of `assign_partial_charges` which calculates the average partial charges at the AM1 level of theory using conformers selected using the ELF10 method.

Resolves #655 