### PR TITLE
Assign molecule charges on ref mols when return_topology=True

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -12,9 +12,11 @@ Releases follow the ``major.minor.micro`` scheme recommended by `PEP440 <https:/
 
 Behavior changed
 """"""""""""""""
-- `PR #648 <https://github.com/openforcefield/openforcefield/pull/648>`_: Removes the 
+- `PR #648 <https://github.com/openforcefield/openforcefield/pull/648>`_: Removes the
   ``utils.structure`` module, which was deprecated in 0.2.0.
-
+- `PR #670 <https://github.com/openforcefield/openforcefield/pull/670>`_: Makes the
+  :py:class:`Topology <openforcefield.topology.Topology>` returned by ``create_openmm_system``
+  contain the partial charges and partial bond orders (if any) assigned during parameterization.
 
 0.7.1 - OETK2020 Compatibility and Minor Update
 -----------------------------------------------

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -1883,6 +1883,36 @@ class TestForceFieldChargeAssignment:
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q != 0 * unit.elementary_charge
 
+    @pytest.mark.parametrize('charge_method,additional_offxmls', [ ('ToolkitAM1BCC', []),
+                                                                   ('LibraryCharges', [xml_ethanol_library_charges_ff]),
+                                                                   ('ChargeIncrementHandler', [xml_charge_increment_model_formal_charges]),
+                                                                   ('charge_from_molecules', [])])
+    def test_charges_on_ref_mols_when_using_return_topology(self, charge_method, additional_offxmls):
+        """Ensure that charges are set on returned topology if the user specifies 'return_topology=True' in
+        create_openmm_system"""
+        from simtk.openmm import NonbondedForce
+
+        mol = create_acetate()
+        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml', *additional_offxmls)
+        charge_mols = []
+        if charge_method == 'charge_from_molecules':
+            mol.partial_charges = np.array([-1.3, -0.2, -0.1, 0., 0.1, 0.2, 0.3]) * unit.elementary_charge
+            charge_mols = [mol]
+        omm_system, ret_top = ff.create_openmm_system(mol.to_topology(),
+                                                      charge_from_molecules=charge_mols,
+                                                      return_topology=True)
+        nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
+        ref_mol_from_ret_top = [i for i in ret_top.reference_molecules][0]
+
+        # Make sure the charges on the molecule are all nonzero, and that the molecule's
+        # partial_charges array matches the charges in the openmm system
+        all_charges_zero = True
+        for particle_index, ref_mol_charge in enumerate(ref_mol_from_ret_top.partial_charges):
+            q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
+            assert q == ref_mol_charge
+            if q != 0. * unit.elementary_charge:
+                all_charges_zero = False
+        assert not(all_charges_zero)
 
 
 

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -1890,6 +1890,7 @@ class TestForceFieldChargeAssignment:
     def test_charges_on_ref_mols_when_using_return_topology(self, charge_method, additional_offxmls):
         """Ensure that charges are set on returned topology if the user specifies 'return_topology=True' in
         create_openmm_system"""
+        # TODO: Should this test also cover multiple unique molecules?
         from simtk.openmm import NonbondedForce
 
         mol = create_acetate()

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -1157,24 +1157,30 @@ class ForceField:
         ----------
         topology : openforcefield.topology.Topology
             The ``Topology`` corresponding to the system to be parameterized
-        charge_from_molecules : List[openforcefield.molecule.Molecule], optional
+        charge_from_molecules : List[openforcefield.molecule.Molecule], optional. default =[]
             If specified, partial charges will be taken from the given molecules
             instead of being determined by the force field.
-        partial_bond_orders_from_molecules : List[openforcefield.molecule.Molecule], optional
+        partial_bond_orders_from_molecules : List[openforcefield.molecule.Molecule], optional. default=[]
             If specified, partial bond orders will be taken from the given molecules
             instead of being determined by the force field.
             **All** bonds on each molecule given must have ``fractional_bond_order`` specified.
             A `ValueError` will be raised if any bonds have ``fractional_bond_order=None``.
             Molecules in the topology not represented in this list will have fractional
             bond orders calculated using underlying toolkits as needed.
-        return_topology : bool
+        return_topology : bool, optional. default=False
             If ``True``, return tuple of ``(system, topology)``, where
-            ``topology`` is the processed topology. Default ``False``.
+            ``topology`` is the processed topology. Default ``False``. This topology will have the
+            final partial charges assigned on its reference_molecules attribute, as well as partial
+            bond orders (if they were calculated).
 
         Returns
         -------
         system : simtk.openmm.System
             The newly created OpenMM System corresponding to the specified ``topology``
+        topology : openforcefield.topology.Topology, optional.
+            If the `return_topology` keyword argument is used, this method will also return a Topology. This
+            can be used to inspect the partial charges and partial bond orders assigned to the molecules
+            during parameterization.
 
         """
         return_topology = kwargs.pop('return_topology', False)

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -3178,13 +3178,10 @@ class ElectrostaticsHandler(_NonbondedHandler):
             if self.check_charges_assigned(ref_mol, topology):
                 continue
 
-            # Make a temporary copy of ref_mol to assign charges from charge_mol
-            temp_mol = FrozenMolecule(ref_mol)
-
             # First, check whether any of the reference molecules in the topology are in the charge_from_mol list
             charges_from_charge_mol = False
             if 'charge_from_molecules' in kwargs:
-                charges_from_charge_mol = self.assign_charge_from_molecules(temp_mol, kwargs['charge_from_molecules'])
+                charges_from_charge_mol = self.assign_charge_from_molecules(ref_mol, kwargs['charge_from_molecules'])
 
             # If this reference molecule wasn't in the charge_from_molecules list, end this iteration
             if not(charges_from_charge_mol):
@@ -3206,7 +3203,7 @@ class ElectrostaticsHandler(_NonbondedHandler):
 
                     topology_particle_index = topology_particle.topology_particle_index
 
-                    particle_charge = temp_mol._partial_charges[ref_mol_particle_index]
+                    particle_charge = ref_mol._partial_charges[ref_mol_particle_index]
 
                     # Retrieve nonbonded parameters for reference atom (charge not set yet)
                     _, sigma, epsilon = force.getParticleParameters(topology_particle_index)
@@ -3394,10 +3391,9 @@ class LibraryChargeHandler(_NonbondedHandler):
         for top_mol in topology.topology_molecules:
 
             # Make a temporary copy of ref_mol to assign charges from charge_mol
-            temp_mol = FrozenMolecule(top_mol.reference_molecule)
 
             # If charges were already assigned, skip this molecule
-            if self.check_charges_assigned(temp_mol, topology):
+            if self.check_charges_assigned(top_mol.reference_molecule, topology):
                 continue
 
             # Ensure all of the atoms in this mol are covered, otherwise skip it
@@ -3416,7 +3412,7 @@ class LibraryChargeHandler(_NonbondedHandler):
                                             sigma,
                                             epsilon)
 
-            ref_mols_assigned.add(temp_mol)
+            ref_mols_assigned.add(top_mol.reference_molecule)
 
         # Finally, mark that charges were assigned for this reference molecule
         for assigned_mol in ref_mols_assigned:
@@ -3466,15 +3462,12 @@ class ToolkitAM1BCCHandler(_NonbondedHandler):
             if self.check_charges_assigned(ref_mol, topology):
                 continue
 
-            # Make a temporary copy of ref_mol to assign charges
-            temp_mol = FrozenMolecule(ref_mol)
-
             # If the molecule wasn't already assigned charge values, calculate them here
             toolkit_registry = kwargs.get('toolkit_registry', GLOBAL_TOOLKIT_REGISTRY)
             try:
                 # We don't need to generate conformers here, since that will be done by default in
                 # compute_partial_charges_am1bcc if the use_conformers kwarg isn't defined
-                temp_mol.compute_partial_charges_am1bcc(toolkit_registry=toolkit_registry)
+                ref_mol.compute_partial_charges_am1bcc(toolkit_registry=toolkit_registry)
             except Exception as e:
                 warnings.warn(str(e), Warning)
                 continue
@@ -3491,7 +3484,7 @@ class ToolkitAM1BCCHandler(_NonbondedHandler):
 
                     topology_particle_index = topology_particle.topology_particle_index
 
-                    particle_charge = temp_mol._partial_charges[ref_mol_particle_index]
+                    particle_charge = ref_mol._partial_charges[ref_mol_particle_index]
 
                     # Retrieve nonbonded parameters for reference atom (charge not set yet)
                     _, sigma, epsilon = force.getParticleParameters(topology_particle_index)
@@ -3632,14 +3625,11 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
             if self.check_charges_assigned(ref_mol, topology):
                 continue
 
-            # Make a temporary copy of ref_mol to assign charges from charge_mol
-            temp_mol = FrozenMolecule(ref_mol)
-
             toolkit_registry = kwargs.get('toolkit_registry', GLOBAL_TOOLKIT_REGISTRY)
             try:
                 # If the molecule wasn't assigned parameters from a manually-input charge_mol, calculate them here
-                temp_mol.generate_conformers(n_conformers=self.number_of_conformers)
-                temp_mol.assign_partial_charges(partial_charge_method=self.partial_charge_method,
+                ref_mol.generate_conformers(n_conformers=self.number_of_conformers)
+                ref_mol.assign_partial_charges(partial_charge_method=self.partial_charge_method,
                                                 toolkit_registry=toolkit_registry)
             except Exception as e:
                 warnings.warn(str(e), Warning)
@@ -3655,7 +3645,7 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
                         ref_mol_particle_index = topology_particle.atom.molecule_particle_index
                     if type(topology_particle) is TopologyVirtualSite:
                         ref_mol_particle_index = topology_particle.virtual_site.molecule_particle_index
-                    particle_charge = temp_mol._partial_charges[ref_mol_particle_index]
+                    particle_charge = ref_mol._partial_charges[ref_mol_particle_index]
                     charges_to_assign[topology_particle_index] = particle_charge
 
             # Find SMARTS-based matches for charge increments


### PR DESCRIPTION
Now that we're making more extensive use of the `return_topology` kwarg to `create_openmm_system`, I thought it'd make sense to also assign the assigned charges to the reference molecules. This PR adds that behavior, as well as a test that it works for our current charge methods.


- [x] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [x] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
