### PR TITLE
Lint with black and set up automated black check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,6 @@ name: lint
 
 on:
   push:
-    paths:
-      - 'openforcefield/**.py'
-      - 'setup.cfg'
 
 jobs:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: lint
+
+on:
+  push:
+    paths:
+      - 'openforcefield/**.py'
+      - 'setup.cfg'
+
+jobs:
+
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+
+      - name: Install linters
+        run: |
+          pip install black
+
+      - name: Run black
+        run: |
+          black openff --check openforcefield

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
 
       - name: Run black
         run: |
-          black openff --check openforcefield
+          black --check openforcefield

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -268,18 +268,14 @@ The naming conventions of classes, functions, and variables follows `PEP8 <https
 
 We place a high priority on code cleanliness and readability, even if code could be written more compactly. For example, 15-character variable names are fine. Triply nested list comprehensions are not.
 
-The ``openforcefield`` toolkit uses automated code formatting tools ("linters") to maintain consistent style and remove the burden of adhering to these standards by hand. Currently, three are employed:
+The ``openforcefield`` toolkit is in the process of adopting code formatting tools ("linters") to maintain consistent style and remove the burden of adhering to these standards by hand. Currently, only one is employed:
 1. `Black <https://black.readthedocs.io/>`_, the uncompromising code formatter, automatically formats code with a consistent style.
-2. `isort <https://timothycrosley.github.io/isort/>`_ enforces a consistent ordering of imports.
-3. `Flake8 <https://flake8.pycqa.org/>`_ checks for other potential style issues. It does not automatically apply changes, it only reports issues it finds. It is highly configurable and we have some rules turned off; see the ``setup.cfg`` file for details.
 
-There is a step in CI that uses these tools to check for a consistent style. To ensure that changes follow these standards, you can install and run these tools locally:
+There is a step in CI that uses these tool(s) to check for a consistent style. To ensure that changes follow these standards, you can install and run these tool(s) locally:
 
 .. code-block:: bash
 
-    $ conda install black isort flake8 -c conda-forge
+    $ conda install black -c conda-forge
     $ black openforcefield
-    $ isort openforcefield
-    $ flake8 openforcefield
 
 Anything not covered above is up to personal preference.

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -278,4 +278,4 @@ There is a step in CI that uses these tool(s) to check for a consistent style. T
     $ conda install black -c conda-forge
     $ black openforcefield
 
-Anything not covered above is up to personal preference.
+Anything not covered above is currently up to personal preference, but may change as new linters are added.

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -266,11 +266,20 @@ The naming conventions of classes, functions, and variables follows `PEP8 <https
 - Use ``file_path``, ``file_name``, and ``file_stem`` to indicate ``path/to/stem.extension``, ``stem.extension``, and ``stem`` respectively, consistently with the variables in the standard ``pathlib`` library.
 - Use ``n_x`` to abbreviate "number of X` (e.g. `n_atoms`, `n_molecules`).
 
-We place a high priority on code cleanliness and readability.
-So, 15-character variable names are fine.
-Triply nested list comprehensions are not.
+We place a high priority on code cleanliness and readability, even if code could be written more compactly. For example, 15-character variable names are fine. Triply nested list comprehensions are not.
 
+The ``openforcefield`` toolkit uses automated code formatting tools ("linters") to maintain consistent style and remove the burden of adhering to these standards by hand. Currently, three are employed:
+1. `Black <https://black.readthedocs.io/>`_, the uncompromising code formatter, automatically formats code with a consistent style.
+2. `isort <https://timothycrosley.github.io/isort/>`_ enforces a consistent ordering of imports.
+3. `Flake8 <https://flake8.pycqa.org/>`_ checks for other potential style issues. It does not automatically apply changes, it only reports issues it finds. It is highly configurable and we have some rules turned off; see the ``setup.cfg`` file for details.
+
+There is a step in CI that uses these tools to check for a consistent style. To ensure that changes follow these standards, you can install and run these tools locally:
+
+.. code-block:: bash
+
+    $ conda install black isort flake8 -c conda-forge
+    $ black openforcefield
+    $ isort openforcefield
+    $ flake8 openforcefield
 
 Anything not covered above is up to personal preference.
-To remove the human friction from code formatting, we will likely adopt a standard formatter like `black <https://github.com/psf/black>`_ in the near future.
-

--- a/openforcefield/__init__.py
+++ b/openforcefield/__init__.py
@@ -1,3 +1,4 @@
 from ._version import get_versions
-__version__ = get_versions()['version']
+
+__version__ = get_versions()["version"]
 del get_versions

--- a/openforcefield/_version.py
+++ b/openforcefield/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -58,17 +57,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -76,10 +76,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -116,16 +119,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -181,7 +190,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -190,7 +199,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -198,19 +207,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -225,8 +241,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -234,10 +249,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -260,17 +284,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -279,10 +302,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -293,13 +318,13 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[
+        0
+    ].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -330,8 +355,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -445,11 +469,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -469,9 +495,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -485,8 +515,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -495,13 +524,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for i in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -515,6 +547,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/openforcefield/tests/conftest.py
+++ b/openforcefield/tests/conftest.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#=============================================================================================
+# =============================================================================================
 # MODULE DOCSTRING
-#=============================================================================================
+# =============================================================================================
 
 """
 Configuration file for pytest.
@@ -13,11 +13,12 @@ This adds the following command line options.
 """
 
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import pytest
+
 
 def pytest_configure(config):
     """
@@ -29,9 +30,10 @@ def pytest_configure(config):
     )
 
 
-#=============================================================================================
+# =============================================================================================
 # UTILITY FUNCTIONS
-#=============================================================================================
+# =============================================================================================
+
 
 def untar_full_alkethoh_and_freesolv_set():
     """When running slow tests, we unpack the full AlkEthOH and FreeSolv test
@@ -45,16 +47,17 @@ def untar_full_alkethoh_and_freesolv_set():
     import tarfile
     from openforcefield.utils import get_data_file_path
 
-    molecule_dir_path = get_data_file_path('molecules')
-    for tarfile_name in ['AlkEthOH_tripos.tar.gz', 'FreeSolv.tar.gz']:
+    molecule_dir_path = get_data_file_path("molecules")
+    for tarfile_name in ["AlkEthOH_tripos.tar.gz", "FreeSolv.tar.gz"]:
         tarfile_path = os.path.join(molecule_dir_path, tarfile_name)
-        with tarfile.open(tarfile_path, 'r:gz') as tar:
+        with tarfile.open(tarfile_path, "r:gz") as tar:
             tar.extractall(path=molecule_dir_path)
 
 
-#=============================================================================================
+# =============================================================================================
 # CONFIGURATION
-#=============================================================================================
+# =============================================================================================
+
 
 def pytest_addoption(parser):
     """Add the pytest command line option --runslow and --failwip.
@@ -69,7 +72,10 @@ def pytest_addoption(parser):
         "--runslow", action="store_true", default=False, help="run slow tests"
     )
     parser.addoption(
-        "--failwip", action="store_true", default=False, help="fail work in progress tests"
+        "--failwip",
+        action="store_true",
+        default=False,
+        help="fail work in progress tests",
     )
 
 
@@ -82,17 +88,23 @@ def pytest_collection_modifyitems(config, items):
         untar_full_alkethoh_and_freesolv_set()
     else:
         # Mark for skipping all items marked as slow.
-        skip_slow = pytest.mark.skip(reason="specify --runslow pytest option to run this test.")
+        skip_slow = pytest.mark.skip(
+            reason="specify --runslow pytest option to run this test."
+        )
         for item in items:
             if "slow" in item.keywords:
                 item.add_marker(skip_slow)
 
     # Mark work-in-progress tests for xfail.
     if not config.getoption("failwip"):
-        xfail_wip_reason = ("This is a work in progress test. Specify "
-                            "--failwip pytest option to make this test fail.")
+        xfail_wip_reason = (
+            "This is a work in progress test. Specify "
+            "--failwip pytest option to make this test fail."
+        )
         for item in items:
-            if 'wip' in item.keywords:
+            if "wip" in item.keywords:
                 # Augment original reason.
-                reason = xfail_wip_reason + item.get_closest_marker('wip').kwargs.get('reason', '')
+                reason = xfail_wip_reason + item.get_closest_marker("wip").kwargs.get(
+                    "reason", ""
+                )
                 item.add_marker(pytest.mark.xfail(reason=reason))

--- a/openforcefield/tests/plugins.py
+++ b/openforcefield/tests/plugins.py
@@ -3,8 +3,8 @@ from openforcefield.typing.engines.smirnoff import ParameterHandler, ParameterIO
 
 
 class CustomHandler(ParameterHandler):
-    _TAGNAME = 'CustomHandler'
+    _TAGNAME = "CustomHandler"
 
 
 class CustomIOHandler(ParameterIOHandler):
-    _FORMAT = 'JSON'
+    _FORMAT = "JSON"

--- a/openforcefield/tests/test_chemicalenvironment.py
+++ b/openforcefield/tests/test_chemicalenvironment.py
@@ -6,75 +6,171 @@ from openforcefield.utils.toolkits import OPENEYE_AVAILABLE
 toolkits = []
 if OPENEYE_AVAILABLE:
     from openforcefield.utils.toolkits import RDKitToolkitWrapper, OpenEyeToolkitWrapper
-    toolkits.append('openeye')
+
+    toolkits.append("openeye")
     toolkits.append(OpenEyeToolkitWrapper())
 else:
     from openforcefield.utils.toolkits import RDKitToolkitWrapper
-    toolkits.append('rdkit')
+
+    toolkits.append("rdkit")
     toolkits.append(RDKitToolkitWrapper())
 
 
-class TestChemicalEnvironments():
+class TestChemicalEnvironments:
     def test_createEnvironments(self):
         """
         Test all types of ChemicalEnvironment objects with defined atoms and bonds
         Each will be tetrahedral carbons connected by ring single bonds
         """
-        carbon = [['#6'], ['X4']]
-        singleBond = [['-'], ['@']]
-        atom = AtomChemicalEnvironment('[#6X4:1]','CT')
-        bond = BondChemicalEnvironment('[#6X4:1]-[#6X4:2]', 'CT-CT')
-        angle = AngleChemicalEnvironment('[#6X4:1]-[#6X4:2]-[#6X4:3]', 'CT-CT-CT')
-        torsion = TorsionChemicalEnvironment('[#6X4:1]-[#6X4:2]-[#6X4:3]-[#6X4:4]', 'CT-CT-CT-CT')
-        improper = ImproperChemicalEnvironment('[#6X4:1]-[#6X4:2](-[#6X4:3])-[#6X4:4]', 'CT-CT(-CT)-CT')
+        carbon = [["#6"], ["X4"]]
+        singleBond = [["-"], ["@"]]
+        atom = AtomChemicalEnvironment("[#6X4:1]", "CT")
+        bond = BondChemicalEnvironment("[#6X4:1]-[#6X4:2]", "CT-CT")
+        angle = AngleChemicalEnvironment("[#6X4:1]-[#6X4:2]-[#6X4:3]", "CT-CT-CT")
+        torsion = TorsionChemicalEnvironment(
+            "[#6X4:1]-[#6X4:2]-[#6X4:3]-[#6X4:4]", "CT-CT-CT-CT"
+        )
+        improper = ImproperChemicalEnvironment(
+            "[#6X4:1]-[#6X4:2](-[#6X4:3])-[#6X4:4]", "CT-CT(-CT)-CT"
+        )
 
-    @pytest.mark.parametrize(['smirks', 'expected_valence', 'expected_chemenv_class'],
-                             [["[#6](-[#1])-[#8]", None, ChemicalEnvironment],
-                              ["[#6&X4&H0:1](-[#1])-[#6&X4]", 'Atom', AtomChemicalEnvironment],
-                              ["[#6&X4&H0:1](-[#1])-[#6&X4:2]", 'Bond', BondChemicalEnvironment],
-                              ["[*:1]-[*:2](-[#6&X4])-[*:3]", 'Angle', AngleChemicalEnvironment],
-                              ["[#6&X4&H0:1](-[#1])-[#6&X4:2]-[#6&X4&H0:3](-[#1])-[#6&X4:4]", 'ProperTorsion',
-                               TorsionChemicalEnvironment],
-                              ["[#1:1]-[#6&X4:2](-[#8:3])-[#1:4]", 'ImproperTorsion', ImproperChemicalEnvironment],
-                              # Test that an improper smirks is also valid as a general ChemicalEnvironment
-                              ["[#1:1]-[#6&X4:2](-[#8:3])-[*:4](-[#6&H1])-[#8:5]", None, ChemicalEnvironment],
-                              ["[#6$(*~[#6]=[#8])$(*-,=[#7!-1,#8,#16,#7])]", None, ChemicalEnvironment],
-                              ["CCC", None, ChemicalEnvironment],
-                              ["[#6:1]1(-;!@[#1,#6])=;@[#6]-;@[#6]1", 'Atom', ChemicalEnvironment],
-                              ["C(O-[#7,#8])CC=[*]", None, ChemicalEnvironment],
-                              ["[#6$([#6X4](~[#7!-1,#8!-1,#16!-1,#9,#17,#35,#53])(~[#8]~[#1])):1]-[#6X2H2;+0:2]-,=,:;!@;!#[#7!-1,#8,#16:3]-[#4:4]",
-                               'ProperTorsion', TorsionChemicalEnvironment],
-                              ["[#6$([#6X4](~[#7!-1,#8!-1,#16!-1,#9,#17,#35,#53])(~[#8]~[#1])):1]1=CCCC1", 'Atom', AtomChemicalEnvironment],
-                              ["[*:1]-[#7X3:2](-[#6a$(*1ccc(-[#8-1X1])cc1):3])-[*:4]", 'ImproperTorsion',
-                               ImproperChemicalEnvironment],
-                              ["[#6X4:1]1~[*:2]~[*$(*~[#1]):3]1", 'Angle', AngleChemicalEnvironment],
-                              ["[$([#7]1~[#6]-CC1)]", None, ChemicalEnvironment],
-                              ["[$(c1ccccc1)]", None, ChemicalEnvironment],
-                              # The next two tests are for ring-closing bonds
-                              ["[H][C@:4]1(C(C([C:3]([N:2]1[C:1](=O)C([H])([H])[H])([H])[H])([H])[H])([H])[H])C=O",
-                               'ImproperTorsion', ChemicalEnvironment],
-                              ["[P:1]=1=[P]=[P]=[P]=[P:2]=1", 'Bond', BondChemicalEnvironment],
-                              ]
-                             )
-    @pytest.mark.parametrize('toolkit', toolkits)
-    def test_parseSMIRKS(self, toolkit, smirks, expected_valence, expected_chemenv_class):
+    @pytest.mark.parametrize(
+        ["smirks", "expected_valence", "expected_chemenv_class"],
+        [
+            ["[#6](-[#1])-[#8]", None, ChemicalEnvironment],
+            ["[#6&X4&H0:1](-[#1])-[#6&X4]", "Atom", AtomChemicalEnvironment],
+            ["[#6&X4&H0:1](-[#1])-[#6&X4:2]", "Bond", BondChemicalEnvironment],
+            ["[*:1]-[*:2](-[#6&X4])-[*:3]", "Angle", AngleChemicalEnvironment],
+            [
+                "[#6&X4&H0:1](-[#1])-[#6&X4:2]-[#6&X4&H0:3](-[#1])-[#6&X4:4]",
+                "ProperTorsion",
+                TorsionChemicalEnvironment,
+            ],
+            [
+                "[#1:1]-[#6&X4:2](-[#8:3])-[#1:4]",
+                "ImproperTorsion",
+                ImproperChemicalEnvironment,
+            ],
+            # Test that an improper smirks is also valid as a general ChemicalEnvironment
+            [
+                "[#1:1]-[#6&X4:2](-[#8:3])-[*:4](-[#6&H1])-[#8:5]",
+                None,
+                ChemicalEnvironment,
+            ],
+            ["[#6$(*~[#6]=[#8])$(*-,=[#7!-1,#8,#16,#7])]", None, ChemicalEnvironment],
+            ["CCC", None, ChemicalEnvironment],
+            ["[#6:1]1(-;!@[#1,#6])=;@[#6]-;@[#6]1", "Atom", ChemicalEnvironment],
+            ["C(O-[#7,#8])CC=[*]", None, ChemicalEnvironment],
+            [
+                "[#6$([#6X4](~[#7!-1,#8!-1,#16!-1,#9,#17,#35,#53])(~[#8]~[#1])):1]-[#6X2H2;+0:2]-,=,:;!@;!#[#7!-1,#8,#16:3]-[#4:4]",
+                "ProperTorsion",
+                TorsionChemicalEnvironment,
+            ],
+            [
+                "[#6$([#6X4](~[#7!-1,#8!-1,#16!-1,#9,#17,#35,#53])(~[#8]~[#1])):1]1=CCCC1",
+                "Atom",
+                AtomChemicalEnvironment,
+            ],
+            [
+                "[*:1]-[#7X3:2](-[#6a$(*1ccc(-[#8-1X1])cc1):3])-[*:4]",
+                "ImproperTorsion",
+                ImproperChemicalEnvironment,
+            ],
+            ["[#6X4:1]1~[*:2]~[*$(*~[#1]):3]1", "Angle", AngleChemicalEnvironment],
+            ["[$([#7]1~[#6]-CC1)]", None, ChemicalEnvironment],
+            ["[$(c1ccccc1)]", None, ChemicalEnvironment],
+            # The next two tests are for ring-closing bonds
+            [
+                "[H][C@:4]1(C(C([C:3]([N:2]1[C:1](=O)C([H])([H])[H])([H])[H])([H])[H])([H])[H])C=O",
+                "ImproperTorsion",
+                ChemicalEnvironment,
+            ],
+            ["[P:1]=1=[P]=[P]=[P]=[P:2]=1", "Bond", BondChemicalEnvironment],
+        ],
+    )
+    @pytest.mark.parametrize("toolkit", toolkits)
+    def test_parseSMIRKS(
+        self, toolkit, smirks, expected_valence, expected_chemenv_class
+    ):
         """
         Test creating environments with SMIRKS
         """
-        env = expected_chemenv_class(smirks = smirks, toolkit_registry=toolkit)
+        env = expected_chemenv_class(smirks=smirks, toolkit_registry=toolkit)
         actual_type = env.get_type()
-        assert actual_type == expected_valence, \
-               f"SMIRKS ({smirks}) classified as {actual_type} instead of {expected_valence} using {toolkit} toolkit"
+        assert (
+            actual_type == expected_valence
+        ), f"SMIRKS ({smirks}) classified as {actual_type} instead of {expected_valence} using {toolkit} toolkit"
 
-    @pytest.mark.parametrize(('smirks', 'wrong_envs'),
-    [('[*]', [AtomChemicalEnvironment, BondChemicalEnvironment, AngleChemicalEnvironment, TorsionChemicalEnvironment, ImproperChemicalEnvironment]),
-     ("[*:1]", [BondChemicalEnvironment, AngleChemicalEnvironment, TorsionChemicalEnvironment,ImproperChemicalEnvironment]),
-     ("[*:1]~[*:2]", [AtomChemicalEnvironment, AngleChemicalEnvironment, TorsionChemicalEnvironment, ImproperChemicalEnvironment]),
-     ("[*:3]~[*:2]~[*:1]", [AtomChemicalEnvironment, BondChemicalEnvironment, TorsionChemicalEnvironment, ImproperChemicalEnvironment]),
-     ("[*:1]~[*:2]~[*:3]~[*:4]", [AtomChemicalEnvironment, BondChemicalEnvironment, AngleChemicalEnvironment, ImproperChemicalEnvironment]),
-     ("[*:1]~[*:2](~[*:3])~[*:4]", [AtomChemicalEnvironment, BondChemicalEnvironment, AngleChemicalEnvironment, TorsionChemicalEnvironment]),
-     ("[*:1]~[*:2]~[*:3]~[*:4]~[*:5]", [AtomChemicalEnvironment, BondChemicalEnvironment, AngleChemicalEnvironment,TorsionChemicalEnvironment, ImproperChemicalEnvironment])
-     ])
+    @pytest.mark.parametrize(
+        ("smirks", "wrong_envs"),
+        [
+            (
+                "[*]",
+                [
+                    AtomChemicalEnvironment,
+                    BondChemicalEnvironment,
+                    AngleChemicalEnvironment,
+                    TorsionChemicalEnvironment,
+                    ImproperChemicalEnvironment,
+                ],
+            ),
+            (
+                "[*:1]",
+                [
+                    BondChemicalEnvironment,
+                    AngleChemicalEnvironment,
+                    TorsionChemicalEnvironment,
+                    ImproperChemicalEnvironment,
+                ],
+            ),
+            (
+                "[*:1]~[*:2]",
+                [
+                    AtomChemicalEnvironment,
+                    AngleChemicalEnvironment,
+                    TorsionChemicalEnvironment,
+                    ImproperChemicalEnvironment,
+                ],
+            ),
+            (
+                "[*:3]~[*:2]~[*:1]",
+                [
+                    AtomChemicalEnvironment,
+                    BondChemicalEnvironment,
+                    TorsionChemicalEnvironment,
+                    ImproperChemicalEnvironment,
+                ],
+            ),
+            (
+                "[*:1]~[*:2]~[*:3]~[*:4]",
+                [
+                    AtomChemicalEnvironment,
+                    BondChemicalEnvironment,
+                    AngleChemicalEnvironment,
+                    ImproperChemicalEnvironment,
+                ],
+            ),
+            (
+                "[*:1]~[*:2](~[*:3])~[*:4]",
+                [
+                    AtomChemicalEnvironment,
+                    BondChemicalEnvironment,
+                    AngleChemicalEnvironment,
+                    TorsionChemicalEnvironment,
+                ],
+            ),
+            (
+                "[*:1]~[*:2]~[*:3]~[*:4]~[*:5]",
+                [
+                    AtomChemicalEnvironment,
+                    BondChemicalEnvironment,
+                    AngleChemicalEnvironment,
+                    TorsionChemicalEnvironment,
+                    ImproperChemicalEnvironment,
+                ],
+            ),
+        ],
+    )
     def test_creating_wrong_environments(self, smirks, wrong_envs):
         """
         Test exceptions for making environments with the wrong smirks
@@ -83,7 +179,7 @@ class TestChemicalEnvironments():
             with pytest.raises(SMIRKSMismatchError):
                 env = wrong_env(smirks)
 
-    @pytest.mark.parametrize('toolkit', toolkits)
+    @pytest.mark.parametrize("toolkit", toolkits)
     def test_wrong_smirks_error(self, toolkit):
         """
         Check that an imparseable SMIRKS raises errors

--- a/openforcefield/tests/test_examples.py
+++ b/openforcefield/tests/test_examples.py
@@ -1,47 +1,47 @@
 #!/usr/bin/env python
 
-#======================================================================
+# ======================================================================
 # MODULE DOCSTRING
-#======================================================================
+# ======================================================================
 
 """
 Test that the examples in the repo run without errors.
 """
 
-#======================================================================
+# ======================================================================
 # GLOBAL IMPORTS
-#======================================================================
+# ======================================================================
 
 import glob
 import os
 import re
 import subprocess
 import textwrap
-import  tempfile
+import tempfile
 
 import pytest
 
 from openforcefield.utils import RDKIT_AVAILABLE, get_data_file_path
 
 
-#======================================================================
+# ======================================================================
 # TEST UTILITIES
-#======================================================================
+# ======================================================================
 
-ROOT_DIR_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..')
+ROOT_DIR_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..")
 
 
 def run_script_file(file_path):
     """Run through the shell a python script."""
-    cmd = ['python', file_path]
-    if 'conformer_energies.py' in file_path:
-        cmd.append('--filename')
-        mol_file = get_data_file_path('molecules/ruxolitinib_conformers.sdf')
+    cmd = ["python", file_path]
+    if "conformer_energies.py" in file_path:
+        cmd.append("--filename")
+        mol_file = get_data_file_path("molecules/ruxolitinib_conformers.sdf")
         cmd.append(mol_file)
     try:
         subprocess.check_call(cmd)
     except subprocess.CalledProcessError:
-        raise Exception('Example {file_path} failed'.format(file_path=file_path))
+        raise Exception("Example {file_path} failed".format(file_path=file_path))
 
 
 def run_script_str(script_str):
@@ -51,16 +51,16 @@ def run_script_str(script_str):
 
     """
     with tempfile.TemporaryDirectory() as tmp_dir:
-        temp_file_path = os.path.join(tmp_dir, 'temp.py')
+        temp_file_path = os.path.join(tmp_dir, "temp.py")
         # Create temporary python script.
-        with open(temp_file_path, 'w') as f:
+        with open(temp_file_path, "w") as f:
             f.write(script_str)
         # Run the Python script.
         try:
             run_script_file(temp_file_path)
         except:
-            script_str = textwrap.indent(script_str, '    ')
-            raise Exception(f'The following script failed:\n{script_str}')
+            script_str = textwrap.indent(script_str, "    ")
+            raise Exception(f"The following script failed:\n{script_str}")
 
 
 def find_examples():
@@ -71,17 +71,13 @@ def find_examples():
     example_file_paths : List[str]
         List of python script to execute.
     """
-    slow_examples = {
-        os.path.join('SMIRNOFF_comparison', 'compare_set_energies.py')
-    }
-    examples_dir_path = os.path.join(ROOT_DIR_PATH, 'examples')
+    slow_examples = {os.path.join("SMIRNOFF_comparison", "compare_set_energies.py")}
+    examples_dir_path = os.path.join(ROOT_DIR_PATH, "examples")
 
-    requires_rdkit = {
-        os.path.join('conformer_energies', 'conformer_energies.py')
-    }
+    requires_rdkit = {os.path.join("conformer_energies", "conformer_energies.py")}
 
     example_file_paths = []
-    for example_file_path in glob.glob(os.path.join(examples_dir_path, '*', '*.py')):
+    for example_file_path in glob.glob(os.path.join(examples_dir_path, "*", "*.py")):
         example_file_path = os.path.relpath(example_file_path)
         example_file_paths.append(example_file_path)
         if not RDKIT_AVAILABLE:
@@ -92,7 +88,9 @@ def find_examples():
         for slow_example in slow_examples:
             if slow_example in example_file_path:
                 # This is a slow example.
-                example_file_path = pytest.param(example_file_path, marks=pytest.mark.slow)
+                example_file_path = pytest.param(
+                    example_file_path, marks=pytest.mark.slow
+                )
     return example_file_paths
 
 
@@ -104,24 +102,24 @@ def find_readme_examples():
     readme_examples : List[str]
         The list of Python scripts included in the README.md files.
     """
-    readme_file_path = os.path.join(ROOT_DIR_PATH, 'README.md')
-    with open(readme_file_path, 'r') as f:
+    readme_file_path = os.path.join(ROOT_DIR_PATH, "README.md")
+    with open(readme_file_path, "r") as f:
         readme_content = f.read()
-    return re.findall('```python(.*?)```', readme_content, flags=re.DOTALL)
+    return re.findall("```python(.*?)```", readme_content, flags=re.DOTALL)
 
 
-#======================================================================
+# ======================================================================
 # TESTS
-#======================================================================
+# ======================================================================
 
-@pytest.mark.parametrize('readme_example_str', find_readme_examples())
+
+@pytest.mark.parametrize("readme_example_str", find_readme_examples())
 def test_readme_examples(readme_example_str):
     """Test the example"""
     run_script_str(readme_example_str)
 
 
-@pytest.mark.parametrize('example_file_path', find_examples())
+@pytest.mark.parametrize("example_file_path", find_examples())
 def test_examples(example_file_path):
     """Test that the example run without errors."""
     run_script_file(example_file_path)
-

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#=============================================================================================
+# =============================================================================================
 # MODULE DOCSTRING
-#=============================================================================================
+# =============================================================================================
 
 """
 Tests for forcefield class
@@ -10,9 +10,9 @@ Tests for forcefield class
 """
 
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import copy
 import os
@@ -24,20 +24,33 @@ from numpy.testing import assert_almost_equal
 import pytest
 from tempfile import NamedTemporaryFile
 
-from openforcefield.utils.toolkits import (OpenEyeToolkitWrapper, RDKitToolkitWrapper, AmberToolsToolkitWrapper,
-    ToolkitRegistry, ChargeMethodUnavailableError)
+from openforcefield.utils.toolkits import (
+    OpenEyeToolkitWrapper,
+    RDKitToolkitWrapper,
+    AmberToolsToolkitWrapper,
+    ToolkitRegistry,
+    ChargeMethodUnavailableError,
+)
 from openforcefield.utils import get_data_file_path
 from openforcefield.topology import Molecule, Topology
-from openforcefield.typing.engines.smirnoff import (ForceField, IncompatibleParameterError, SMIRNOFFSpecError,
-    XMLParameterIOHandler, ParameterHandler, get_available_force_fields)
+from openforcefield.typing.engines.smirnoff import (
+    ForceField,
+    IncompatibleParameterError,
+    SMIRNOFFSpecError,
+    XMLParameterIOHandler,
+    ParameterHandler,
+    get_available_force_fields,
+)
 
 
-#======================================================================
+# ======================================================================
 # GLOBAL CONSTANTS
-#======================================================================
+# ======================================================================
 
 # File paths.
-TIP3P_SDF_FILE_PATH = get_data_file_path(os.path.join('systems', 'monomers', 'water.sdf'))
+TIP3P_SDF_FILE_PATH = get_data_file_path(
+    os.path.join("systems", "monomers", "water.sdf")
+)
 
 XML_FF_GENERICS = """<?xml version='1.0' encoding='ASCII'?>
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
@@ -61,7 +74,8 @@ XML_FF_GENERICS = """<?xml version='1.0' encoding='ASCII'?>
 </SMIRNOFF>
 """
 
-simple_xml_ff = str.encode('''<?xml version='1.0' encoding='ASCII'?>
+simple_xml_ff = str.encode(
+    """<?xml version='1.0' encoding='ASCII'?>
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
   <Bonds version="0.3">
     <Bond smirks="[#6X4:1]-[#6X4:2]" id="b1" k="620.0 * kilocalories_per_mole/angstrom**2" length="1.526 * angstrom"/>
@@ -87,9 +101,10 @@ simple_xml_ff = str.encode('''<?xml version='1.0' encoding='ASCII'?>
   <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
   <ToolkitAM1BCC version="0.3"/>
 </SMIRNOFF>
-''')
+"""
+)
 
-xml_ff_w_comments = '''<?xml version='1.0' encoding='ASCII'?>
+xml_ff_w_comments = """<?xml version='1.0' encoding='ASCII'?>
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
   <!-- SMIRNOFF (SMIRKS Native Open Force Field) template file -->
   <Date>2018-07-14</Date>
@@ -120,10 +135,10 @@ xml_ff_w_comments = '''<?xml version='1.0' encoding='ASCII'?>
   <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1" cutoff="9.0 * angstrom" pme_tolerance="0.00001"/>
   <ToolkitAM1BCC version="0.3"/>
 </SMIRNOFF>
-'''
+"""
 
 
-xml_ff_w_cosmetic_elements = '''<?xml version='1.0' encoding='ASCII'?>
+xml_ff_w_cosmetic_elements = """<?xml version='1.0' encoding='ASCII'?>
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
   <!-- SMIRNOFF (SMIRKS Native Open Force Field) template file -->
   <Date>MMXVIII-VII-XIV</Date>
@@ -155,23 +170,23 @@ xml_ff_w_cosmetic_elements = '''<?xml version='1.0' encoding='ASCII'?>
   <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1" cutoff="9.0 * angstrom" pme_tolerance="0.00001"/>
   <ToolkitAM1BCC version="0.3"/>
 </SMIRNOFF>
-'''
+"""
 
-xml_toolkitam1bcc_ff = '''
+xml_toolkitam1bcc_ff = """
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
   <ToolkitAM1BCC version="0.3"/>
 </SMIRNOFF>
-'''
+"""
 
-xml_ethanol_library_charges_ff = '''
+xml_ethanol_library_charges_ff = """
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
     <LibraryCharges version="0.3">
        <LibraryCharge smirks="[#1:1]-[#6:2](-[#1:3])(-[#1:4])-[#6:5](-[#1:6])(-[#1:7])-[#8:8]-[#1:9]" charge1="-0.02*elementary_charge" charge2="-0.2*elementary_charge" charge3="-0.02*elementary_charge" charge4="-0.02*elementary_charge" charge5="-0.1*elementary_charge" charge6="-0.01*elementary_charge" charge7="-0.01*elementary_charge" charge8="0.3*elementary_charge" charge9="0.08*elementary_charge" />
     </LibraryCharges>
 </SMIRNOFF>
-'''
+"""
 
-xml_ethanol_library_charges_in_parts_ff = '''
+xml_ethanol_library_charges_in_parts_ff = """
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
     <LibraryCharges version="0.3">
        <!-- Note that the oxygen is covered twice here. The correct behavior should be to take the charge from the SECOND LibraryCharge, as it should overwrite the first -->
@@ -179,9 +194,9 @@ xml_ethanol_library_charges_in_parts_ff = '''
        <LibraryCharge smirks="[#8:1]-[#1:2]" charge1="0.3*elementary_charge" charge2="0.08*elementary_charge" />
     </LibraryCharges>
 </SMIRNOFF>
-'''
+"""
 
-xml_ethanol_library_charges_by_atom_ff = '''
+xml_ethanol_library_charges_by_atom_ff = """
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
     <LibraryCharges version="0.3">
        <LibraryCharge smirks="[#1:1]-[#6]" charge1="-0.02*elementary_charge" />
@@ -192,43 +207,43 @@ xml_ethanol_library_charges_by_atom_ff = '''
        <LibraryCharge smirks="[#1:1]-[#8]" charge1="0.08*elementary_charge" />
     </LibraryCharges>
 </SMIRNOFF>
-'''
+"""
 
-xml_OH_library_charges_xml = '''
+xml_OH_library_charges_xml = """
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
     <LibraryCharges version="0.3">
        <LibraryCharge smirks="[#1:1]" charge1="1.*elementary_charge" />
        <LibraryCharge smirks="[#8:1]" charge1="-2.*elementary_charge" />
     </LibraryCharges>
 </SMIRNOFF>
-'''
+"""
 
-xml_CH_zeroes_library_charges_xml = '''
+xml_CH_zeroes_library_charges_xml = """
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
     <LibraryCharges version="0.3">
        <LibraryCharge smirks="[#1:1]" charge1="0.*elementary_charge" />
        <LibraryCharge smirks="[#6:1]" charge1="0.*elementary_charge" />
     </LibraryCharges>
 </SMIRNOFF>
-'''
+"""
 
-xml_spec_docs_ala_library_charges_xml = '''
+xml_spec_docs_ala_library_charges_xml = """
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
     <LibraryCharges version="0.3">
        <LibraryCharge name="ALA" smirks="[NX3:1]([#1:2])([#6])[#6H1:3]([#1:4])([#6:5]([#1:6])([#1:7])[#1:8])[#6:9](=[#8:10])[#7]" charge1="-0.4157*elementary_charge" charge2="0.2719*elementary_charge" charge3="0.0337*elementary_charge" charge4="0.0823*elementary_charge" charge5="-0.1825*elementary_charge" charge6="0.0603*elementary_charge" charge7="0.0603*elementary_charge" charge8="0.0603*elementary_charge" charge9="0.5973*elementary_charge" charge10="-0.5679*elementary_charge"/>
     </LibraryCharges>
 </SMIRNOFF>
-'''
+"""
 
-xml_spec_docs_tip3p_library_charges_xml = '''
+xml_spec_docs_tip3p_library_charges_xml = """
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
     <LibraryCharges version="0.3">
        <LibraryCharge name="TIP3P" smirks="[#1:1]-[#8X2H2+0:2]-[#1:3]" charge1="0.417*elementary_charge" charge2="-0.834*elementary_charge" charge3="0.417*elementary_charge"/>
     </LibraryCharges>
 </SMIRNOFF>
-'''
+"""
 
-xml_spec_docs_charge_increment_model_xml = '''
+xml_spec_docs_charge_increment_model_xml = """
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
   <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="AM1-Mulliken">
     <!-- A fractional charge can be moved along a single bond -->
@@ -239,24 +254,24 @@ xml_spec_docs_charge_increment_model_xml = '''
     <ChargeIncrement smirks="[N:1]([H:2])([H:3])" charge_increment1="0.02*elementary_charge" charge_increment2="-0.01*elementary_charge" charge_increment3="-0.01*elementary_charge"/>
   </ChargeIncrementModel>
 </SMIRNOFF>
-'''
+"""
 
-xml_charge_increment_model_formal_charges = '''
+xml_charge_increment_model_formal_charges = """
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
   <ChargeIncrementModel version="0.3" number_of_conformers="0" partial_charge_method="formal_charge"/>
 </SMIRNOFF>
-'''
+"""
 
-xml_ff_torsion_bo = '''<?xml version='1.0' encoding='ASCII'?>
+xml_ff_torsion_bo = """<?xml version='1.0' encoding='ASCII'?>
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
   <ProperTorsions version="0.3" potential="k*(1+cos(periodicity*theta-phase))">
     <Proper smirks="[*:1]~[#6X3:2]~[#6X3:3]~[*:4]" id="tbo1" periodicity1="2" phase1="0.0 * degree" k1_bondorder1="1.00*kilocalories_per_mole" k1_bondorder2="1.80*kilocalories_per_mole" idivf1="1.0"/>
     <Proper smirks="[*:1]~[#6X4:2]~[#8X2:3]~[*:4]" id="tbo2" periodicity1="2" phase1="0.0 * degree" k1_bondorder1="1.00*kilocalories_per_mole" k1_bondorder2="1.80*kilocalories_per_mole" idivf1="1.0"/>
   </ProperTorsions>
 </SMIRNOFF>
-'''
+"""
 
-xml_ff_torsion_bo_standard_supersede = '''<?xml version='1.0' encoding='ASCII'?>
+xml_ff_torsion_bo_standard_supersede = """<?xml version='1.0' encoding='ASCII'?>
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
   <ProperTorsions version="0.3" potential="k*(1+cos(periodicity*theta-phase))">
     <Proper smirks="[*:1]~[#6X3:2]~[#6X3:3]~[*:4]" id="tbo1" periodicity1="2" phase1="0.0 * degree" k1_bondorder1="1.00*kilocalories_per_mole" k1_bondorder2="1.80*kilocalories_per_mole" idivf1="1.0"/>
@@ -264,10 +279,11 @@ xml_ff_torsion_bo_standard_supersede = '''<?xml version='1.0' encoding='ASCII'?>
     <Proper smirks="[*:1]~[#6X4:2]-[#8X2:3]~[#1:4]" id="t1" periodicity1="2" phase1="0.0 * degree" k1="1.20*kilocalories_per_mole" idivf1="1.0"/>
   </ProperTorsions>
 </SMIRNOFF>
-'''
-#======================================================================
+"""
+# ======================================================================
 # TEST UTILITY FUNCTIONS
-#======================================================================
+# ======================================================================
+
 
 def round_charge(xml):
     """Round charge fields in a serialized OpenMM system to 2 decimal places"""
@@ -298,7 +314,7 @@ def create_cis_1_2_dichloroethene():
     cis_dichloroethene.add_atom(1, 0, False)
     cis_dichloroethene.add_atom(1, 0, False)
     cis_dichloroethene.add_bond(0, 1, 1, False)
-    cis_dichloroethene.add_bond(1, 2, 2, False, 'Z')
+    cis_dichloroethene.add_bond(1, 2, 2, False, "Z")
     cis_dichloroethene.add_bond(2, 3, 1, False)
     cis_dichloroethene.add_bond(1, 4, 1, False)
     cis_dichloroethene.add_bond(2, 5, 1, False)
@@ -329,7 +345,10 @@ def create_ethanol():
     ethanol.add_bond(1, 6, 1, False, fractional_bond_order=1)  # C1 - H6
     ethanol.add_bond(1, 7, 1, False, fractional_bond_order=1)  # C1 - H7
     ethanol.add_bond(2, 8, 1, False, fractional_bond_order=1)  # O2 - H8
-    charges = unit.Quantity(np.array([-0.4, -0.3, -0.2, -0.1, 0.00001, 0.1, 0.2, 0.3, 0.4]), unit.elementary_charge)
+    charges = unit.Quantity(
+        np.array([-0.4, -0.3, -0.2, -0.1, 0.00001, 0.1, 0.2, 0.3, 0.4]),
+        unit.elementary_charge,
+    )
     ethanol.partial_charges = charges
 
     return ethanol
@@ -360,9 +379,13 @@ def create_reversed_ethanol():
     ethanol.add_bond(7, 2, 1, False, fractional_bond_order=1)  # C7 - H2
     ethanol.add_bond(7, 1, 1, False, fractional_bond_order=1)  # C7 - H1
     ethanol.add_bond(6, 0, 1, False, fractional_bond_order=1)  # O6 - H0
-    charges = unit.Quantity(np.array([0.4, 0.3, 0.2, 0.1, 0.00001, -0.1, -0.2, -0.3, -0.4]), unit.elementary_charge)
+    charges = unit.Quantity(
+        np.array([0.4, 0.3, 0.2, 0.1, 0.00001, -0.1, -0.2, -0.3, -0.4]),
+        unit.elementary_charge,
+    )
     ethanol.partial_charges = charges
     return ethanol
+
 
 def create_benzene_no_aromatic():
     """
@@ -396,6 +419,7 @@ def create_benzene_no_aromatic():
     benzene.add_bond(5, 11, 1, False)  # C5 - C11
     return benzene
 
+
 def create_acetaldehyde():
     """
     Creates an openforcefield.topology.Molecule representation of acetaldehyde through the API
@@ -418,6 +442,7 @@ def create_acetaldehyde():
     acetaldehyde.partial_charges = charges
     return acetaldehyde
 
+
 def create_acetate():
     """
     Creates an openforcefield.topology.Molecule representation of
@@ -428,7 +453,7 @@ def create_acetate():
     acetate.add_atom(6, 0, False)  # C0
     acetate.add_atom(6, 0, False)  # C1
     acetate.add_atom(8, 0, False)  # O2
-    acetate.add_atom(8, -1, False) # O3
+    acetate.add_atom(8, -1, False)  # O3
     acetate.add_atom(1, 0, False)  # H4
     acetate.add_atom(1, 0, False)  # H5
     acetate.add_atom(1, 0, False)  # H6
@@ -439,6 +464,7 @@ def create_acetate():
     acetate.add_bond(0, 5, 1, False)  # C0 - H5
     acetate.add_bond(0, 6, 1, False)  # C0 - H6
     return acetate
+
 
 def create_cyclohexane():
     """
@@ -485,103 +511,191 @@ def create_cyclohexane():
     return cyclohexane
 
 
-
 nonbonded_resolution_matrix = [
-    {'vdw_method': 'cutoff', 'electrostatics_method': 'Coulomb', 'has_periodic_box': True,
-     'omm_force': None, 'exception': IncompatibleParameterError, 'exception_match': ''},
-    {'vdw_method': 'cutoff', 'electrostatics_method': 'Coulomb', 'has_periodic_box': False,
-     'omm_force': openmm.NonbondedForce.NoCutoff, 'exception': None, 'exception_match': ''},
-    {'vdw_method': 'cutoff', 'electrostatics_method': 'reaction-field', 'has_periodic_box': True,
-     'omm_force': None, 'exception': SMIRNOFFSpecError, 'exception_match': 'reaction-field'},
-    {'vdw_method': 'cutoff', 'electrostatics_method': 'reaction-field', 'has_periodic_box': False,
-     'omm_force': None, 'exception': SMIRNOFFSpecError, 'exception_match': 'reaction-field'},
-    {'vdw_method': 'cutoff', 'electrostatics_method': 'PME', 'has_periodic_box': True,
-     'omm_force': openmm.NonbondedForce.PME, 'exception': None, 'exception_match': ''},
-    {'vdw_method': 'cutoff', 'electrostatics_method': 'PME', 'has_periodic_box': False,
-     'omm_force': openmm.NonbondedForce.NoCutoff, 'exception': None, 'exception_match': ''},
-
-    {'vdw_method': 'PME', 'electrostatics_method': 'Coulomb', 'has_periodic_box': True,
-     'omm_force': None, 'exception': IncompatibleParameterError, 'exception_match': ''},
-    {'vdw_method': 'PME', 'electrostatics_method': 'Coulomb', 'has_periodic_box': False,
-     'omm_force': openmm.NonbondedForce.NoCutoff, 'exception': None, 'exception_match': ''},
-    {'vdw_method': 'PME', 'electrostatics_method': 'reaction-field', 'has_periodic_box': True,
-     'omm_force': None, 'exception': SMIRNOFFSpecError, 'exception_match': 'reaction-field'},
-    {'vdw_method': 'PME', 'electrostatics_method': 'reaction-field', 'has_periodic_box': False,
-     'omm_force': None, 'exception': SMIRNOFFSpecError, 'exception_match': 'reaction-field'},
-    {'vdw_method': 'PME', 'electrostatics_method': 'PME', 'has_periodic_box': True,
-     'omm_force': openmm.NonbondedForce.LJPME, 'exception': None, 'exception_match': ''},
-    {'vdw_method': 'PME', 'electrostatics_method': 'PME', 'has_periodic_box': False,
-     'omm_force': openmm.NonbondedForce.NoCutoff, 'exception': None, 'exception_match': ''},
-     ]
+    {
+        "vdw_method": "cutoff",
+        "electrostatics_method": "Coulomb",
+        "has_periodic_box": True,
+        "omm_force": None,
+        "exception": IncompatibleParameterError,
+        "exception_match": "",
+    },
+    {
+        "vdw_method": "cutoff",
+        "electrostatics_method": "Coulomb",
+        "has_periodic_box": False,
+        "omm_force": openmm.NonbondedForce.NoCutoff,
+        "exception": None,
+        "exception_match": "",
+    },
+    {
+        "vdw_method": "cutoff",
+        "electrostatics_method": "reaction-field",
+        "has_periodic_box": True,
+        "omm_force": None,
+        "exception": SMIRNOFFSpecError,
+        "exception_match": "reaction-field",
+    },
+    {
+        "vdw_method": "cutoff",
+        "electrostatics_method": "reaction-field",
+        "has_periodic_box": False,
+        "omm_force": None,
+        "exception": SMIRNOFFSpecError,
+        "exception_match": "reaction-field",
+    },
+    {
+        "vdw_method": "cutoff",
+        "electrostatics_method": "PME",
+        "has_periodic_box": True,
+        "omm_force": openmm.NonbondedForce.PME,
+        "exception": None,
+        "exception_match": "",
+    },
+    {
+        "vdw_method": "cutoff",
+        "electrostatics_method": "PME",
+        "has_periodic_box": False,
+        "omm_force": openmm.NonbondedForce.NoCutoff,
+        "exception": None,
+        "exception_match": "",
+    },
+    {
+        "vdw_method": "PME",
+        "electrostatics_method": "Coulomb",
+        "has_periodic_box": True,
+        "omm_force": None,
+        "exception": IncompatibleParameterError,
+        "exception_match": "",
+    },
+    {
+        "vdw_method": "PME",
+        "electrostatics_method": "Coulomb",
+        "has_periodic_box": False,
+        "omm_force": openmm.NonbondedForce.NoCutoff,
+        "exception": None,
+        "exception_match": "",
+    },
+    {
+        "vdw_method": "PME",
+        "electrostatics_method": "reaction-field",
+        "has_periodic_box": True,
+        "omm_force": None,
+        "exception": SMIRNOFFSpecError,
+        "exception_match": "reaction-field",
+    },
+    {
+        "vdw_method": "PME",
+        "electrostatics_method": "reaction-field",
+        "has_periodic_box": False,
+        "omm_force": None,
+        "exception": SMIRNOFFSpecError,
+        "exception_match": "reaction-field",
+    },
+    {
+        "vdw_method": "PME",
+        "electrostatics_method": "PME",
+        "has_periodic_box": True,
+        "omm_force": openmm.NonbondedForce.LJPME,
+        "exception": None,
+        "exception_match": "",
+    },
+    {
+        "vdw_method": "PME",
+        "electrostatics_method": "PME",
+        "has_periodic_box": False,
+        "omm_force": openmm.NonbondedForce.NoCutoff,
+        "exception": None,
+        "exception_match": "",
+    },
+]
 
 partial_charge_method_resolution_matrix = [
-    {'toolkit': AmberToolsToolkitWrapper,
-     'partial_charge_method': 'AM1-Mulliken',
-     'exception': None,
-     'exception_match': ''
-     },
-    {'toolkit': AmberToolsToolkitWrapper,
-     'partial_charge_method': 'Gasteiger',
-     'exception': None,
-     'exception_match': ''
-     },
-    {'toolkit': AmberToolsToolkitWrapper,
-     'partial_charge_method': 'Madeup-ChargeMethod',
-     'exception': ChargeMethodUnavailableError,
-     'exception_match': ''
-     },
-    {'toolkit': OpenEyeToolkitWrapper,
-     'partial_charge_method': 'AM1-Mulliken',
-     'exception': None,
-     'exception_match': ''
-     },
-    {'toolkit': OpenEyeToolkitWrapper,
-     'partial_charge_method': 'Gasteiger',
-     'exception': None,
-     'exception_match': ''
-     },
-    {'toolkit': OpenEyeToolkitWrapper,
-     'partial_charge_method': 'MMFF94',
-     'exception': None,
-     'exception_match': ''
-     },
-    {'toolkit': OpenEyeToolkitWrapper,
-     'partial_charge_method': 'am1bcc',
-     'exception': None,
-     'exception_match': ''
-     },
-    {'toolkit': OpenEyeToolkitWrapper,
-     'partial_charge_method': 'am1bccnosymspt',
-     'exception': None,
-     'exception_match': ''
-     },
-    {'toolkit': OpenEyeToolkitWrapper,
-     'partial_charge_method': 'am1bccelf10',
-     'exception': None,
-     'exception_match': ''
-     },
-    {'toolkit': OpenEyeToolkitWrapper,
-     'partial_charge_method': 'Madeup-ChargeMethod',
-     'exception': ChargeMethodUnavailableError,
-     'exception_match': ''
-     }
-     ]
+    {
+        "toolkit": AmberToolsToolkitWrapper,
+        "partial_charge_method": "AM1-Mulliken",
+        "exception": None,
+        "exception_match": "",
+    },
+    {
+        "toolkit": AmberToolsToolkitWrapper,
+        "partial_charge_method": "Gasteiger",
+        "exception": None,
+        "exception_match": "",
+    },
+    {
+        "toolkit": AmberToolsToolkitWrapper,
+        "partial_charge_method": "Madeup-ChargeMethod",
+        "exception": ChargeMethodUnavailableError,
+        "exception_match": "",
+    },
+    {
+        "toolkit": OpenEyeToolkitWrapper,
+        "partial_charge_method": "AM1-Mulliken",
+        "exception": None,
+        "exception_match": "",
+    },
+    {
+        "toolkit": OpenEyeToolkitWrapper,
+        "partial_charge_method": "Gasteiger",
+        "exception": None,
+        "exception_match": "",
+    },
+    {
+        "toolkit": OpenEyeToolkitWrapper,
+        "partial_charge_method": "MMFF94",
+        "exception": None,
+        "exception_match": "",
+    },
+    {
+        "toolkit": OpenEyeToolkitWrapper,
+        "partial_charge_method": "am1bcc",
+        "exception": None,
+        "exception_match": "",
+    },
+    {
+        "toolkit": OpenEyeToolkitWrapper,
+        "partial_charge_method": "am1bccnosymspt",
+        "exception": None,
+        "exception_match": "",
+    },
+    {
+        "toolkit": OpenEyeToolkitWrapper,
+        "partial_charge_method": "am1bccelf10",
+        "exception": None,
+        "exception_match": "",
+    },
+    {
+        "toolkit": OpenEyeToolkitWrapper,
+        "partial_charge_method": "Madeup-ChargeMethod",
+        "exception": ChargeMethodUnavailableError,
+        "exception_match": "",
+    },
+]
 
 
-#=============================================================================================
+# =============================================================================================
 # TESTS
-#=============================================================================================
+# =============================================================================================
 
 
 toolkit_registries = []
 if OpenEyeToolkitWrapper.is_available():
-    toolkit_registries.append((ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper]), "OE"))
+    toolkit_registries.append(
+        (ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper]), "OE")
+    )
 if RDKitToolkitWrapper.is_available() and AmberToolsToolkitWrapper.is_available():
-    toolkit_registries.append((ToolkitRegistry(toolkit_precedence=[RDKitToolkitWrapper, AmberToolsToolkitWrapper]),
-                               'RDKit+AmberTools'))
+    toolkit_registries.append(
+        (
+            ToolkitRegistry(
+                toolkit_precedence=[RDKitToolkitWrapper, AmberToolsToolkitWrapper]
+            ),
+            "RDKit+AmberTools",
+        )
+    )
 
 
-class TestForceField():
+class TestForceField:
     """Test the ForceField class"""
 
     def test_get_available_force_fields_loadable(self, full_path, force_field_file):
@@ -590,19 +704,19 @@ class TestForceField():
 
         # Incomplete list of some expected force fields
         expected_force_fields = [
-            'smirnoff99Frosst-1.0.0.offxml',
-            'smirnoff99Frosst-1.1.0.offxml',
-            'openff-1.0.0.offxml',
-            'openff_unconstrainted-1.0.0.offxml',
-            'openff-1.1.0.offxml',
-            'openff-1.2.0.offxml',
+            "smirnoff99Frosst-1.0.0.offxml",
+            "smirnoff99Frosst-1.1.0.offxml",
+            "openff-1.0.0.offxml",
+            "openff_unconstrainted-1.0.0.offxml",
+            "openff-1.1.0.offxml",
+            "openff-1.2.0.offxml",
         ]
 
         for ff in expected_force_fields:
             assert ff in available_force_fields
 
-    @pytest.mark.parametrize('full_path', [(True, False)])
-    @pytest.mark.parametrize('force_field_file', [*get_available_force_fields()])
+    @pytest.mark.parametrize("full_path", [(True, False)])
+    @pytest.mark.parametrize("force_field_file", [*get_available_force_fields()])
     def test_get_available_force_fields_loadable(self, full_path, force_field_file):
         """Ensure get_available_force_fields returns load-able files"""
         ForceField(force_field_file)
@@ -612,107 +726,109 @@ class TestForceField():
         forcefield = ForceField()
 
         # Should find BondHandler and AngleHandler, since they're default classes
-        forcefield.get_parameter_handler('Bonds')
-        forcefield.get_parameter_handler('Angles')
+        forcefield.get_parameter_handler("Bonds")
+        forcefield.get_parameter_handler("Angles")
 
         # Shouldn't find InvalidKey handler, since it doesn't exist
         with pytest.raises(KeyError) as excinfo:
-            forcefield.get_parameter_handler('InvalidKey')
+            forcefield.get_parameter_handler("InvalidKey")
 
     def test_create_forcefield_custom_handler_classes(self):
         """Test constructor given specific classes to register"""
         from openforcefield.typing.engines.smirnoff import BondHandler
+
         forcefield = ForceField(parameter_handler_classes=[BondHandler])
 
         # Should find BondHandler, since we registered it
-        forcefield.get_parameter_handler('Bonds')
+        forcefield.get_parameter_handler("Bonds")
 
         # Shouldn't find AngleHandler, since we didn't allow that to be registered
         with pytest.raises(KeyError) as excinfo:
-            forcefield.get_parameter_handler('Angles')
+            forcefield.get_parameter_handler("Angles")
 
     def test_create_forcefield_from_file(self):
         """Test basic file loading in constructor"""
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
-        assert len(forcefield._parameter_handlers['Bonds']._parameters) == 87
-        assert len(forcefield._parameter_handlers['Angles']._parameters) == 38
-        assert len(forcefield._parameter_handlers['ProperTorsions']._parameters) == 158
-        assert len(forcefield._parameter_handlers['ImproperTorsions']._parameters) == 4
-        assert len(forcefield._parameter_handlers['vdW']._parameters) == 35
-        assert forcefield.aromaticity_model == 'OEAroModel_MDL'
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
+        assert len(forcefield._parameter_handlers["Bonds"]._parameters) == 87
+        assert len(forcefield._parameter_handlers["Angles"]._parameters) == 38
+        assert len(forcefield._parameter_handlers["ProperTorsions"]._parameters) == 158
+        assert len(forcefield._parameter_handlers["ImproperTorsions"]._parameters) == 4
+        assert len(forcefield._parameter_handlers["vdW"]._parameters) == 35
+        assert forcefield.aromaticity_model == "OEAroModel_MDL"
 
     def test_load_bad_string(self):
         with pytest.raises(IOError) as exception_info:
-            ForceField('1234')
-        assert 'Source 1234 could not be read.' in str(exception_info.value)
-        assert 'syntax error' in str(exception_info.value)
+            ForceField("1234")
+        assert "Source 1234 could not be read." in str(exception_info.value)
+        assert "syntax error" in str(exception_info.value)
 
-    @pytest.mark.skip(reason='Needs to be updated for 0.2.0 syntax')
+    @pytest.mark.skip(reason="Needs to be updated for 0.2.0 syntax")
     def test_create_forcefield_from_file_list(self):
         # These offxml files are located in package data path, which is automatically installed and searched
         file_paths = [smirnoff99Frosst_offxml_file_path, tip3p_offxml_file_path]
         # Create a forcefield from multiple offxml files
         forcefield = ForceField(file_paths)
 
-    @pytest.mark.skip(reason='Needs to be updated for 0.2.0 syntax')
+    @pytest.mark.skip(reason="Needs to be updated for 0.2.0 syntax")
     def test_create_forcefield_from_file_path_iterator(self):
         # These offxml files are located in package data path, which is automatically installed and searched
         file_paths = [smirnoff99Frosst_offxml_file_path, tip3p_offxml_file_path]
         # A generator should work as well
         forcefield = ForceField(iter(file_paths))
 
-    @pytest.mark.skip(reason='Needs to be updated for 0.2.0 syntax')
+    @pytest.mark.skip(reason="Needs to be updated for 0.2.0 syntax")
     def test_create_gbsa():
         """Test reading of ffxml files with GBSA support.
         """
-        forcefield = ForceField('test_forcefields/Frosst_AlkEthOH_GBSA.offxml')
+        forcefield = ForceField("test_forcefields/Frosst_AlkEthOH_GBSA.offxml")
 
-    @pytest.mark.skip(reason='Needs to be updated for 0.2.0 syntax')
+    @pytest.mark.skip(reason="Needs to be updated for 0.2.0 syntax")
     def test_create_forcefield_from_url(self):
         urls = [
-            'https://raw.githubusercontent.com/openforcefield/openforcefield/master/openforcefield/data/test_forcefields/smirnoff99Frosst.offxml',
-            'https://raw.githubusercontent.com/openforcefield/openforcefield/master/openforcefield/data/test_forcefields/tip3p.offxml'
+            "https://raw.githubusercontent.com/openforcefield/openforcefield/master/openforcefield/data/test_forcefields/smirnoff99Frosst.offxml",
+            "https://raw.githubusercontent.com/openforcefield/openforcefield/master/openforcefield/data/test_forcefields/tip3p.offxml",
         ]
         # Test creation with smirnoff99frosst URL
         forcefield = ForceField(urls[0])
 
-    @pytest.mark.skip(reason='Needs to be updated for 0.2.0 syntax')
+    @pytest.mark.skip(reason="Needs to be updated for 0.2.0 syntax")
     def test_create_forcefield_from_url_list(self):
         urls = [
-            'https://raw.githubusercontent.com/openforcefield/openforcefield/master/openforcefield/data/test_forcefields/smirnoff99Frosst.offxml',
-            'https://raw.githubusercontent.com/openforcefield/openforcefield/master/openforcefield/data/test_forcefields/tip3p.offxml'
+            "https://raw.githubusercontent.com/openforcefield/openforcefield/master/openforcefield/data/test_forcefields/smirnoff99Frosst.offxml",
+            "https://raw.githubusercontent.com/openforcefield/openforcefield/master/openforcefield/data/test_forcefields/tip3p.offxml",
         ]
         # Test creation with multiple URLs
         forcefield = ForceField(urls)
 
-    @pytest.mark.skip(reason='Needs to be updated for 0.2.0 syntax')
+    @pytest.mark.skip(reason="Needs to be updated for 0.2.0 syntax")
     def test_create_forcefield_from_url_iterator(self):
         urls = [
-            'https://raw.githubusercontent.com/openforcefield/openforcefield/master/openforcefield/data/test_forcefields/smirnoff99Frosst.offxml',
-            'https://raw.githubusercontent.com/openforcefield/openforcefield/master/openforcefield/data/test_forcefields/tip3p.offxml'
+            "https://raw.githubusercontent.com/openforcefield/openforcefield/master/openforcefield/data/test_forcefields/smirnoff99Frosst.offxml",
+            "https://raw.githubusercontent.com/openforcefield/openforcefield/master/openforcefield/data/test_forcefields/tip3p.offxml",
         ]
         # A generator should work as well
         forcefield = ForceField(iter(urls))
 
-
     def test_create_forcefield_from_xml_string(self):
         forcefield = ForceField(simple_xml_ff)
-        assert len(forcefield._parameter_handlers['Bonds']._parameters) == 2
-        assert len(forcefield._parameter_handlers['Angles']._parameters) == 2
-        assert len(forcefield._parameter_handlers['ProperTorsions']._parameters) == 3
-        assert len(forcefield._parameter_handlers['ImproperTorsions']._parameters) == 2
-        assert len(forcefield._parameter_handlers['vdW']._parameters) == 2
+        assert len(forcefield._parameter_handlers["Bonds"]._parameters) == 2
+        assert len(forcefield._parameter_handlers["Angles"]._parameters) == 2
+        assert len(forcefield._parameter_handlers["ProperTorsions"]._parameters) == 3
+        assert len(forcefield._parameter_handlers["ImproperTorsions"]._parameters) == 2
+        assert len(forcefield._parameter_handlers["vdW"]._parameters) == 2
 
-    @pytest.mark.skip(reason='Needs to be updated for 0.2.0 syntax')
+    @pytest.mark.skip(reason="Needs to be updated for 0.2.0 syntax")
     def test_deep_copy(self):
         forcefield = ForceField(smirnoff99Frosst_offxml_file_path)
         # Deep copy
         forcefield2 = copy.deepcopy(cls.forcefield)
-        assert_forcefields_equal(cls.forcefield, forcefield2,
-                                 "ForceField deep copy does not match original ForceField")
+        assert_forcefields_equal(
+            cls.forcefield,
+            forcefield2,
+            "ForceField deep copy does not match original ForceField",
+        )
 
-
-    @pytest.mark.skip(reason='Needs to be updated for 0.2.0 syntax')
+    @pytest.mark.skip(reason="Needs to be updated for 0.2.0 syntax")
     # TODO: This should check the output of forcefield.to_dict
     def test_serialize(self):
 
@@ -720,14 +836,18 @@ class TestForceField():
         # Serialize/deserialize
         serialized_forcefield = cls.forcefield.__getstate__()
         forcefield2 = ForceField.__setstate__(serialized_forcefield)
-        assert_forcefields_equal(cls.forcefield, forcefield2,
-                                 "Deserialized serialized ForceField does not match original ForceField")
+        assert_forcefields_equal(
+            cls.forcefield,
+            forcefield2,
+            "Deserialized serialized ForceField does not match original ForceField",
+        )
 
     def test_pickle(self):
         """
         Test pickling and unpickling a forcefield
         """
         import pickle
+
         forcefield_1 = ForceField(simple_xml_ff)
         pickled = pickle.dumps(forcefield_1)
         forcefield_2 = pickle.loads(pickled)
@@ -738,130 +858,175 @@ class TestForceField():
         Test pickling and unpickling a forcefield with cosmetic attributes
         """
         import pickle
-        forcefield_1 = ForceField(xml_ff_w_cosmetic_elements, allow_cosmetic_attributes=True)
+
+        forcefield_1 = ForceField(
+            xml_ff_w_cosmetic_elements, allow_cosmetic_attributes=True
+        )
         pickled = pickle.dumps(forcefield_1)
         forcefield_2 = pickle.loads(pickled)
         assert forcefield_1.to_string() == forcefield_2.to_string()
         # Ensure that the cosmetic attributes stuck around
-        assert 'blah=blah2' in forcefield_2.to_string()
+        assert "blah=blah2" in forcefield_2.to_string()
 
     def test_xml_string_roundtrip(self):
         """
         Test writing a ForceField to an XML string
         """
         forcefield_1 = ForceField(simple_xml_ff)
-        string_1 = forcefield_1.to_string('XML')
+        string_1 = forcefield_1.to_string("XML")
         forcefield_2 = ForceField(string_1)
-        string_2 = forcefield_2.to_string('XML')
+        string_2 = forcefield_2.to_string("XML")
         assert string_1 == string_2
-
 
     def test_xml_string_roundtrip_keep_cosmetic(self):
         """
         Test roundtripping a forcefield to an XML string with and without retaining cosmetic elements
         """
         # Ensure an exception is raised if we try to read the XML string with cosmetic attributes
-        with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg [(]parameters: k, length[)]  passed") as excinfo:
+        with pytest.raises(
+            SMIRNOFFSpecError,
+            match="Unexpected kwarg [(]parameters: k, length[)]  passed",
+        ) as excinfo:
             forcefield = ForceField(xml_ff_w_cosmetic_elements)
 
         # Create a forcefield from XML successfully, by explicitly permitting cosmetic attributes
-        forcefield_1 = ForceField(xml_ff_w_cosmetic_elements, allow_cosmetic_attributes=True)
+        forcefield_1 = ForceField(
+            xml_ff_w_cosmetic_elements, allow_cosmetic_attributes=True
+        )
 
         # Convert the forcefield back to XML
-        string_1 = forcefield_1.to_string('XML', discard_cosmetic_attributes=False)
+        string_1 = forcefield_1.to_string("XML", discard_cosmetic_attributes=False)
 
         # Ensure that the new XML string has cosmetic attributes in it
         assert 'cosmetic_element="why not?"' in string_1
         assert 'parameterize_eval="blah=blah2"' in string_1
-        with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg [(]parameters: k, length[)]  passed") as excinfo:
+        with pytest.raises(
+            SMIRNOFFSpecError,
+            match="Unexpected kwarg [(]parameters: k, length[)]  passed",
+        ) as excinfo:
             forcefield = ForceField(string_1, allow_cosmetic_attributes=False)
 
         # Complete the forcefield_1 --> string --> forcefield_2 roundtrip
         forcefield_2 = ForceField(string_1, allow_cosmetic_attributes=True)
 
         # Ensure that the forcefield remains the same after the roundtrip
-        string_2 = forcefield_2.to_string('XML', discard_cosmetic_attributes=False)
+        string_2 = forcefield_2.to_string("XML", discard_cosmetic_attributes=False)
         assert string_1 == string_2
 
         # Discard the cosmetic attributes and ensure that the string is different
-        string_3 = forcefield_2.to_string('XML', discard_cosmetic_attributes=True)
+        string_3 = forcefield_2.to_string("XML", discard_cosmetic_attributes=True)
         assert string_1 != string_3
         # Ensure that the new XML string does NOT have cosmetic attributes in it
         assert 'cosmetic_element="why not?"' not in string_3
         assert 'parameterize_eval="blah=blah2"' not in string_3
 
-
     def test_read_0_1_smirnoff(self):
         """Test reading an 0.1 spec OFFXML file"""
-        ff = ForceField('test_forcefields/smirnoff99Frosst_reference_0_1_spec.offxml')
-
+        ff = ForceField("test_forcefields/smirnoff99Frosst_reference_0_1_spec.offxml")
 
     def test_read_0_1_smirff(self):
         """Test reading an 0.1 spec OFFXML file, enclosed by the legacy "SMIRFF" tag"""
-        ff = ForceField('test_forcefields/smirff99Frosst_reference_0_1_spec.offxml')
-
+        ff = ForceField("test_forcefields/smirff99Frosst_reference_0_1_spec.offxml")
 
     def test_read_0_2_smirnoff(self):
         """Test reading an 0.2 spec OFFXML file"""
-        ff = ForceField('test_forcefields/smirnoff99Frosst_reference_0_2_spec.offxml')
+        ff = ForceField("test_forcefields/smirnoff99Frosst_reference_0_2_spec.offxml")
 
-
-    @pytest.mark.parametrize('file_path_extension', ['xml', 'XML', 'offxml', 'OFFXML'])
-    @pytest.mark.parametrize('specified_format', [None, 'xml', 'XML', '.xml', '.XML',
-                                                  'offxml', 'OFFXML', '.offxml', '.OFFXML',
-                                                  XMLParameterIOHandler()])
+    @pytest.mark.parametrize("file_path_extension", ["xml", "XML", "offxml", "OFFXML"])
+    @pytest.mark.parametrize(
+        "specified_format",
+        [
+            None,
+            "xml",
+            "XML",
+            ".xml",
+            ".XML",
+            "offxml",
+            "OFFXML",
+            ".offxml",
+            ".OFFXML",
+            XMLParameterIOHandler(),
+        ],
+    )
     def test_xml_file_roundtrip(self, file_path_extension, specified_format):
         """
         Test roundtripping a ForceField to and from an XML file
         """
         # These files will be deleted once garbage collection runs (end of this function)
-        iofile1 = NamedTemporaryFile(suffix='.' + file_path_extension)
-        iofile2 = NamedTemporaryFile(suffix='.' + file_path_extension)
+        iofile1 = NamedTemporaryFile(suffix="." + file_path_extension)
+        iofile2 = NamedTemporaryFile(suffix="." + file_path_extension)
         forcefield_1 = ForceField(simple_xml_ff)
         forcefield_1.to_file(iofile1.name, io_format=specified_format)
         forcefield_2 = ForceField(iofile1.name)
         forcefield_2.to_file(iofile2.name, io_format=specified_format)
         assert open(iofile1.name).read() == open(iofile2.name).read()
 
-
-    @pytest.mark.parametrize('file_path_extension', ['xml', 'XML', 'offxml', 'OFFXML'])
-    @pytest.mark.parametrize('specified_format', [None, 'xml', 'XML', '.xml', '.XML',
-                                                  'offxml', 'OFFXML', '.offxml', '.OFFXML',
-                                                  XMLParameterIOHandler()])
-    def test_xml_file_roundtrip_keep_cosmetic(self, file_path_extension, specified_format):
+    @pytest.mark.parametrize("file_path_extension", ["xml", "XML", "offxml", "OFFXML"])
+    @pytest.mark.parametrize(
+        "specified_format",
+        [
+            None,
+            "xml",
+            "XML",
+            ".xml",
+            ".XML",
+            "offxml",
+            "OFFXML",
+            ".offxml",
+            ".OFFXML",
+            XMLParameterIOHandler(),
+        ],
+    )
+    def test_xml_file_roundtrip_keep_cosmetic(
+        self, file_path_extension, specified_format
+    ):
         """
         Test roundtripping a forcefield to an XML file with and without retaining cosmetic elements
         """
         # These files will be deleted once garbage collection runs (end of this function)
-        iofile1 = NamedTemporaryFile(suffix='.' + file_path_extension)
-        iofile2 = NamedTemporaryFile(suffix='.' + file_path_extension)
-        iofile3 = NamedTemporaryFile(suffix='.' + file_path_extension)
+        iofile1 = NamedTemporaryFile(suffix="." + file_path_extension)
+        iofile2 = NamedTemporaryFile(suffix="." + file_path_extension)
+        iofile3 = NamedTemporaryFile(suffix="." + file_path_extension)
 
         # Ensure an exception is raised if we try to read the XML string with cosmetic attributes
-        with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg [(]parameters: k, length[)]  passed") as excinfo:
+        with pytest.raises(
+            SMIRNOFFSpecError,
+            match="Unexpected kwarg [(]parameters: k, length[)]  passed",
+        ) as excinfo:
             forcefield = ForceField(xml_ff_w_cosmetic_elements)
 
         # Create a forcefield from XML successfully
-        forcefield_1 = ForceField(xml_ff_w_cosmetic_elements, allow_cosmetic_attributes=True)
+        forcefield_1 = ForceField(
+            xml_ff_w_cosmetic_elements, allow_cosmetic_attributes=True
+        )
 
         # Convert the forcefield back to XML, keeping cosmetic attributes
-        forcefield_1.to_file(iofile1.name, discard_cosmetic_attributes=False, io_format=specified_format)
+        forcefield_1.to_file(
+            iofile1.name, discard_cosmetic_attributes=False, io_format=specified_format
+        )
 
         # Ensure that the new XML string has cosmetic attributes in it
         assert 'cosmetic_element="why not?"' in open(iofile1.name).read()
         assert 'parameterize_eval="blah=blah2"' in open(iofile1.name).read()
-        with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg [(]parameters: k, length[)]  passed") as excinfo:
+        with pytest.raises(
+            SMIRNOFFSpecError,
+            match="Unexpected kwarg [(]parameters: k, length[)]  passed",
+        ) as excinfo:
             forcefield = ForceField(iofile1.name, allow_cosmetic_attributes=False)
 
         # Complete the forcefield_1 --> file --> forcefield_2 roundtrip
         forcefield_2 = ForceField(iofile1.name, allow_cosmetic_attributes=True)
 
         # Ensure that the forcefield remains the same after the roundtrip
-        forcefield_2.to_file(iofile2.name, discard_cosmetic_attributes=False, io_format=specified_format)
+        forcefield_2.to_file(
+            iofile2.name, discard_cosmetic_attributes=False, io_format=specified_format
+        )
         assert open(iofile1.name).read() == open(iofile2.name).read()
 
         # Discard the cosmetic attributes and ensure that the string is different
-        forcefield_2.to_file(iofile3.name, discard_cosmetic_attributes=True, io_format=specified_format)
+        forcefield_2.to_file(
+            iofile3.name, discard_cosmetic_attributes=True, io_format=specified_format
+        )
         assert open(iofile1.name).read() != open(iofile3.name).read()
 
         # Ensure that the new XML string does NOT have cosmetic attributes in it
@@ -871,86 +1036,108 @@ class TestForceField():
     def test_load_section_without_section_version(self):
         """Ensure that a SMIRNOFFSpecError is raised if we try to load a SMIRNOFF section without a version.
         Section versions are a requirement added in the 0.3 spec."""
-        with pytest.raises(SMIRNOFFSpecError, match="Missing version while trying to construct "
-                                                    "<class 'openforcefield.typing.engines."
-                                                    "smirnoff.parameters.ToolkitAM1BCCHandler'>.") as excinfo:
-            ff = ForceField('<?xml version="1.0" encoding="ASCII"?>'
-                            '<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">'
-                            '  <ToolkitAM1BCC/>'
-                            '</SMIRNOFF>')
-
+        with pytest.raises(
+            SMIRNOFFSpecError,
+            match="Missing version while trying to construct "
+            "<class 'openforcefield.typing.engines."
+            "smirnoff.parameters.ToolkitAM1BCCHandler'>.",
+        ) as excinfo:
+            ff = ForceField(
+                '<?xml version="1.0" encoding="ASCII"?>'
+                '<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">'
+                "  <ToolkitAM1BCC/>"
+                "</SMIRNOFF>"
+            )
 
     def test_load_two_sources(self):
         """Test loading data from two SMIRNOFF data sources"""
-        ff = ForceField(simple_xml_ff, xml_ff_w_cosmetic_elements, allow_cosmetic_attributes=True)
-        assert len(ff.get_parameter_handler('Bonds').parameters) == 4
-
+        ff = ForceField(
+            simple_xml_ff, xml_ff_w_cosmetic_elements, allow_cosmetic_attributes=True
+        )
+        assert len(ff.get_parameter_handler("Bonds").parameters) == 4
 
     def test_load_two_sources_authors_dates(self):
         """Test that authors and dates are handled properly"""
-        ff = ForceField(xml_ff_w_cosmetic_elements, xml_ff_w_comments, allow_cosmetic_attributes=True)
-        xml_str = ff.to_string('XML')
-        assert '<Author>Alice and Bob AND C. I. Bayly, OpenEye/UC Irvine; C. C. Bannan, ' \
-               'UC Irvine; D. L. Mobley, UC Irvine</Author>' in xml_str
-        assert '<Date>MMXVIII-VII-XIV AND 2018-07-14</Date>' in xml_str
+        ff = ForceField(
+            xml_ff_w_cosmetic_elements,
+            xml_ff_w_comments,
+            allow_cosmetic_attributes=True,
+        )
+        xml_str = ff.to_string("XML")
+        assert (
+            "<Author>Alice and Bob AND C. I. Bayly, OpenEye/UC Irvine; C. C. Bannan, "
+            "UC Irvine; D. L. Mobley, UC Irvine</Author>" in xml_str
+        )
+        assert "<Date>MMXVIII-VII-XIV AND 2018-07-14</Date>" in xml_str
 
         # Test property getters
-        assert 'Alice and Bob AND C. I. Bayly, OpenEye/UC Irvine; C. C. Bannan, ' \
-               'UC Irvine; D. L. Mobley, UC Irvine' == ff.author
-        assert 'MMXVIII-VII-XIV AND 2018-07-14' == ff.date
+        assert (
+            "Alice and Bob AND C. I. Bayly, OpenEye/UC Irvine; C. C. Bannan, "
+            "UC Irvine; D. L. Mobley, UC Irvine" == ff.author
+        )
+        assert "MMXVIII-VII-XIV AND 2018-07-14" == ff.date
 
         # Test property setters
-        ff.author = 'Me'
-        ff.date = 'yesteryear'
-        xml_str = ff.to_string('XML')
-        assert '<Author>Me</Author>' in xml_str
-        assert '<Date>yesteryear</Date>' in xml_str
+        ff.author = "Me"
+        ff.date = "yesteryear"
+        xml_str = ff.to_string("XML")
+        assert "<Author>Me</Author>" in xml_str
+        assert "<Date>yesteryear</Date>" in xml_str
 
         # Unset both author and date and ensure they don't get written out.
         ff.author = None
         ff.date = None
-        xml_str = ff.to_string('XML')
-        assert '<Author>' not in xml_str
-        assert '<Date>' not in xml_str
-
+        xml_str = ff.to_string("XML")
+        assert "<Author>" not in xml_str
+        assert "<Date>" not in xml_str
 
     def test_load_two_sources_incompatible_tags(self):
         """Test loading data from two SMIRNOFF data sources which have incompatible physics"""
         # Make an XML forcefield with a modifiedvdW 1-4 scaling factor
         nonstandard_xml_ff = xml_ff_w_comments.replace('scale14="0.5"', 'scale14="1.0"')
-        with pytest.raises(IncompatibleParameterError, match="handler value: 0.5, incompatible value: 1.0") as excinfo:
+        with pytest.raises(
+            IncompatibleParameterError,
+            match="handler value: 0.5, incompatible value: 1.0",
+        ) as excinfo:
             ff = ForceField(simple_xml_ff, nonstandard_xml_ff)
-
 
     def test_gbsahandler_sa_model_none(self):
         """
         Ensure that string values of "None" are correctly interpreted in the GBSAHandler's sa_model field
         """
-        gbsa_ff_xml = '''<?xml version='1.0' encoding='ASCII'?>
+        gbsa_ff_xml = """<?xml version='1.0' encoding='ASCII'?>
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
     <GBSA version="0.3" gb_model="HCT" solvent_dielectric="78.5" solute_dielectric="1" sa_model="None" surface_area_penalty="5.4*calories/mole/angstroms**2" solvent_radius="1.4*angstroms">
           <Atom smirks="[*:1]" radius="0.15*nanometer" scale="0.8"/>
     </GBSA>
 </SMIRNOFF>
-'''
+"""
         from openforcefield.typing.engines.smirnoff import ForceField
+
         ff = ForceField(gbsa_ff_xml)
 
-
-    @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
+    @pytest.mark.parametrize(
+        "toolkit_registry,registry_description", toolkit_registries
+    )
     def test_parameterize_ethanol(self, toolkit_registry, registry_description):
         from simtk.openmm import app
 
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
-        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
+        pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
         molecules = [create_ethanol()]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 
-        omm_system = forcefield.create_openmm_system(topology, toolkit_registry=toolkit_registry)
+        omm_system = forcefield.create_openmm_system(
+            topology, toolkit_registry=toolkit_registry
+        )
 
     @pytest.fixture()
     def create_circular_handler_dependencies(self):
-        from openforcefield.typing.engines.smirnoff.parameters import BondHandler, AngleHandler, ConstraintHandler
+        from openforcefield.typing.engines.smirnoff.parameters import (
+            BondHandler,
+            AngleHandler,
+            ConstraintHandler,
+        )
 
         # Modify the BondHandler and AngleHandler classes to depend on the other one running first during
         # system parameterization. Unfortunately, I can't figure out how to do this just to these _instances_
@@ -967,50 +1154,73 @@ class TestForceField():
         BondHandler._DEPENDENCIES = orig_bh_depends
         AngleHandler._DEPENDENCIES = orig_ah_depends
 
-    @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
-    def test_parameterize_ethanol_handler_dependency_loop(self, create_circular_handler_dependencies, toolkit_registry, registry_description):
+    @pytest.mark.parametrize(
+        "toolkit_registry,registry_description", toolkit_registries
+    )
+    def test_parameterize_ethanol_handler_dependency_loop(
+        self,
+        create_circular_handler_dependencies,
+        toolkit_registry,
+        registry_description,
+    ):
         """Test parameterizing ethanol, but failing because custom handler classes can not resolve
          which order to run in"""
         from simtk.openmm import app
+
         # from openforcefield.typing.engines.smirnoff.parameters import BondHandler, AngleHandler, ConstraintHandler
 
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
 
-        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
         molecules = [create_ethanol()]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
-        with pytest.raises(RuntimeError, match="Unable to resolve order in which to run ParameterHandlers. "
-                                               "Dependencies do not form a directed acyclic graph") as excinfo:
-            omm_system = forcefield.create_openmm_system(topology, toolkit_registry=toolkit_registry)
-
+        with pytest.raises(
+            RuntimeError,
+            match="Unable to resolve order in which to run ParameterHandlers. "
+            "Dependencies do not form a directed acyclic graph",
+        ) as excinfo:
+            omm_system = forcefield.create_openmm_system(
+                topology, toolkit_registry=toolkit_registry
+            )
 
     def test_parameterize_ethanol_missing_torsion(self):
         from simtk.openmm import app
-        from openforcefield.typing.engines.smirnoff.parameters import UnassignedProperTorsionParameterException
+        from openforcefield.typing.engines.smirnoff.parameters import (
+            UnassignedProperTorsionParameterException,
+        )
 
-        forcefield = ForceField('''
+        forcefield = ForceField(
+            """
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
   <ProperTorsions version="0.3" potential="k*(1+cos(periodicity*theta-phase))">
     <Proper smirks="[#99:1]-[#99X4:2]-[#99:3]-[#99:4]" id="t1" idivf1="1" k1="0.156 * kilocalories_per_mole" periodicity1="3" phase1="0.0 * degree"/>
   </ProperTorsions>
 </SMIRNOFF>
-''')
-        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
+"""
+        )
+        pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
         molecules = [create_ethanol()]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
-        with pytest.raises(UnassignedProperTorsionParameterException,
-                           match='- Topology indices [(]5, 0, 1, 6[)]: '
-                                 'names and elements [(](H\d+)? H[)], [(](C\d+)? C[)], [(](C\d+)? C[)], [(](H\d+)? H[)],') \
-                as excinfo:
+        with pytest.raises(
+            UnassignedProperTorsionParameterException,
+            match="- Topology indices [(]5, 0, 1, 6[)]: "
+            "names and elements [(](H\d+)? H[)], [(](C\d+)? C[)], [(](C\d+)? C[)], [(](H\d+)? H[)],",
+        ) as excinfo:
             omm_system = forcefield.create_openmm_system(topology)
 
-    @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
-    def test_parameterize_1_cyclohexane_1_ethanol(self, toolkit_registry, registry_description):
+    @pytest.mark.parametrize(
+        "toolkit_registry,registry_description", toolkit_registries
+    )
+    def test_parameterize_1_cyclohexane_1_ethanol(
+        self, toolkit_registry, registry_description
+    ):
         """Test parameterizing a periodic system of two distinct molecules"""
         from simtk.openmm import app
 
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
-        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
+        pdbfile = app.PDBFile(
+            get_data_file_path("systems/test_systems/1_cyclohexane_1_ethanol.pdb")
+        )
         # toolkit_wrapper = RDKitToolkitWrapper()
         molecules = [create_ethanol(), create_cyclohexane()]
         # molecules = [Molecule.from_file(get_data_file_path(name)) for name in ('molecules/ethanol.mol2',
@@ -1019,46 +1229,67 @@ class TestForceField():
 
         omm_system = forcefield.create_openmm_system(topology)
 
-    @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
-    def test_parameterize_1_cyclohexane_1_ethanol_vacuum(self, toolkit_registry, registry_description):
+    @pytest.mark.parametrize(
+        "toolkit_registry,registry_description", toolkit_registries
+    )
+    def test_parameterize_1_cyclohexane_1_ethanol_vacuum(
+        self, toolkit_registry, registry_description
+    ):
         """Test parametrizing a nonperiodic system of two distinct molecules"""
         from simtk.openmm import app
 
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
-        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
+        pdbfile = app.PDBFile(
+            get_data_file_path("systems/test_systems/1_cyclohexane_1_ethanol.pdb")
+        )
         molecules = [create_ethanol(), create_cyclohexane()]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         topology.box_vectors = None
 
         omm_system = forcefield.create_openmm_system(topology)
 
-
-
     @pytest.mark.slow
-    @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
-    @pytest.mark.parametrize("box", ['ethanol_water.pdb',
-                                     'cyclohexane_water.pdb',
-                                     'cyclohexane_ethanol_0.4_0.6.pdb',
-                                     'propane_methane_butanol_0.2_0.3_0.5.pdb'])
-    def test_parameterize_large_system(self, toolkit_registry, registry_description, box):
+    @pytest.mark.parametrize(
+        "toolkit_registry,registry_description", toolkit_registries
+    )
+    @pytest.mark.parametrize(
+        "box",
+        [
+            "ethanol_water.pdb",
+            "cyclohexane_water.pdb",
+            "cyclohexane_ethanol_0.4_0.6.pdb",
+            "propane_methane_butanol_0.2_0.3_0.5.pdb",
+        ],
+    )
+    def test_parameterize_large_system(
+        self, toolkit_registry, registry_description, box
+    ):
         """Test parameterizing a large system of several distinct molecules.
         This test is very slow, so it is only run if the --runslow option is provided to pytest.
         """
         from simtk.openmm import app
 
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
-        box_file_path = get_data_file_path(os.path.join('systems', 'packmol_boxes', box))
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
+        box_file_path = get_data_file_path(
+            os.path.join("systems", "packmol_boxes", box)
+        )
         pdbfile = app.PDBFile(box_file_path)
-        mol_names = ['water', 'cyclohexane', 'ethanol', 'propane', 'methane', 'butanol']
-        sdf_files = [get_data_file_path(os.path.join('systems', 'monomers', name+'.sdf')) for name in mol_names]
+        mol_names = ["water", "cyclohexane", "ethanol", "propane", "methane", "butanol"]
+        sdf_files = [
+            get_data_file_path(os.path.join("systems", "monomers", name + ".sdf"))
+            for name in mol_names
+        ]
         molecules = [Molecule.from_file(sdf_file) for sdf_file in sdf_files]
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, )
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules,)
 
-        omm_system = forcefield.create_openmm_system(topology, toolkit_registry=toolkit_registry)
+        omm_system = forcefield.create_openmm_system(
+            topology, toolkit_registry=toolkit_registry
+        )
         # TODO: Add check to ensure system energy is finite
 
-
-    @pytest.mark.skipif( not(OpenEyeToolkitWrapper.is_available()), reason='Test requires OE toolkit')
+    @pytest.mark.skipif(
+        not (OpenEyeToolkitWrapper.is_available()), reason="Test requires OE toolkit"
+    )
     def test_parameterize_ethanol_different_reference_ordering_openeye(self):
         """
         Test parameterizing the same PDB, using reference mol2s that have different atom orderings.
@@ -1068,22 +1299,22 @@ class TestForceField():
         from simtk.openmm import app
         from simtk.openmm import XmlSerializer
 
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
-        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
+        pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
         # Load the unique molecules with one atom ordering
-        molecules1 = [Molecule.from_file(get_data_file_path('molecules/ethanol.sdf'))]
-        topology1 = Topology.from_openmm(pdbfile.topology,
-                                         unique_molecules=molecules1,
-                                         )
-        omm_system1 = forcefield.create_openmm_system(topology1,
-                                                      toolkit_registry=toolkit_registry)
+        molecules1 = [Molecule.from_file(get_data_file_path("molecules/ethanol.sdf"))]
+        topology1 = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules1,)
+        omm_system1 = forcefield.create_openmm_system(
+            topology1, toolkit_registry=toolkit_registry
+        )
         # Load the unique molecules with a different atom ordering
-        molecules2 = [Molecule.from_file(get_data_file_path('molecules/ethanol_reordered.sdf'))]
-        topology2 = Topology.from_openmm(pdbfile.topology,
-                                         unique_molecules=molecules2,
-                                         )
-        omm_system2 = forcefield.create_openmm_system(topology2,
-                                                      toolkit_registry=toolkit_registry)
+        molecules2 = [
+            Molecule.from_file(get_data_file_path("molecules/ethanol_reordered.sdf"))
+        ]
+        topology2 = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules2,)
+        omm_system2 = forcefield.create_openmm_system(
+            topology2, toolkit_registry=toolkit_registry
+        )
 
         serialized_1 = XmlSerializer.serialize(omm_system1)
         serialized_2 = XmlSerializer.serialize(omm_system2)
@@ -1093,7 +1324,9 @@ class TestForceField():
 
         assert serialized_1 == serialized_2
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='Test requires RDKit toolkit')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="Test requires RDKit toolkit"
+    )
     def test_parameterize_ethanol_different_reference_ordering_rdkit(self):
         """
         Test parameterizing the same PDB, using reference mol2s that have different atom orderings.
@@ -1103,26 +1336,27 @@ class TestForceField():
         from simtk.openmm import app
         from simtk.openmm import XmlSerializer
 
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[RDKitToolkitWrapper, AmberToolsToolkitWrapper])
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
-        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[RDKitToolkitWrapper, AmberToolsToolkitWrapper]
+        )
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
+        pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
 
         # Load the unique molecules with one atom ordering
-        molecules1 = [Molecule.from_file(get_data_file_path('molecules/ethanol.sdf'))]
-        topology1 = Topology.from_openmm(pdbfile.topology,
-                                         unique_molecules=molecules1,
-
-                                         )
-        omm_system1 = forcefield.create_openmm_system(topology1,
-                                                      toolkit_registry=toolkit_registry)
+        molecules1 = [Molecule.from_file(get_data_file_path("molecules/ethanol.sdf"))]
+        topology1 = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules1,)
+        omm_system1 = forcefield.create_openmm_system(
+            topology1, toolkit_registry=toolkit_registry
+        )
 
         # Load the unique molecules with a different atom ordering
-        molecules2 = [Molecule.from_file(get_data_file_path('molecules/ethanol_reordered.sdf'))]
-        topology2 = Topology.from_openmm(pdbfile.topology,
-                                         unique_molecules=molecules2,
-                                         )
-        omm_system2 = forcefield.create_openmm_system(topology2,
-                                                      toolkit_registry=toolkit_registry)
+        molecules2 = [
+            Molecule.from_file(get_data_file_path("molecules/ethanol_reordered.sdf"))
+        ]
+        topology2 = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules2,)
+        omm_system2 = forcefield.create_openmm_system(
+            topology2, toolkit_registry=toolkit_registry
+        )
 
         serialized_1 = XmlSerializer.serialize(omm_system1)
         serialized_2 = XmlSerializer.serialize(omm_system2)
@@ -1132,8 +1366,9 @@ class TestForceField():
 
         assert serialized_1 == serialized_2
 
-
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='Test requires RDKit toolkit')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="Test requires RDKit toolkit"
+    )
     def test_parameterize_mol_missing_stereo_rdkit(self):
         """
         Test parameterizing a molecule with undefined stereochemsity using the RDKit/AmberTools backend.
@@ -1141,16 +1376,20 @@ class TestForceField():
 
         from openforcefield.topology import Molecule, Topology
         from openforcefield.typing.engines.smirnoff import ForceField
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[RDKitToolkitWrapper, AmberToolsToolkitWrapper])
 
-        molecule = Molecule.from_smiles('CC1CCC(=O)O1', allow_undefined_stereo=True)
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[RDKitToolkitWrapper, AmberToolsToolkitWrapper]
+        )
+
+        molecule = Molecule.from_smiles("CC1CCC(=O)O1", allow_undefined_stereo=True)
         topology = Topology.from_molecules([molecule])
 
-        force_field = ForceField('test_forcefields/smirnoff99Frosst.offxml')
+        force_field = ForceField("test_forcefields/smirnoff99Frosst.offxml")
         force_field.create_openmm_system(topology, toolkit_registry=toolkit_registry)
 
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='Test requires OpenEye toolkit')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="Test requires OpenEye toolkit"
+    )
     def test_parameterize_mol_missing_stereo_openeye(self):
         """
         Test parameterizing a molecule with undefined stereochemsity using the OpenEye backend.
@@ -1158,74 +1397,87 @@ class TestForceField():
 
         from openforcefield.topology import Molecule, Topology
         from openforcefield.typing.engines.smirnoff import ForceField
+
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper])
 
-        molecule = Molecule.from_smiles('CC1CCC(=O)O1', allow_undefined_stereo=True)
+        molecule = Molecule.from_smiles("CC1CCC(=O)O1", allow_undefined_stereo=True)
         topology = Topology.from_molecules([molecule])
 
-        force_field = ForceField('test_forcefields/smirnoff99Frosst.offxml')
+        force_field = ForceField("test_forcefields/smirnoff99Frosst.offxml")
         force_field.create_openmm_system(topology, toolkit_registry=toolkit_registry)
 
-    @pytest.mark.skip(reason="We will not support going directly to ParmEd for now."
-                             "We will instead feed OpenMM System objects to ParmEd "
-                             "for further processing.")
+    @pytest.mark.skip(
+        reason="We will not support going directly to ParmEd for now."
+        "We will instead feed OpenMM System objects to ParmEd "
+        "for further processing."
+    )
     def test_parameterize_ethanol_to_parmed(self):
         from simtk.openmm import app
 
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
-        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
-        #toolkit_wrapper = RDKitToolkitWrapper()
-        molecules = [ Molecule.from_file(get_data_file_path(name)) for name in ('molecules/ethanol.mol2',) ]
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
+        pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
+        # toolkit_wrapper = RDKitToolkitWrapper()
+        molecules = [
+            Molecule.from_file(get_data_file_path(name))
+            for name in ("molecules/ethanol.mol2",)
+        ]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 
-        parmed_system = forcefield.create_parmed_structure(topology, positions=pdbfile.getPositions())
+        parmed_system = forcefield.create_parmed_structure(
+            topology, positions=pdbfile.getPositions()
+        )
 
-
-
-
-    @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
-    def test_pass_invalid_kwarg_to_create_openmm_system(self, toolkit_registry, registry_description):
+    @pytest.mark.parametrize(
+        "toolkit_registry,registry_description", toolkit_registries
+    )
+    def test_pass_invalid_kwarg_to_create_openmm_system(
+        self, toolkit_registry, registry_description
+    ):
         """Test to ensure an exception is raised when an unrecognized kwarg is passed """
         from simtk.openmm import app
 
-        file_path = get_data_file_path('test_forcefields/smirnoff99Frosst.offxml')
+        file_path = get_data_file_path("test_forcefields/smirnoff99Frosst.offxml")
         forcefield = ForceField(file_path)
-        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
         molecules = []
-        molecules.append(Molecule.from_smiles('CCO'))
+        molecules.append(Molecule.from_smiles("CCO"))
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 
-        with pytest.raises(ValueError, match=".* not used by any registered force Handler: {'invalid_kwarg'}.*") as e:
-            omm_system = forcefield.create_openmm_system(topology, invalid_kwarg='aaa', toolkit_registry=toolkit_registry)
-
+        with pytest.raises(
+            ValueError,
+            match=".* not used by any registered force Handler: {'invalid_kwarg'}.*",
+        ) as e:
+            omm_system = forcefield.create_openmm_system(
+                topology, invalid_kwarg="aaa", toolkit_registry=toolkit_registry
+            )
 
     @pytest.mark.parametrize("inputs", nonbonded_resolution_matrix)
-    def test_nonbonded_method_resolution(self,
-                                         inputs
-                                         ):
+    def test_nonbonded_method_resolution(self, inputs):
         """Test predefined permutations of input options to ensure nonbonded handling is correctly resolved"""
         from simtk.openmm import app
 
-        vdw_method = inputs['vdw_method']
-        electrostatics_method = inputs['electrostatics_method']
-        has_periodic_box = inputs['has_periodic_box']
-        omm_force = inputs['omm_force']
-        exception = inputs['exception']
-        exception_match= inputs['exception_match']
+        vdw_method = inputs["vdw_method"]
+        electrostatics_method = inputs["electrostatics_method"]
+        has_periodic_box = inputs["has_periodic_box"]
+        omm_force = inputs["omm_force"]
+        exception = inputs["exception"]
+        exception_match = inputs["exception_match"]
 
         molecules = [create_ethanol()]
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
 
-        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
+        pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 
-        if not(has_periodic_box):
+        if not (has_periodic_box):
             topology.box_vectors = None
 
         if exception is None:
             # The method is validated and may raise an exception if it's not supported.
-            forcefield.get_parameter_handler('vdW', {}).method = vdw_method
-            forcefield.get_parameter_handler('Electrostatics', {}).method = electrostatics_method
+            forcefield.get_parameter_handler("vdW", {}).method = vdw_method
+            forcefield.get_parameter_handler(
+                "Electrostatics", {}
+            ).method = electrostatics_method
             omm_system = forcefield.create_openmm_system(topology)
             nonbond_method_matched = False
             for f_idx in range(omm_system.getNumForces()):
@@ -1237,33 +1489,35 @@ class TestForceField():
         else:
             with pytest.raises(exception, match=exception_match) as excinfo:
                 # The method is validated and may raise an exception if it's not supported.
-                forcefield.get_parameter_handler('vdW', {}).method = vdw_method
-                forcefield.get_parameter_handler('Electrostatics', {}).method = electrostatics_method
+                forcefield.get_parameter_handler("vdW", {}).method = vdw_method
+                forcefield.get_parameter_handler(
+                    "Electrostatics", {}
+                ).method = electrostatics_method
                 omm_system = forcefield.create_openmm_system(topology)
 
     def test_registered_parameter_handlers(self):
         """Test registered_parameter_handlers property"""
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
         registered_handlers = forcefield.registered_parameter_handlers
 
         expected_handlers = [
-            'Bonds',
-            'Angles',
-            'ProperTorsions',
-            'ImproperTorsions',
-            'vdW',
-            'Electrostatics',
-            'ToolkitAM1BCC',
+            "Bonds",
+            "Angles",
+            "ProperTorsions",
+            "ImproperTorsions",
+            "vdW",
+            "Electrostatics",
+            "ToolkitAM1BCC",
         ]
 
         for expected_handler in expected_handlers:
             assert expected_handler in registered_handlers
 
-        assert 'LibraryChrages' not in registered_handlers
+        assert "LibraryChrages" not in registered_handlers
 
     def test_parameter_handler_lookup(self):
         """Ensure __getitem__ lookups work"""
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
 
         handlers_before = sorted(forcefield._parameter_handlers)
 
@@ -1275,10 +1529,10 @@ class TestForceField():
 
         assert handlers_before == handlers_after
 
-    @pytest.mark.parametrize('unregistered_handler', ['LibraryCharges', 'foobar'])
+    @pytest.mark.parametrize("unregistered_handler", ["LibraryCharges", "foobar"])
     def test_unregistered_parameter_handler_lookup(self, unregistered_handler):
         """Ensure __getitem__ lookups do not register new handlers"""
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
 
         assert unregistered_handler not in forcefield._parameter_handlers
         with pytest.raises(KeyError, match=unregistered_handler):
@@ -1287,27 +1541,31 @@ class TestForceField():
 
     def test_lookup_parameter_handler_object(self):
         """Ensure __getitem__ raises NotImplemented when passed a ParameterHandler object"""
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
-        bonds = forcefield['Bonds']
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
+        bonds = forcefield["Bonds"]
         with pytest.raises(NotImplementedError):
             forcefield[bonds]
         with pytest.raises(NotImplementedError):
             forcefield[type(bonds)]
-        
+
+
 class TestForceFieldChargeAssignment:
-
     def generate_monatomic_ions():
-        return (('Li+', +1*unit.elementary_charge),
-                ('Na+', +1*unit.elementary_charge),
-                ('K+', +1*unit.elementary_charge),
-                ('Rb+', +1*unit.elementary_charge),
-                ('Cs+', +1*unit.elementary_charge),
-                ('F-', -1*unit.elementary_charge),
-                ('Cl-', -1*unit.elementary_charge),
-                ('Br-', -1*unit.elementary_charge),
-                ('I-', -1*unit.elementary_charge))
+        return (
+            ("Li+", +1 * unit.elementary_charge),
+            ("Na+", +1 * unit.elementary_charge),
+            ("K+", +1 * unit.elementary_charge),
+            ("Rb+", +1 * unit.elementary_charge),
+            ("Cs+", +1 * unit.elementary_charge),
+            ("F-", -1 * unit.elementary_charge),
+            ("Cl-", -1 * unit.elementary_charge),
+            ("Br-", -1 * unit.elementary_charge),
+            ("I-", -1 * unit.elementary_charge),
+        )
 
-    @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
+    @pytest.mark.parametrize(
+        "toolkit_registry,registry_description", toolkit_registries
+    )
     def test_charges_from_molecule(self, toolkit_registry, registry_description):
         """Test skipping charge generation and instead getting charges from the original Molecule"""
         # Create an ethanol molecule without using a toolkit
@@ -1315,71 +1573,88 @@ class TestForceFieldChargeAssignment:
 
         from simtk.openmm import app, NonbondedForce
 
-        file_path = get_data_file_path('test_forcefields/smirnoff99Frosst.offxml')
+        file_path = get_data_file_path("test_forcefields/smirnoff99Frosst.offxml")
         forcefield = ForceField(file_path)
-        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
-        topology = Topology.from_openmm(pdbfile.topology,
-                                        unique_molecules=molecules)
-        omm_system = forcefield.create_openmm_system(topology,
-                                                     charge_from_molecules=molecules,
-                                                     toolkit_registry=toolkit_registry)
-        nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
-        expected_charges = ((0, -0.4 * unit.elementary_charge),
-                            (1, -0.3 * unit.elementary_charge),
-                            (2, -0.2 * unit.elementary_charge),
-                            )
+        pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
+        omm_system = forcefield.create_openmm_system(
+            topology, charge_from_molecules=molecules, toolkit_registry=toolkit_registry
+        )
+        nonbondedForce = [
+            f for f in omm_system.getForces() if type(f) == NonbondedForce
+        ][0]
+        expected_charges = (
+            (0, -0.4 * unit.elementary_charge),
+            (1, -0.3 * unit.elementary_charge),
+            (2, -0.2 * unit.elementary_charge),
+        )
         for particle_index, expected_charge in expected_charges:
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q == expected_charge
 
         # In 1_ethanol_reordered.pdb, the first three atoms go O-C-C instead of C-C-O. This part of the test ensures
         # that the charges are correctly mapped according to this PDB in the resulting system.
-        pdbfile2 = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol_reordered.pdb'))
-        topology2 = Topology.from_openmm(pdbfile2.topology,
-                                         unique_molecules=molecules)
-        omm_system2 = forcefield.create_openmm_system(topology2,
-                                                      charge_from_molecules=molecules,
-                                                      toolkit_registry=toolkit_registry)
-        nonbondedForce2 = [f for f in omm_system2.getForces() if type(f) == NonbondedForce][0]
-        expected_charges2 = ((0, -0.2*unit.elementary_charge),
-                             (1, -0.4*unit.elementary_charge),
-                             (2, -0.3*unit.elementary_charge),
-                            )
+        pdbfile2 = app.PDBFile(
+            get_data_file_path("systems/test_systems/1_ethanol_reordered.pdb")
+        )
+        topology2 = Topology.from_openmm(pdbfile2.topology, unique_molecules=molecules)
+        omm_system2 = forcefield.create_openmm_system(
+            topology2,
+            charge_from_molecules=molecules,
+            toolkit_registry=toolkit_registry,
+        )
+        nonbondedForce2 = [
+            f for f in omm_system2.getForces() if type(f) == NonbondedForce
+        ][0]
+        expected_charges2 = (
+            (0, -0.2 * unit.elementary_charge),
+            (1, -0.4 * unit.elementary_charge),
+            (2, -0.3 * unit.elementary_charge),
+        )
         for particle_index, expected_charge in expected_charges2:
             q, sigma, epsilon = nonbondedForce2.getParticleParameters(particle_index)
             assert q == expected_charge
 
-
-    @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
+    @pytest.mark.parametrize(
+        "toolkit_registry,registry_description", toolkit_registries
+    )
     def test_nonintegral_charge_exception(self, toolkit_registry, registry_description):
         """Test skipping charge generation and instead getting charges from the original Molecule"""
         from simtk.openmm import app
-        from openforcefield.typing.engines.smirnoff.parameters import NonintegralMoleculeChargeException
+        from openforcefield.typing.engines.smirnoff.parameters import (
+            NonintegralMoleculeChargeException,
+        )
+
         # Create an ethanol molecule without using a toolkit
         ethanol = create_ethanol()
-        ethanol.partial_charges[0] = 1. * unit.elementary_charge
+        ethanol.partial_charges[0] = 1.0 * unit.elementary_charge
 
-
-        file_path = get_data_file_path('test_forcefields/smirnoff99Frosst.offxml')
+        file_path = get_data_file_path("test_forcefields/smirnoff99Frosst.offxml")
         forcefield = ForceField(file_path)
-        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_ethanol.pdb'))
-        topology = Topology.from_openmm(pdbfile.topology,
-                                        unique_molecules=[ethanol])
+        pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=[ethanol])
 
         # Fail because nonintegral charges aren't allowed
-        with pytest.raises(NonintegralMoleculeChargeException,
-                           match="Partial charge sum [(]1.40001 e[)] for molecule"):
-            omm_system = forcefield.create_openmm_system(topology,
-                                                         charge_from_molecules=[ethanol],
-                                                         toolkit_registry=toolkit_registry)
+        with pytest.raises(
+            NonintegralMoleculeChargeException,
+            match="Partial charge sum [(]1.40001 e[)] for molecule",
+        ):
+            omm_system = forcefield.create_openmm_system(
+                topology,
+                charge_from_molecules=[ethanol],
+                toolkit_registry=toolkit_registry,
+            )
         # Pass when the `allow_nonintegral_charges` keyword is included
-        omm_system = forcefield.create_openmm_system(topology,
-                                                     charge_from_molecules=[ethanol],
-                                                     toolkit_registry=toolkit_registry,
-                                                     allow_nonintegral_charges=True)
+        omm_system = forcefield.create_openmm_system(
+            topology,
+            charge_from_molecules=[ethanol],
+            toolkit_registry=toolkit_registry,
+            allow_nonintegral_charges=True,
+        )
 
-
-    @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
+    @pytest.mark.parametrize(
+        "toolkit_registry,registry_description", toolkit_registries
+    )
     def test_some_charges_from_molecule(self, toolkit_registry, registry_description):
         """
         Test creating an OpenMM system where some charges come from a Molecule, but others come from toolkit
@@ -1391,34 +1666,45 @@ class TestForceFieldChargeAssignment:
 
         from simtk.openmm import app, NonbondedForce
 
-        file_path = get_data_file_path('test_forcefields/smirnoff99Frosst.offxml')
+        file_path = get_data_file_path("test_forcefields/smirnoff99Frosst.offxml")
         forcefield = ForceField(file_path)
-        pdbfile = app.PDBFile(get_data_file_path('systems/test_systems/1_cyclohexane_1_ethanol.pdb'))
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules, )
+        pdbfile = app.PDBFile(
+            get_data_file_path("systems/test_systems/1_cyclohexane_1_ethanol.pdb")
+        )
+        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules,)
 
-        omm_system = forcefield.create_openmm_system(topology,
-                                                     charge_from_molecules=[ethanol],
-                                                     toolkit_registry=toolkit_registry)
-        nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
-        expected_charges = ((18, -0.4 * unit.elementary_charge),
-                            (19, -0.3 * unit.elementary_charge),
-                            (20, -0.2 * unit.elementary_charge),
-                            )
+        omm_system = forcefield.create_openmm_system(
+            topology, charge_from_molecules=[ethanol], toolkit_registry=toolkit_registry
+        )
+        nonbondedForce = [
+            f for f in omm_system.getForces() if type(f) == NonbondedForce
+        ][0]
+        expected_charges = (
+            (18, -0.4 * unit.elementary_charge),
+            (19, -0.3 * unit.elementary_charge),
+            (20, -0.2 * unit.elementary_charge),
+        )
         for particle_index, expected_charge in expected_charges:
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q == expected_charge
         for particle_index in range(topology.n_topology_particles):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
-            assert q != (0. * unit.elementary_charge)
+            assert q != (0.0 * unit.elementary_charge)
 
     def test_library_charges_to_single_water(self):
         """Test assigning charges to one water molecule using library charges"""
         from simtk.openmm import NonbondedForce
 
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml', 'test_forcefields/tip3p.offxml')
-        mol = Molecule.from_file(get_data_file_path(os.path.join('systems', 'monomers','water.sdf')))
+        ff = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml", "test_forcefields/tip3p.offxml"
+        )
+        mol = Molecule.from_file(
+            get_data_file_path(os.path.join("systems", "monomers", "water.sdf"))
+        )
         omm_system = ff.create_openmm_system(mol.to_topology())
-        nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
+        nonbondedForce = [
+            f for f in omm_system.getForces() if type(f) == NonbondedForce
+        ][0]
         expected_charges = [-0.834, 0.417, 0.417] * unit.elementary_charge
         for particle_index, expected_charge in enumerate(expected_charges):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
@@ -1439,25 +1725,47 @@ class TestForceFieldChargeAssignment:
 
     def test_charge_increment_model_forward_and_reverse_ethanol(self):
         """Test application of ChargeIncrements to the same molecule with different orderings in the topology"""
-        test_charge_increment_model_ff = '''
+        test_charge_increment_model_ff = """
         <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
           <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
           <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
             <ChargeIncrement smirks="[#6X4:1]-[#8:2]" charge_increment1="-0.05*elementary_charge" charge_increment2="0.05*elementary_charge"/>
             <ChargeIncrement smirks="[C:1][C:2][O:3]" charge_increment1="0.2*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge"/>
           </ChargeIncrementModel>
-        </SMIRNOFF>'''
-        file_path = get_data_file_path('test_forcefields/smirnoff99Frosst.offxml')
+        </SMIRNOFF>"""
+        file_path = get_data_file_path("test_forcefields/smirnoff99Frosst.offxml")
         ff = ForceField(file_path, test_charge_increment_model_ff)
-        del ff._parameter_handlers['ToolkitAM1BCC']
+        del ff._parameter_handlers["ToolkitAM1BCC"]
         top = Topology.from_molecules([create_ethanol(), create_reversed_ethanol()])
         sys = ff.create_openmm_system(top)
-        nonbonded_force = [force for force in sys.getForces() if isinstance(force, openmm.NonbondedForce)][0]
-        expected_charges = [0.2, -0.15, -0.05, 0., 0., 0., 0., 0., 0.,
-                            0., 0., 0., 0., 0., 0., -0.05, -0.15, 0.2] * unit.elementary_charge
+        nonbonded_force = [
+            force
+            for force in sys.getForces()
+            if isinstance(force, openmm.NonbondedForce)
+        ][0]
+        expected_charges = [
+            0.2,
+            -0.15,
+            -0.05,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            -0.05,
+            -0.15,
+            0.2,
+        ] * unit.elementary_charge
         for idx, expected_charge in enumerate(expected_charges):
             charge, _, _ = nonbonded_force.getParticleParameters(idx)
-            assert abs(charge - expected_charge) < 1.e-6 * unit.elementary_charge
+            assert abs(charge - expected_charge) < 1.0e-6 * unit.elementary_charge
 
     def test_charge_increment_model_initialize_with_no_elements(self):
         """Ensure that we can initialize a ForceField object from an OFFXML with a ChargeIncrementModel header, but no
@@ -1467,27 +1775,31 @@ class TestForceFieldChargeAssignment:
     def test_charge_increment_model_net_charge(self):
         """Test application of charge increments on a molecule with a net charge"""
         from simtk import unit
-        test_charge_increment_model_ff = '''
+
+        test_charge_increment_model_ff = """
         <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
           <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
           <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
             <ChargeIncrement smirks="[#6X3:1]-[#8X1-1:2]" charge_increment1="-0.05*elementary_charge" charge_increment2="0.05*elementary_charge"/>
             <ChargeIncrement smirks="[#6X3:1]=[#8X1:2]" charge_increment1="0.2*elementary_charge" charge_increment2="-0.2*elementary_charge"/>
           </ChargeIncrementModel>
-        </SMIRNOFF>'''
-        file_path = get_data_file_path('test_forcefields/smirnoff99Frosst.offxml')
+        </SMIRNOFF>"""
+        file_path = get_data_file_path("test_forcefields/smirnoff99Frosst.offxml")
         ff = ForceField(file_path, test_charge_increment_model_ff)
-        del ff._parameter_handlers['ToolkitAM1BCC']
+        del ff._parameter_handlers["ToolkitAM1BCC"]
 
         acetate = create_acetate()
         top = acetate.to_topology()
         sys = ff.create_openmm_system(top)
-        nonbonded_force = [force for force in sys.getForces() if isinstance(force, openmm.NonbondedForce)][0]
-        expected_charges = [0, 0.15, -0.2 , -0.95, 0, 0, 0] * unit.elementary_charge
+        nonbonded_force = [
+            force
+            for force in sys.getForces()
+            if isinstance(force, openmm.NonbondedForce)
+        ][0]
+        expected_charges = [0, 0.15, -0.2, -0.95, 0, 0, 0] * unit.elementary_charge
         for idx, expected_charge in enumerate(expected_charges):
             charge, _, _ = nonbonded_force.getParticleParameters(idx)
-            assert abs(charge - expected_charge) < 1.e-6 * unit.elementary_charge
-
+            assert abs(charge - expected_charge) < 1.0e-6 * unit.elementary_charge
 
     def test_charge_increment_model_deduplicate_symmetric_matches(self):
         """Test that chargeincrementmodelhandler deduplicates symmetric matches"""
@@ -1498,136 +1810,206 @@ class TestForceFieldChargeAssignment:
 
         # Test a charge increment that matches all C-H bonds at once
         # (this should be applied once: C0-H3-H4-H5)
-        test_charge_increment_model_ff = '''
+        test_charge_increment_model_ff = """
         <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
           <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
           <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
             <ChargeIncrement smirks="[#6X4:1]([#1:2])([#1:3])([#1:4])" charge_increment1="0.3*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge" charge_increment4="-0.1*elementary_charge"/>
           </ChargeIncrementModel>
-        </SMIRNOFF>'''
-        file_path = get_data_file_path('test_forcefields/smirnoff99Frosst.offxml')
+        </SMIRNOFF>"""
+        file_path = get_data_file_path("test_forcefields/smirnoff99Frosst.offxml")
         ff = ForceField(file_path, test_charge_increment_model_ff)
-        del ff._parameter_handlers['ToolkitAM1BCC']
-
+        del ff._parameter_handlers["ToolkitAM1BCC"]
 
         sys = ff.create_openmm_system(top)
-        nonbonded_force = [force for force in sys.getForces() if isinstance(force, openmm.NonbondedForce)][0]
-        expected_charges = [0.3, 0, 0, -0.1, -0.1, -0.1, 0., 0., 0.] * unit.elementary_charge
+        nonbonded_force = [
+            force
+            for force in sys.getForces()
+            if isinstance(force, openmm.NonbondedForce)
+        ][0]
+        expected_charges = [
+            0.3,
+            0,
+            0,
+            -0.1,
+            -0.1,
+            -0.1,
+            0.0,
+            0.0,
+            0.0,
+        ] * unit.elementary_charge
         for idx, expected_charge in enumerate(expected_charges):
             charge, _, _ = nonbonded_force.getParticleParameters(idx)
-            assert abs(charge - expected_charge) < 1.e-6 * unit.elementary_charge
+            assert abs(charge - expected_charge) < 1.0e-6 * unit.elementary_charge
 
         # Test a charge increment that matches two C-H bonds at a time
         # (this should be applied 3 times: C0-H3-H4, C0-H3-H5, C0-H4-H5)
-        test_charge_increment_model_ff = '''
+        test_charge_increment_model_ff = """
         <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
           <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
           <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
             <ChargeIncrement smirks="[#6X4:1]([#1:2])([#1:3])[#6][#8]" charge_increment1="0.1*elementary_charge" charge_increment2="-0.05*elementary_charge" charge_increment3="-0.05*elementary_charge"/>
           </ChargeIncrementModel>
-        </SMIRNOFF>'''
-        file_path = get_data_file_path('test_forcefields/smirnoff99Frosst.offxml')
+        </SMIRNOFF>"""
+        file_path = get_data_file_path("test_forcefields/smirnoff99Frosst.offxml")
         ff = ForceField(file_path, test_charge_increment_model_ff)
-        del ff._parameter_handlers['ToolkitAM1BCC']
-
+        del ff._parameter_handlers["ToolkitAM1BCC"]
 
         sys = ff.create_openmm_system(top)
-        nonbonded_force = [force for force in sys.getForces() if isinstance(force, openmm.NonbondedForce)][0]
-        expected_charges = [0.3, 0, 0, -0.1, -0.1, -0.1, 0., 0., 0.] * unit.elementary_charge
+        nonbonded_force = [
+            force
+            for force in sys.getForces()
+            if isinstance(force, openmm.NonbondedForce)
+        ][0]
+        expected_charges = [
+            0.3,
+            0,
+            0,
+            -0.1,
+            -0.1,
+            -0.1,
+            0.0,
+            0.0,
+            0.0,
+        ] * unit.elementary_charge
         for idx, expected_charge in enumerate(expected_charges):
             charge, _, _ = nonbonded_force.getParticleParameters(idx)
-            assert abs(charge - expected_charge) < 1.e-6 * unit.elementary_charge
-
+            assert abs(charge - expected_charge) < 1.0e-6 * unit.elementary_charge
 
         # Test a charge increment that matches ONE C-H bond at a time
         # (this should be applied three times: C0-H3, C0-H4, C0-H5)
-        test_charge_increment_model_ff = '''
+        test_charge_increment_model_ff = """
         <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
           <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
           <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
             <ChargeIncrement smirks="[#6X4:1]([#1:2])[#6][#8]" charge_increment1="0.1*elementary_charge" charge_increment2="-0.1*elementary_charge"/>
           </ChargeIncrementModel>
-        </SMIRNOFF>'''
-        file_path = get_data_file_path('test_forcefields/smirnoff99Frosst.offxml')
+        </SMIRNOFF>"""
+        file_path = get_data_file_path("test_forcefields/smirnoff99Frosst.offxml")
         ff = ForceField(file_path, test_charge_increment_model_ff)
-        del ff._parameter_handlers['ToolkitAM1BCC']
+        del ff._parameter_handlers["ToolkitAM1BCC"]
 
         sys = ff.create_openmm_system(top)
-        nonbonded_force = [force for force in sys.getForces() if isinstance(force, openmm.NonbondedForce)][0]
-        expected_charges = [0.3, 0, 0, -0.1, -0.1, -0.1, 0., 0., 0.] * unit.elementary_charge
+        nonbonded_force = [
+            force
+            for force in sys.getForces()
+            if isinstance(force, openmm.NonbondedForce)
+        ][0]
+        expected_charges = [
+            0.3,
+            0,
+            0,
+            -0.1,
+            -0.1,
+            -0.1,
+            0.0,
+            0.0,
+            0.0,
+        ] * unit.elementary_charge
         for idx, expected_charge in enumerate(expected_charges):
             charge, _, _ = nonbonded_force.getParticleParameters(idx)
-            assert abs(charge - expected_charge) < 1.e-6 * unit.elementary_charge
+            assert abs(charge - expected_charge) < 1.0e-6 * unit.elementary_charge
 
     def test_charge_increment_model_completely_overlapping_matches_override(self):
         """Ensure that DIFFERENT chargeincrements override one another if they apply to the
         same atoms, regardless of order"""
         from simtk import unit
-        test_charge_increment_model_ff = '''
+
+        test_charge_increment_model_ff = """
         <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
           <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
           <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
             <ChargeIncrement smirks="[#1:1]-[#6:2]([#1:3])([#1:4])" charge_increment1="0.123*elementary_charge" charge_increment2="0.369*elementary_charge" charge_increment3="-0.123*elementary_charge" charge_increment4="0.123*elementary_charge"/>
             <ChargeIncrement smirks="[#6X4:1]([#1:2])([#1:3])([#1:4])" charge_increment1="0.3*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge" charge_increment4="-0.1*elementary_charge"/>
           </ChargeIncrementModel>
-        </SMIRNOFF>'''
-        file_path = get_data_file_path('test_forcefields/smirnoff99Frosst.offxml')
+        </SMIRNOFF>"""
+        file_path = get_data_file_path("test_forcefields/smirnoff99Frosst.offxml")
         ff = ForceField(file_path, test_charge_increment_model_ff)
-        del ff._parameter_handlers['ToolkitAM1BCC']
+        del ff._parameter_handlers["ToolkitAM1BCC"]
 
         ethanol = create_ethanol()
         top = ethanol.to_topology()
         sys = ff.create_openmm_system(top)
-        nonbonded_force = [force for force in sys.getForces() if isinstance(force, openmm.NonbondedForce)][0]
-        expected_charges = [0.3, 0, 0, -0.1, -0.1, -0.1, 0., 0., 0.] * unit.elementary_charge
+        nonbonded_force = [
+            force
+            for force in sys.getForces()
+            if isinstance(force, openmm.NonbondedForce)
+        ][0]
+        expected_charges = [
+            0.3,
+            0,
+            0,
+            -0.1,
+            -0.1,
+            -0.1,
+            0.0,
+            0.0,
+            0.0,
+        ] * unit.elementary_charge
         for idx, expected_charge in enumerate(expected_charges):
             charge, _, _ = nonbonded_force.getParticleParameters(idx)
-            assert abs(charge - expected_charge) < 1.e-6 * unit.elementary_charge
-
+            assert abs(charge - expected_charge) < 1.0e-6 * unit.elementary_charge
 
     def test_charge_increment_model_partially_overlapping_matches_both_apply(self):
         """Ensure that DIFFERENT chargeincrements BOTH get applied if they match
         a partially-overlapping set of atoms"""
         from simtk import unit
-        test_charge_increment_model_ff = '''
+
+        test_charge_increment_model_ff = """
         <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
           <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
           <ChargeIncrementModel version="0.3" number_of_conformers="0" partial_charge_method="formal_charge">
             <ChargeIncrement smirks="[#6X4:1]([#1:2])([#1:3])([#1:4])" charge_increment1="0.3*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge" charge_increment4="-0.1*elementary_charge"/>
             <ChargeIncrement smirks="[#6X4:1][#6X4:2][#8]" charge_increment1="0.05*elementary_charge" charge_increment2="-0.05*elementary_charge"/>
           </ChargeIncrementModel>
-        </SMIRNOFF>'''
-        file_path = get_data_file_path('test_forcefields/smirnoff99Frosst.offxml')
+        </SMIRNOFF>"""
+        file_path = get_data_file_path("test_forcefields/smirnoff99Frosst.offxml")
         ff = ForceField(file_path, test_charge_increment_model_ff)
-        del ff._parameter_handlers['ToolkitAM1BCC']
+        del ff._parameter_handlers["ToolkitAM1BCC"]
 
         ethanol = create_ethanol()
         top = ethanol.to_topology()
         sys = ff.create_openmm_system(top)
-        nonbonded_force = [force for force in sys.getForces() if isinstance(force, openmm.NonbondedForce)][0]
-        expected_charges = [0.35, -0.05, 0, -0.1, -0.1, -0.1, 0., 0., 0.] * unit.elementary_charge
+        nonbonded_force = [
+            force
+            for force in sys.getForces()
+            if isinstance(force, openmm.NonbondedForce)
+        ][0]
+        expected_charges = [
+            0.35,
+            -0.05,
+            0,
+            -0.1,
+            -0.1,
+            -0.1,
+            0.0,
+            0.0,
+            0.0,
+        ] * unit.elementary_charge
         for idx, expected_charge in enumerate(expected_charges):
             charge, _, _ = nonbonded_force.getParticleParameters(idx)
-            assert abs(charge - expected_charge) < 1.e-6 * unit.elementary_charge
+            assert abs(charge - expected_charge) < 1.0e-6 * unit.elementary_charge
 
     @pytest.mark.parametrize("inputs", partial_charge_method_resolution_matrix)
     def test_partial_charge_resolution(self, inputs):
         """Check that the proper partial charge methods are available, and that unavailable partial charge methods
         raise an exception.
         """
-        toolkit_wrapper_class = inputs['toolkit']
-        if not(toolkit_wrapper_class.is_available()):
+        toolkit_wrapper_class = inputs["toolkit"]
+        if not (toolkit_wrapper_class.is_available()):
             pytest.skip(f"{toolkit_wrapper_class} is not available.")
         toolkit_wrapper = toolkit_wrapper_class()
-        partial_charge_method = inputs['partial_charge_method']
-        expected_exception = inputs['exception']
-        expected_exception_match = inputs['exception_match']
+        partial_charge_method = inputs["partial_charge_method"]
+        expected_exception = inputs["exception"]
+        expected_exception_match = inputs["exception_match"]
         ethanol = create_ethanol()
         ethanol.generate_conformers()
         if expected_exception is None:
-            ethanol.assign_partial_charges(partial_charge_method=partial_charge_method,
-                                           toolkit_registry=toolkit_wrapper)
-            abs_charge_sum = 0. * unit.elementary_charge
+            ethanol.assign_partial_charges(
+                partial_charge_method=partial_charge_method,
+                toolkit_registry=toolkit_wrapper,
+            )
+            abs_charge_sum = 0.0 * unit.elementary_charge
 
             # Ensure that nonzero charges were assigned
             for pc in ethanol.partial_charges:
@@ -1635,9 +2017,13 @@ class TestForceFieldChargeAssignment:
             assert abs_charge_sum > 0.5 * unit.elementary_charge
 
         else:
-            with pytest.raises(expected_exception, match=expected_exception_match) as excinfo:
-                ethanol.assign_partial_charges(partial_charge_method=partial_charge_method,
-                                                toolkit_registry=toolkit_wrapper)
+            with pytest.raises(
+                expected_exception, match=expected_exception_match
+            ) as excinfo:
+                ethanol.assign_partial_charges(
+                    partial_charge_method=partial_charge_method,
+                    toolkit_registry=toolkit_wrapper,
+                )
 
     def test_library_charge_hierarchy(self):
         """Test assigning charges to one water molecule using library charges, where two LCs match and the
@@ -1645,21 +2031,33 @@ class TestForceFieldChargeAssignment:
         from simtk.openmm import NonbondedForce
 
         # Test with xml_OH_library_charges_xml loaded last, which should assign dummy partial charges
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml',
-                        'test_forcefields/tip3p.offxml',
-                        xml_OH_library_charges_xml)
-        mol = Molecule.from_file(get_data_file_path(os.path.join('systems', 'monomers','water.sdf')))
+        ff = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml",
+            "test_forcefields/tip3p.offxml",
+            xml_OH_library_charges_xml,
+        )
+        mol = Molecule.from_file(
+            get_data_file_path(os.path.join("systems", "monomers", "water.sdf"))
+        )
         omm_system = ff.create_openmm_system(mol.to_topology())
-        nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
-        expected_charges = [-2., 1., 1.] * unit.elementary_charge
+        nonbondedForce = [
+            f for f in omm_system.getForces() if type(f) == NonbondedForce
+        ][0]
+        expected_charges = [-2.0, 1.0, 1.0] * unit.elementary_charge
         for particle_index, expected_charge in enumerate(expected_charges):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q == expected_charge
 
         # Test again, but with tip3p.offxml loaded last (loading the correct partial charges)
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml', xml_OH_library_charges_xml, 'test_forcefields/tip3p.offxml', )
+        ff = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml",
+            xml_OH_library_charges_xml,
+            "test_forcefields/tip3p.offxml",
+        )
         omm_system = ff.create_openmm_system(mol.to_topology())
-        nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
+        nonbondedForce = [
+            f for f in omm_system.getForces() if type(f) == NonbondedForce
+        ][0]
         expected_charges = [-0.834, 0.417, 0.417] * unit.elementary_charge
         for particle_index, expected_charge in enumerate(expected_charges):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
@@ -1669,12 +2067,25 @@ class TestForceFieldChargeAssignment:
         """Test assigning charges to two water molecules using library charges"""
         from simtk.openmm import NonbondedForce
 
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml', 'test_forcefields/tip3p.offxml')
-        mol = Molecule.from_file(get_data_file_path(os.path.join('systems', 'monomers','water.sdf')))
+        ff = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml", "test_forcefields/tip3p.offxml"
+        )
+        mol = Molecule.from_file(
+            get_data_file_path(os.path.join("systems", "monomers", "water.sdf"))
+        )
         top = Topology.from_molecules([mol, mol])
         omm_system = ff.create_openmm_system(top)
-        nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
-        expected_charges = [-0.834, 0.417, 0.417, -0.834, 0.417, 0.417] * unit.elementary_charge
+        nonbondedForce = [
+            f for f in omm_system.getForces() if type(f) == NonbondedForce
+        ][0]
+        expected_charges = [
+            -0.834,
+            0.417,
+            0.417,
+            -0.834,
+            0.417,
+            0.417,
+        ] * unit.elementary_charge
         for particle_index, expected_charge in enumerate(expected_charges):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q == expected_charge
@@ -1686,7 +2097,9 @@ class TestForceFieldChargeAssignment:
         # Define a library charge parameter for ethanol (C1-C2-O3) where C1 has charge -0.2, and its Hs have -0.02,
         # C2 has charge -0.1 and its Hs have -0.01, and O3 has charge 0.3, and its H has charge 0.08
 
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml', xml_ethanol_library_charges_ff)
+        ff = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml", xml_ethanol_library_charges_ff
+        )
 
         # ethanol.sdf
         #      H5   H8
@@ -1709,32 +2122,64 @@ class TestForceFieldChargeAssignment:
         #      |    |
         #      H3   H1
 
-
-        molecules = [Molecule.from_file(get_data_file_path('molecules/ethanol.sdf')),
-                     Molecule.from_file(get_data_file_path('molecules/ethanol_reordered.sdf')),
-                     create_reversed_ethanol()]
+        molecules = [
+            Molecule.from_file(get_data_file_path("molecules/ethanol.sdf")),
+            Molecule.from_file(get_data_file_path("molecules/ethanol_reordered.sdf")),
+            create_reversed_ethanol(),
+        ]
         top = Topology.from_molecules(molecules)
         omm_system = ff.create_openmm_system(top)
-        nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
-        expected_charges = [-0.2, -0.1, 0.3, 0.08, -0.02, -0.02, -0.02, -0.01, -0.01,
-                            -0.2, 0.3, -0.1, 0.08, -0.02, -0.02, -0.02, -0.01, -0.01,
-                            0.08, -0.01, -0.01, -0.02, -0.02, -0.02, 0.3, -0.1, -0.2] * unit.elementary_charge
+        nonbondedForce = [
+            f for f in omm_system.getForces() if type(f) == NonbondedForce
+        ][0]
+        expected_charges = [
+            -0.2,
+            -0.1,
+            0.3,
+            0.08,
+            -0.02,
+            -0.02,
+            -0.02,
+            -0.01,
+            -0.01,
+            -0.2,
+            0.3,
+            -0.1,
+            0.08,
+            -0.02,
+            -0.02,
+            -0.02,
+            -0.01,
+            -0.01,
+            0.08,
+            -0.01,
+            -0.01,
+            -0.02,
+            -0.02,
+            -0.02,
+            0.3,
+            -0.1,
+            -0.2,
+        ] * unit.elementary_charge
         for particle_index, expected_charge in enumerate(expected_charges):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q == expected_charge
 
-
-    @pytest.mark.parametrize('monatomic_ion,formal_charge', generate_monatomic_ions())
+    @pytest.mark.parametrize("monatomic_ion,formal_charge", generate_monatomic_ions())
     def test_library_charges_monatomic_ions(self, monatomic_ion, formal_charge):
         """Test assigning library charges to each of the monatomic ions in openff-1.1.0.xml"""
         from simtk.openmm import NonbondedForce
 
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml',
-                        'test_forcefields/ion_charges.offxml')
+        ff = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml",
+            "test_forcefields/ion_charges.offxml",
+        )
         mol = Molecule.from_smiles("[{}]".format(monatomic_ion))
         omm_system = ff.create_openmm_system(mol.to_topology())
 
-        nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
+        nonbondedForce = [
+            f for f in omm_system.getForces() if type(f) == NonbondedForce
+        ][0]
         q, sigma, epsilon = nonbondedForce.getParticleParameters(0)
         assert q == formal_charge
 
@@ -1743,30 +2188,63 @@ class TestForceFieldChargeAssignment:
         if not applicable, then AM1BCC otherwise"""
         from simtk.openmm import NonbondedForce
 
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml',
-                        xml_CH_zeroes_library_charges_xml,
-                        'test_forcefields/tip3p.offxml',
-                        xml_charge_increment_model_formal_charges
-                        )
+        ff = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml",
+            xml_CH_zeroes_library_charges_xml,
+            "test_forcefields/tip3p.offxml",
+            xml_charge_increment_model_formal_charges,
+        )
         # Cyclohexane will be assigned nonzero charges based on `charge_from_molecules` kwarg
-        cyclohexane = Molecule.from_file(get_data_file_path(os.path.join('systems', 'monomers','cyclohexane.sdf')))
+        cyclohexane = Molecule.from_file(
+            get_data_file_path(os.path.join("systems", "monomers", "cyclohexane.sdf"))
+        )
         # Butanol will be assigned zero-valued charges based on `charge_from_molecules` kwarg
-        butanol = Molecule.from_file(get_data_file_path(os.path.join('systems', 'monomers', 'butanol.sdf')))
+        butanol = Molecule.from_file(
+            get_data_file_path(os.path.join("systems", "monomers", "butanol.sdf"))
+        )
         # Propane will be assigned charges from AM1BCC
-        propane = Molecule.from_file(get_data_file_path(os.path.join('systems', 'monomers', 'propane.sdf')))
+        propane = Molecule.from_file(
+            get_data_file_path(os.path.join("systems", "monomers", "propane.sdf"))
+        )
         # Water will be assigned TIP3P librarycharges
-        water = Molecule.from_file(get_data_file_path(os.path.join('systems', 'monomers', 'water.sdf')))
+        water = Molecule.from_file(
+            get_data_file_path(os.path.join("systems", "monomers", "water.sdf"))
+        )
         # Ethanol should be caught by ToolkitAM1BCC
-        ethanol = Molecule.from_file(get_data_file_path(os.path.join('systems', 'monomers', 'ethanol.sdf')))
+        ethanol = Molecule.from_file(
+            get_data_file_path(os.path.join("systems", "monomers", "ethanol.sdf"))
+        )
         # iodide should fail to be assigned charges by AM1-BCC, and instead be caught by ChargeIncrementHandler
         # (and assigned formal charge by dummy charge method)
-        iodide = Molecule.from_smiles('[I-1]')
+        iodide = Molecule.from_smiles("[I-1]")
 
         # Assign dummy partial charges to cyclohexane, which we expect to find in the final system since it
         # is included in the charge_from_molecules kwarg to create_openmm_system
-        cyclohexane.partial_charges = np.array([-0.2, -0.2, -0.2, -0.2, -0.2, -0.2,
-                                             0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
-                                             0.1, 0.1, 0.1, 0.1, 0.1, 0.1]) * unit.elementary_charge
+        cyclohexane.partial_charges = (
+            np.array(
+                [
+                    -0.2,
+                    -0.2,
+                    -0.2,
+                    -0.2,
+                    -0.2,
+                    -0.2,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                ]
+            )
+            * unit.elementary_charge
+        )
 
         # There were previously known issues when parameterizing molecules with all zero charges,
         # so test this explicitly with butanol. Since butanol will be in the charge_from_molecules kwarg,
@@ -1775,39 +2253,85 @@ class TestForceFieldChargeAssignment:
 
         # Add dummy partial charges to propane, which should be IGNORED since it
         # isn't in the charge_from_molecules kwarg
-        propane.partial_charges = np.array([99.] * 11) * unit.elementary_charge
+        propane.partial_charges = np.array([99.0] * 11) * unit.elementary_charge
 
         # Add dummy partial charges to water, which should be IGNORED since it
         # isn't in the charge_from_molecules kwarg
-        water.partial_charges = np.array([99.] * 3) * unit.elementary_charge
+        water.partial_charges = np.array([99.0] * 3) * unit.elementary_charge
 
         #            molecule       correct charge method
-        molecules = [cyclohexane, # charge_from_molecules kwarg
-                     butanol,     # charge_from_molecules kwarg
-                     propane,     # library charges
-                     water,       # library charges
-                     ethanol,     # AM1-BCC
-                     iodide]      # charge increment model (formal charge)
+        molecules = [
+            cyclohexane,  # charge_from_molecules kwarg
+            butanol,  # charge_from_molecules kwarg
+            propane,  # library charges
+            water,  # library charges
+            ethanol,  # AM1-BCC
+            iodide,
+        ]  # charge increment model (formal charge)
         top = Topology.from_molecules(molecules)
-        omm_system = ff.create_openmm_system(top, charge_from_molecules=[cyclohexane, butanol])
+        omm_system = ff.create_openmm_system(
+            top, charge_from_molecules=[cyclohexane, butanol]
+        )
         existing = [f for f in omm_system.getForces() if type(f) == NonbondedForce]
 
         # Ensure that the handlers do not make multiple NonbondedForce objects
         assert len(existing) == 1
         nonbondedForce = existing[0]
-        expected_charges = [# cyclohexane (18 atoms) should have the following values from charge_from_mols
-                            -0.2, -0.2, -0.2, -0.2, -0.2, -0.2,
-                             0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
-                             0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
-                            # butanol (15 atoms) should have the following values from charge_from_mols
-                             0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                             0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                             0.0, 0.0, 0.0,
-                            # propane (11 atoms) should have the following values from xml_CH_zeroes_library_charges_xml
-                             0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                             0.0, 0.0, 0.0, 0.0, 0.0,
-                            # water (3 atoms) should have the following charges from tip3p.offxml
-                            -0.834, 0.417, 0.417] * unit.elementary_charge
+        expected_charges = (
+            [  # cyclohexane (18 atoms) should have the following values from charge_from_mols
+                -0.2,
+                -0.2,
+                -0.2,
+                -0.2,
+                -0.2,
+                -0.2,
+                0.1,
+                0.1,
+                0.1,
+                0.1,
+                0.1,
+                0.1,
+                0.1,
+                0.1,
+                0.1,
+                0.1,
+                0.1,
+                0.1,
+                # butanol (15 atoms) should have the following values from charge_from_mols
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                # propane (11 atoms) should have the following values from xml_CH_zeroes_library_charges_xml
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                # water (3 atoms) should have the following charges from tip3p.offxml
+                -0.834,
+                0.417,
+                0.417,
+            ]
+            * unit.elementary_charge
+        )
 
         # Ensure that the first four molecules have exactly the charges we intended
         for particle_index, expected_charge in enumerate(expected_charges):
@@ -1815,29 +2339,55 @@ class TestForceFieldChargeAssignment:
             assert q == expected_charge
 
         # Ensure the last molecule (ethanol) had _some_ nonzero charge assigned by an AM1BCC implementation
-        for particle_index in range(len(expected_charges), top.n_topology_atoms-1):
+        for particle_index in range(len(expected_charges), top.n_topology_atoms - 1):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q != 0 * unit.elementary_charge
 
         # Ensure that iodine has a charge of -1, specified by charge increment model charge_method="formal charge"
-        q, sigma, epsilon = nonbondedForce.getParticleParameters(top.n_topology_atoms-1)
-        assert q == -1. * unit.elementary_charge
-
+        q, sigma, epsilon = nonbondedForce.getParticleParameters(
+            top.n_topology_atoms - 1
+        )
+        assert q == -1.0 * unit.elementary_charge
 
     def test_assign_charges_to_molecule_in_parts_using_multiple_library_charges(self):
         """Test assigning charges to parts of a molecule using two library charge lines. Note that these LibraryCharge
         SMIRKS have partial overlap, so this also tests that the hierarchy is correctly obeyed."""
         from simtk.openmm import NonbondedForce
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml', xml_ethanol_library_charges_in_parts_ff)
 
+        ff = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml",
+            xml_ethanol_library_charges_in_parts_ff,
+        )
 
-        molecules = [Molecule.from_file(get_data_file_path('molecules/ethanol.sdf')),
-                     Molecule.from_file(get_data_file_path('molecules/ethanol_reordered.sdf'))]
+        molecules = [
+            Molecule.from_file(get_data_file_path("molecules/ethanol.sdf")),
+            Molecule.from_file(get_data_file_path("molecules/ethanol_reordered.sdf")),
+        ]
         top = Topology.from_molecules(molecules)
         omm_system = ff.create_openmm_system(top)
-        nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
-        expected_charges = [-0.2, -0.1, 0.3, 0.08, -0.02, -0.02, -0.02, -0.01, -0.01, -0.2,
-                            0.3, -0.1, 0.08, -0.02, -0.02, -0.02, -0.01, -0.01] * unit.elementary_charge
+        nonbondedForce = [
+            f for f in omm_system.getForces() if type(f) == NonbondedForce
+        ][0]
+        expected_charges = [
+            -0.2,
+            -0.1,
+            0.3,
+            0.08,
+            -0.02,
+            -0.02,
+            -0.02,
+            -0.01,
+            -0.01,
+            -0.2,
+            0.3,
+            -0.1,
+            0.08,
+            -0.02,
+            -0.02,
+            -0.02,
+            -0.01,
+            -0.01,
+        ] * unit.elementary_charge
         for particle_index, expected_charge in enumerate(expected_charges):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q == expected_charge
@@ -1846,81 +2396,135 @@ class TestForceFieldChargeAssignment:
         """Test assigning charges to parts of a molecule using per-atom library charges. Note that these LibraryCharge
         SMIRKS will match multiple atoms, so this is also a test of correct usage of the parameter hierarchy.."""
         from simtk.openmm import NonbondedForce
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml', xml_ethanol_library_charges_by_atom_ff)
 
-        molecules = [Molecule.from_file(get_data_file_path('molecules/ethanol.sdf')),
-                     Molecule.from_file(get_data_file_path('molecules/ethanol_reordered.sdf'))]
+        ff = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml",
+            xml_ethanol_library_charges_by_atom_ff,
+        )
+
+        molecules = [
+            Molecule.from_file(get_data_file_path("molecules/ethanol.sdf")),
+            Molecule.from_file(get_data_file_path("molecules/ethanol_reordered.sdf")),
+        ]
         top = Topology.from_molecules(molecules)
         omm_system = ff.create_openmm_system(top)
-        nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
-        expected_charges = [-0.2, -0.1, 0.3, 0.08, -0.02, -0.02, -0.02, -0.01, -0.01, -0.2,
-                            0.3, -0.1, 0.08, -0.02, -0.02, -0.02, -0.01, -0.01] * unit.elementary_charge
+        nonbondedForce = [
+            f for f in omm_system.getForces() if type(f) == NonbondedForce
+        ][0]
+        expected_charges = [
+            -0.2,
+            -0.1,
+            0.3,
+            0.08,
+            -0.02,
+            -0.02,
+            -0.02,
+            -0.01,
+            -0.01,
+            -0.2,
+            0.3,
+            -0.1,
+            0.08,
+            -0.02,
+            -0.02,
+            -0.02,
+            -0.01,
+            -0.01,
+        ] * unit.elementary_charge
         for particle_index, expected_charge in enumerate(expected_charges):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q == expected_charge
 
-    def test_library_charges_dont_parameterize_molecule_because_of_incomplete_coverage(self):
+    def test_library_charges_dont_parameterize_molecule_because_of_incomplete_coverage(
+        self,
+    ):
         """Fail to assign charges to a molecule because not all atoms can be assigned"""
         from simtk.openmm import NonbondedForce
-        from openforcefield.typing.engines.smirnoff.parameters import UnassignedMoleculeChargeException
+        from openforcefield.typing.engines.smirnoff.parameters import (
+            UnassignedMoleculeChargeException,
+        )
 
-        molecules = [Molecule.from_file(get_data_file_path('molecules/toluene.sdf'))]
+        molecules = [Molecule.from_file(get_data_file_path("molecules/toluene.sdf"))]
         top = Topology.from_molecules(molecules)
 
         # The library charges in the FF should not be able to fully cover toluene
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml', xml_ethanol_library_charges_by_atom_ff)
+        ff = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml",
+            xml_ethanol_library_charges_by_atom_ff,
+        )
         # Delete the ToolkitAM1BCCHandler so the molecule won't get charges from anywhere
-        del ff._parameter_handlers['ToolkitAM1BCC']
-        with pytest.raises(UnassignedMoleculeChargeException,
-                           match="did not have charges assigned by any ParameterHandler") as excinfo:
+        del ff._parameter_handlers["ToolkitAM1BCC"]
+        with pytest.raises(
+            UnassignedMoleculeChargeException,
+            match="did not have charges assigned by any ParameterHandler",
+        ) as excinfo:
             omm_system = ff.create_openmm_system(top)
 
         # If we do NOT delete the ToolkiAM1BCCHandler, then toluene should be assigned some nonzero partial charges.
         # The exact value will vary by toolkit, so we don't test that here.
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml', xml_ethanol_library_charges_by_atom_ff)
+        ff = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml",
+            xml_ethanol_library_charges_by_atom_ff,
+        )
         omm_system = ff.create_openmm_system(top)
-        nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
+        nonbondedForce = [
+            f for f in omm_system.getForces() if type(f) == NonbondedForce
+        ][0]
         for particle_index in range(top.n_topology_atoms):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q != 0 * unit.elementary_charge
 
-    @pytest.mark.parametrize('charge_method,additional_offxmls', [ ('ToolkitAM1BCC', []),
-                                                                   ('LibraryCharges', [xml_ethanol_library_charges_ff]),
-                                                                   ('ChargeIncrementHandler', [xml_charge_increment_model_formal_charges]),
-                                                                   ('charge_from_molecules', [])])
-    def test_charges_on_ref_mols_when_using_return_topology(self, charge_method, additional_offxmls):
+    @pytest.mark.parametrize(
+        "charge_method,additional_offxmls",
+        [
+            ("ToolkitAM1BCC", []),
+            ("LibraryCharges", [xml_ethanol_library_charges_ff]),
+            ("ChargeIncrementHandler", [xml_charge_increment_model_formal_charges]),
+            ("charge_from_molecules", []),
+        ],
+    )
+    def test_charges_on_ref_mols_when_using_return_topology(
+        self, charge_method, additional_offxmls
+    ):
         """Ensure that charges are set on returned topology if the user specifies 'return_topology=True' in
         create_openmm_system"""
         # TODO: Should this test also cover multiple unique molecules?
         from simtk.openmm import NonbondedForce
 
         mol = create_acetate()
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml', *additional_offxmls)
+        ff = ForceField("test_forcefields/smirnoff99Frosst.offxml", *additional_offxmls)
         charge_mols = []
-        if charge_method == 'charge_from_molecules':
-            mol.partial_charges = np.array([-1.3, -0.2, -0.1, 0., 0.1, 0.2, 0.3]) * unit.elementary_charge
+        if charge_method == "charge_from_molecules":
+            mol.partial_charges = (
+                np.array([-1.3, -0.2, -0.1, 0.0, 0.1, 0.2, 0.3])
+                * unit.elementary_charge
+            )
             charge_mols = [mol]
-        omm_system, ret_top = ff.create_openmm_system(mol.to_topology(),
-                                                      charge_from_molecules=charge_mols,
-                                                      return_topology=True)
-        nonbondedForce = [f for f in omm_system.getForces() if type(f) == NonbondedForce][0]
+        omm_system, ret_top = ff.create_openmm_system(
+            mol.to_topology(), charge_from_molecules=charge_mols, return_topology=True
+        )
+        nonbondedForce = [
+            f for f in omm_system.getForces() if type(f) == NonbondedForce
+        ][0]
         ref_mol_from_ret_top = [i for i in ret_top.reference_molecules][0]
 
         # Make sure the charges on the molecule are all nonzero, and that the molecule's
         # partial_charges array matches the charges in the openmm system
         all_charges_zero = True
-        for particle_index, ref_mol_charge in enumerate(ref_mol_from_ret_top.partial_charges):
+        for particle_index, ref_mol_charge in enumerate(
+            ref_mol_from_ret_top.partial_charges
+        ):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q == ref_mol_charge
-            if q != 0. * unit.elementary_charge:
+            if q != 0.0 * unit.elementary_charge:
                 all_charges_zero = False
-        assert not(all_charges_zero)
+        assert not (all_charges_zero)
 
 
-
-#======================================================================
+# ======================================================================
 # TEST CONSTRAINTS
-#======================================================================
+# ======================================================================
+
 
 class TestForceFieldConstraints:
     """Tests that constraints are correctly applied and behave correctly."""
@@ -1929,42 +2533,39 @@ class TestForceFieldConstraints:
     def check_molecule_constraints(cls, molecule, system, bond_elements, bond_length):
         """Check that the bonds in the molecule is correctly constrained."""
         for constraint_idx in range(system.getNumConstraints()):
-            atom1_idx, atom2_idx, distance = system.getConstraintParameters(constraint_idx)
-            atom_elements = {molecule.atoms[atom1_idx].element.symbol,
-                             molecule.atoms[atom2_idx].element.symbol}
+            atom1_idx, atom2_idx, distance = system.getConstraintParameters(
+                constraint_idx
+            )
+            atom_elements = {
+                molecule.atoms[atom1_idx].element.symbol,
+                molecule.atoms[atom2_idx].element.symbol,
+            }
             assert atom_elements == bond_elements
-            assert np.isclose(distance/unit.angstrom, bond_length/unit.angstrom)
+            assert np.isclose(distance / unit.angstrom, bond_length / unit.angstrom)
 
     def test_constraints_hbonds(self):
         """Test that hydrogen bonds constraints are applied correctly to a ethane molecule."""
         # Parametrize an ethane molecule.
-        ethane = Molecule.from_smiles('CC')
+        ethane = Molecule.from_smiles("CC")
         topology = Topology.from_molecules([ethane])
-        ff = ForceField(XML_FF_GENERICS, 'test_forcefields/old/hbonds.offxml')
+        ff = ForceField(XML_FF_GENERICS, "test_forcefields/old/hbonds.offxml")
         system = ff.create_openmm_system(topology)
 
         # Check that all C-H bonds have been constrained to the FF bond length.
-        self.check_molecule_constraints(ethane, system,
-                                        bond_elements={'C', 'H'},
-                                        bond_length= 1.09 * unit.angstrom)
+        self.check_molecule_constraints(
+            ethane, system, bond_elements={"C", "H"}, bond_length=1.09 * unit.angstrom
+        )
 
 
-#======================================================================
+# ======================================================================
 # TEST PARAMETER ASSIGNMENT
-#======================================================================
+# ======================================================================
+
 
 def generate_alkethoh_parameters_assignment_cases():
     """Create dynamically all test cases that should be ran for the AlkEthOH set."""
     # These AlkEthOH molecules are always run by test_alkethoh_parameters_assignment.
-    fast_test_cases = [
-        'r0',
-        'r12',
-        'r118',
-        'c38',
-        'c100',
-        'c1161',
-        'c1266'
-    ]
+    fast_test_cases = ["r0", "r12", "r118", "c38", "c100", "c1161", "c1266"]
 
     def extract_id(file_path):
         """Extract the AlkEthOH molecule ID from the file path."""
@@ -1974,21 +2575,28 @@ def generate_alkethoh_parameters_assignment_cases():
     # Get all the molecules ids from the tarfiles. The tarball is extracted
     # in conftest.py if slow tests are activated.
     import tarfile
-    alkethoh_tar_file_path = get_data_file_path(os.path.join('molecules', 'AlkEthOH_tripos.tar.gz'))
-    with tarfile.open(alkethoh_tar_file_path, 'r:gz') as tar:
+
+    alkethoh_tar_file_path = get_data_file_path(
+        os.path.join("molecules", "AlkEthOH_tripos.tar.gz")
+    )
+    with tarfile.open(alkethoh_tar_file_path, "r:gz") as tar:
         # Collect all the files discarding the duplicates in the test_filt1 folder.
-        slow_test_cases = {extract_id(m.name) for m in tar.getmembers()
-                           if 'crd' in m.name and 'test_filt1' not in m.name}
+        slow_test_cases = {
+            extract_id(m.name)
+            for m in tar.getmembers()
+            if "crd" in m.name and "test_filt1" not in m.name
+        }
 
     # Remove fast test cases from slow ones to avoid duplicate tests.
     # Remove also water (c1302), which was reparameterized in AlkEthOH
     # to be TIP3P (not covered by Frosst_AlkEthOH_parmAtFrosst.
-    for fast_test_case in fast_test_cases + ['c1302']:
+    for fast_test_case in fast_test_cases + ["c1302"]:
         slow_test_cases.remove(fast_test_case)
 
     # Mark all slow cases as slow.
-    slow_test_cases = [pytest.param(case, marks=pytest.mark.slow)
-                       for case in sorted(slow_test_cases)]
+    slow_test_cases = [
+        pytest.param(case, marks=pytest.mark.slow) for case in sorted(slow_test_cases)
+    ]
 
     # Isolate the AlkEthOH ID.
     return fast_test_cases + slow_test_cases
@@ -2000,45 +2608,54 @@ def generate_freesolv_parameters_assignment_cases():
 
     # For these tests, UndefinedStereochemistryError is ignored.
     # The chirality was manually checked (see issue #175).
-    ignore_undefined_stereo = {
-        '2501588',
-        '3266352',
-        '7829570'
-    }
+    ignore_undefined_stereo = {"2501588", "3266352", "7829570"}
 
     # These molecules are always tested by test_freesolv_parameters_assignment().
     # Each test case is (freesolv_id, force_field_version, allow_undefined_stereo).
     fast_test_cases = [
-        ('1019269', '0_0_4_fixed', False),
-        ('63712', '0_0_2', False),  # The XML was regenerated after fixing the issue described in #179.
-        ('1723043', '0_0_2', False),
-        ('2501588', '0_0_2', True),  # Test impropers and undefined stereochemistry.
-        ('3323117', '0_0_2', False),  # The XML was regenerated after fixing the issue described in #179.
-        ('1107178', '0_0_2', False),  # Molecule with iodine
-        ('1036761', '0_0_2', False),  # Molecule with primary amine
+        ("1019269", "0_0_4_fixed", False),
+        (
+            "63712",
+            "0_0_2",
+            False,
+        ),  # The XML was regenerated after fixing the issue described in #179.
+        ("1723043", "0_0_2", False),
+        ("2501588", "0_0_2", True),  # Test impropers and undefined stereochemistry.
+        (
+            "3323117",
+            "0_0_2",
+            False,
+        ),  # The XML was regenerated after fixing the issue described in #179.
+        ("1107178", "0_0_2", False),  # Molecule with iodine
+        ("1036761", "0_0_2", False),  # Molecule with primary amine
     ]
 
     def extract_id(file_path):
         """Extract the FreeSolv ID and force field version from the file subpath."""
         # An example of file path is FreeSolv/xml_0_0_4_fixed/mobley_7913234_vacuum.xml
-        freesolv_id = os.path.basename(file_path).split('_')[1]
+        freesolv_id = os.path.basename(file_path).split("_")[1]
         force_field_version = os.path.basename(os.path.dirname(file_path))[4:]
         allow_undefined_stereo = freesolv_id in ignore_undefined_stereo
         return (freesolv_id, force_field_version, allow_undefined_stereo)
 
     # Get all the tarball XML files available. The tarball is extracted
     # in conftest.py if slow tests are activated.
-    freesolv_tar_file_path = get_data_file_path(os.path.join('molecules', 'FreeSolv.tar.gz'))
-    with tarfile.open(freesolv_tar_file_path, 'r:gz') as tar:
-        slow_test_cases = {extract_id(m.name) for m in tar.getmembers() if '.xml' in m.name}
+    freesolv_tar_file_path = get_data_file_path(
+        os.path.join("molecules", "FreeSolv.tar.gz")
+    )
+    with tarfile.open(freesolv_tar_file_path, "r:gz") as tar:
+        slow_test_cases = {
+            extract_id(m.name) for m in tar.getmembers() if ".xml" in m.name
+        }
 
     # Remove fast test cases from slow ones to avoid duplicate tests.
     for fast_test_case in fast_test_cases:
         slow_test_cases.remove(fast_test_case)
 
     # Mark all slow cases as slow.
-    slow_test_cases = [pytest.param(*case, marks=pytest.mark.slow)
-                       for case in sorted(slow_test_cases)]
+    slow_test_cases = [
+        pytest.param(*case, marks=pytest.mark.slow) for case in sorted(slow_test_cases)
+    ]
 
     return fast_test_cases + slow_test_cases
 
@@ -2046,9 +2663,13 @@ def generate_freesolv_parameters_assignment_cases():
 class TestForceFieldParameterAssignment:
     """Regression tests checking that parameters are assigned correctly."""
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(),
-                        reason='Test requires OE toolkit to read mol2 files')
-    @pytest.mark.parametrize('alkethoh_id', generate_alkethoh_parameters_assignment_cases())
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(),
+        reason="Test requires OE toolkit to read mol2 files",
+    )
+    @pytest.mark.parametrize(
+        "alkethoh_id", generate_alkethoh_parameters_assignment_cases()
+    )
     def test_alkethoh_parameters_assignment(self, alkethoh_id):
         """Test that ForceField assign parameters correctly in the AlkEthOH set.
         The test compares the System parameters of a AlkEthOH molecule
@@ -2064,28 +2685,40 @@ class TestForceFieldParameterAssignment:
         does the job.
 
         """
-        from openforcefield.tests.utils import get_alkethoh_file_path, compare_amber_smirnoff
+        from openforcefield.tests.utils import (
+            get_alkethoh_file_path,
+            compare_amber_smirnoff,
+        )
 
         # Obtain the path to the input files.
-        alkethoh_name = 'AlkEthOH_' + alkethoh_id
-        mol2_filepath, top_filepath, crd_filepath = get_alkethoh_file_path(alkethoh_name, get_amber=True)
+        alkethoh_name = "AlkEthOH_" + alkethoh_id
+        mol2_filepath, top_filepath, crd_filepath = get_alkethoh_file_path(
+            alkethoh_name, get_amber=True
+        )
 
         # Load molecule.
         molecule = Molecule.from_file(mol2_filepath)
 
         # Load forcefield
-        forcefield = ForceField('test_forcefields/Frosst_AlkEthOH_parmAtFrosst.offxml')
+        forcefield = ForceField("test_forcefields/Frosst_AlkEthOH_parmAtFrosst.offxml")
 
         # Compare parameters. Skip the energy checks as the parameter check should be
         # sufficient. We test both energies and parameters in the slow test.
         # We ignore the charges for now as they are not included in the force field.
         # TODO: Reactivate the charge check when we'll be able to load charges from files.
-        compare_amber_smirnoff(top_filepath, crd_filepath, forcefield, molecule,
-                               check_energies=False, ignore_charges=True)
+        compare_amber_smirnoff(
+            top_filepath,
+            crd_filepath,
+            forcefield,
+            molecule,
+            check_energies=False,
+            ignore_charges=True,
+        )
 
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(),
-                        reason='Test requires OE toolkit to read mol2 files')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(),
+        reason="Test requires OE toolkit to read mol2 files",
+    )
     def test_multi_alkethoh_parameters_assignment(self):
         """Test that systems with multiple reference molecules are parametrized correctly.
 
@@ -2096,109 +2729,157 @@ class TestForceFieldParameterAssignment:
 
         """
         import parmed
-        from openforcefield.tests.utils import (get_alkethoh_file_path,
-                                                compare_system_parameters,
-                                                compare_system_energies)
+        from openforcefield.tests.utils import (
+            get_alkethoh_file_path,
+            compare_system_parameters,
+            compare_system_energies,
+        )
 
         # The AlkEthOH molecule ids to mix in the systems.
-        alketoh_ids = ['r0', 'c38', 'c1161']
+        alketoh_ids = ["r0", "c38", "c1161"]
 
         # Load molecules and structures.
         molecules = []
         structures = []
         for alkethoh_id in alketoh_ids:
             mol2_filepath, top_filepath, crd_filepath = get_alkethoh_file_path(
-                'AlkEthOH_'+alkethoh_id, get_amber=True)
+                "AlkEthOH_" + alkethoh_id, get_amber=True
+            )
             molecules.append(Molecule.from_file(mol2_filepath))
             amber_parm = parmed.load_file(top_filepath, crd_filepath)
             # Convert this into a real structure as mixing AmberParm objects is bugged (see ParmEd#1045).
             structures.append(amber_parm.copy(parmed.Structure))
 
         # Merge the structures into a single system with two copies of the last molecule.
-        structure_mixture = structures[0] + structures[1] + structures[2] + structures[-1]
-        amber_system = structure_mixture.createSystem(nonbondedMethod=openmm.app.NoCutoff)
+        structure_mixture = (
+            structures[0] + structures[1] + structures[2] + structures[-1]
+        )
+        amber_system = structure_mixture.createSystem(
+            nonbondedMethod=openmm.app.NoCutoff
+        )
 
         # Create the OpenFF System through ForceField.
-        topology = Topology.from_openmm(structure_mixture.topology, unique_molecules=molecules)
+        topology = Topology.from_openmm(
+            structure_mixture.topology, unique_molecules=molecules
+        )
         topology.box_vectors = None
-        ff = ForceField('test_forcefields/Frosst_AlkEthOH_parmAtFrosst.offxml')
+        ff = ForceField("test_forcefields/Frosst_AlkEthOH_parmAtFrosst.offxml")
         off_system = ff.create_openmm_system(topology)
 
         # Translate the molecules a little to avoid overlapping atoms.
         positions = copy.deepcopy(structure_mixture.positions)
         translate_vectors = [
-            np.array([1.0, 0.0, 0.0])*unit.nanometer,
-            np.array([0.0, 1.0, 0.0])*unit.nanometer,
-            np.array([0.0, 0.0, 1.0])*unit.nanometer,
+            np.array([1.0, 0.0, 0.0]) * unit.nanometer,
+            np.array([0.0, 1.0, 0.0]) * unit.nanometer,
+            np.array([0.0, 0.0, 1.0]) * unit.nanometer,
             # Leave the fourth molecule where it is.
         ]
         current_atom_idx = 0
-        for mol_idx, (translate_vector, mol) in enumerate(zip(translate_vectors, molecules)):
+        for mol_idx, (translate_vector, mol) in enumerate(
+            zip(translate_vectors, molecules)
+        ):
             n_mol_atoms = len(mol.atoms)
-            positions[current_atom_idx:current_atom_idx+n_mol_atoms] += translate_vector
+            positions[
+                current_atom_idx : current_atom_idx + n_mol_atoms
+            ] += translate_vector
             current_atom_idx += n_mol_atoms
 
         # Compare parameters and systems.
         # TODO: Reactivate charges comparison when we'll be able to read them from the file.
-        compare_system_parameters(amber_system, off_system,
-                                  systems_labels=('AMBER', 'SMIRNOFF'),
-                                  ignore_charges=True)
-        compare_system_energies(amber_system, off_system, positions,
-                                ignore_charges=True)
+        compare_system_parameters(
+            amber_system,
+            off_system,
+            systems_labels=("AMBER", "SMIRNOFF"),
+            ignore_charges=True,
+        )
+        compare_system_energies(
+            amber_system, off_system, positions, ignore_charges=True
+        )
 
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(),
-                        reason='Test requires OE toolkit to read mol2 files')
-    @pytest.mark.parametrize(('freesolv_id', 'forcefield_version', 'allow_undefined_stereo'),
-                             generate_freesolv_parameters_assignment_cases())
-    def test_freesolv_parameters_assignment(self, freesolv_id, forcefield_version, allow_undefined_stereo):
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(),
+        reason="Test requires OE toolkit to read mol2 files",
+    )
+    @pytest.mark.parametrize(
+        ("freesolv_id", "forcefield_version", "allow_undefined_stereo"),
+        generate_freesolv_parameters_assignment_cases(),
+    )
+    def test_freesolv_parameters_assignment(
+        self, freesolv_id, forcefield_version, allow_undefined_stereo
+    ):
         """Regression test on parameters assignment based on the FreeSolv set used in the 0.1 paper.
 
         This, contrarily to the similar AlkEthOH test, checks also constraints
         and improper torsions.
 
         """
-        from openforcefield.tests.utils import get_freesolv_file_path, compare_system_parameters
-        mol2_file_path, xml_file_path = get_freesolv_file_path(freesolv_id, forcefield_version)
+        from openforcefield.tests.utils import (
+            get_freesolv_file_path,
+            compare_system_parameters,
+        )
+
+        mol2_file_path, xml_file_path = get_freesolv_file_path(
+            freesolv_id, forcefield_version
+        )
 
         # Load molecules.
-        molecule = Molecule.from_file(mol2_file_path, allow_undefined_stereo=allow_undefined_stereo)
+        molecule = Molecule.from_file(
+            mol2_file_path, allow_undefined_stereo=allow_undefined_stereo
+        )
 
         # Create OpenFF System with the current toolkit.
-        forcefield_file_path = 'test_forcefields/old/test_ff_' + forcefield_version + '_spec_0_2.offxml'
-        ff = ForceField(forcefield_file_path, 'test_forcefields/old/hbonds.offxml')
+        forcefield_file_path = (
+            "test_forcefields/old/test_ff_" + forcefield_version + "_spec_0_2.offxml"
+        )
+        ff = ForceField(forcefield_file_path, "test_forcefields/old/hbonds.offxml")
         ff_system = ff.create_openmm_system(molecule.to_topology())
 
         # Load OpenMM System created with the 0.1 version of the toolkit.
         from simtk import openmm
-        with open(xml_file_path, 'r') as f:
+
+        with open(xml_file_path, "r") as f:
             xml_system = openmm.XmlSerializer.deserialize(f.read())
 
         # Compare parameters. We ignore the improper folds as in 0.0.3 we
         # used a six-fold implementation while we now use a three-fold way.
         # TODO: Reactivate charge comparison once we'll be able to read them from file.
-        compare_system_parameters(ff_system, xml_system,
-                                  systems_labels=('current OpenFF', 'SMIRNOFF 0.0.4'),
-                                  ignore_charges=True, ignore_improper_folds=True)
+        compare_system_parameters(
+            ff_system,
+            xml_system,
+            systems_labels=("current OpenFF", "SMIRNOFF 0.0.4"),
+            ignore_charges=True,
+            ignore_improper_folds=True,
+        )
 
-
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(),
-                        reason='Test requires OE toolkit to read mol2 files')
-    @pytest.mark.parametrize(('is_periodic'), (False, True))
-    @pytest.mark.parametrize(('gbsa_model'), ['HCT', 'OBC1', 'OBC2'])
-    @pytest.mark.parametrize(('freesolv_id', 'forcefield_version', 'allow_undefined_stereo'),
-                             generate_freesolv_parameters_assignment_cases())
-    def test_freesolv_gbsa_energies(self, gbsa_model, is_periodic, freesolv_id, forcefield_version, allow_undefined_stereo):
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(),
+        reason="Test requires OE toolkit to read mol2 files",
+    )
+    @pytest.mark.parametrize(("is_periodic"), (False, True))
+    @pytest.mark.parametrize(("gbsa_model"), ["HCT", "OBC1", "OBC2"])
+    @pytest.mark.parametrize(
+        ("freesolv_id", "forcefield_version", "allow_undefined_stereo"),
+        generate_freesolv_parameters_assignment_cases(),
+    )
+    def test_freesolv_gbsa_energies(
+        self,
+        gbsa_model,
+        is_periodic,
+        freesolv_id,
+        forcefield_version,
+        allow_undefined_stereo,
+    ):
         """
         Regression test on HCT, OBC1, and OBC2 GBSA models. This test ensures that the
         SMIRNOFF-based GBSA models match the equivalent OpenMM implementations.
         """
 
-        from openforcefield.tests.utils import (get_freesolv_file_path,
-                                                compare_system_energies, create_system_from_amber,
-                                                get_context_potential_energy
-                                                )
+        from openforcefield.tests.utils import (
+            get_freesolv_file_path,
+            compare_system_energies,
+            create_system_from_amber,
+            get_context_potential_energy,
+        )
         import parmed as pmd
         from simtk import openmm
         from simtk.openmm import Platform
@@ -2206,44 +2887,57 @@ class TestForceFieldParameterAssignment:
         mol2_file_path, _ = get_freesolv_file_path(freesolv_id, forcefield_version)
 
         # Load molecules.
-        molecule = Molecule.from_file(mol2_file_path, allow_undefined_stereo=allow_undefined_stereo)
+        molecule = Molecule.from_file(
+            mol2_file_path, allow_undefined_stereo=allow_undefined_stereo
+        )
 
         # Give each atom a unique name, otherwise OpenMM will complain
         for idx, atom in enumerate(molecule.atoms):
-            atom.name = f'{atom.element.symbol}{idx}'
+            atom.name = f"{atom.element.symbol}{idx}"
         positions = molecule.conformers[0]
 
-        off_gbsas  = {'HCT': 'test_forcefields/GBSA_HCT-1.0.offxml',
-                      'OBC1': 'test_forcefields/GBSA_OBC1-1.0.offxml',
-                      'OBC2': 'test_forcefields/GBSA_OBC2-1.0.offxml'
-                      }
+        off_gbsas = {
+            "HCT": "test_forcefields/GBSA_HCT-1.0.offxml",
+            "OBC1": "test_forcefields/GBSA_OBC1-1.0.offxml",
+            "OBC2": "test_forcefields/GBSA_OBC2-1.0.offxml",
+        }
         # Create OpenFF System with the current toolkit.
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml',
-                        off_gbsas[gbsa_model])
+        ff = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml", off_gbsas[gbsa_model]
+        )
         off_top = molecule.to_topology()
         if is_periodic:
-            off_top.box_vectors = ((30., 0, 0), (0, 30., 0), (0, 0, 30.)) * unit.angstrom
+            off_top.box_vectors = (
+                (30.0, 0, 0),
+                (0, 30.0, 0),
+                (0, 0, 30.0),
+            ) * unit.angstrom
 
         else:
             off_top.box_vectors = None
 
-        off_omm_system = ff.create_openmm_system(off_top, charge_from_molecules=[molecule])
+        off_omm_system = ff.create_openmm_system(
+            off_top, charge_from_molecules=[molecule]
+        )
 
-        off_nonbonded_force = [force for force in off_omm_system.getForces() if
-                               isinstance(force, openmm.NonbondedForce)][0]
-
+        off_nonbonded_force = [
+            force
+            for force in off_omm_system.getForces()
+            if isinstance(force, openmm.NonbondedForce)
+        ][0]
 
         omm_top = off_top.to_openmm()
         pmd_struct = pmd.openmm.load_topology(omm_top, off_omm_system, positions)
-        prmtop_file = NamedTemporaryFile(suffix='.prmtop')
-        inpcrd_file = NamedTemporaryFile(suffix='.inpcrd')
+        prmtop_file = NamedTemporaryFile(suffix=".prmtop")
+        inpcrd_file = NamedTemporaryFile(suffix=".inpcrd")
         pmd_struct.save(prmtop_file.name, overwrite=True)
         pmd_struct.save(inpcrd_file.name, overwrite=True)
 
-        openmm_gbsas = {'HCT': openmm.app.HCT,
-                        'OBC1': openmm.app.OBC1,
-                        'OBC2': openmm.app.OBC2,
-                        }
+        openmm_gbsas = {
+            "HCT": openmm.app.HCT,
+            "OBC1": openmm.app.OBC1,
+            "OBC2": openmm.app.OBC2,
+        }
 
         # The functional form of the nonbonded force will change depending on whether the cutoff
         # is None during initialization. Therefore, we need to figure that out here.
@@ -2259,36 +2953,55 @@ class TestForceFieldParameterAssignment:
             amber_nb_method = openmm.app.forcefield.NoCutoff
             amber_cutoff = None
 
-        (amber_omm_system,
-         amber_omm_topology,
-         amber_positions) = create_system_from_amber(prmtop_file.name,
-                                                     inpcrd_file.name,
-                                                     implicitSolvent=openmm_gbsas[gbsa_model],
-                                                     nonbondedMethod=amber_nb_method,
-                                                     nonbondedCutoff=amber_cutoff,
-                                                     gbsaModel='ACE',
-                                                     implicitSolventKappa=0.,
-                                                     )
+        (
+            amber_omm_system,
+            amber_omm_topology,
+            amber_positions,
+        ) = create_system_from_amber(
+            prmtop_file.name,
+            inpcrd_file.name,
+            implicitSolvent=openmm_gbsas[gbsa_model],
+            nonbondedMethod=amber_nb_method,
+            nonbondedCutoff=amber_cutoff,
+            gbsaModel="ACE",
+            implicitSolventKappa=0.0,
+        )
 
         # Retrieve the GBSAForce from both the AMBER and OpenForceField systems
-        off_gbsa_forces = [force for force in off_omm_system.getForces() if
-                              (isinstance(force, openmm.GBSAOBCForce) or
-                               isinstance(force, openmm.openmm.CustomGBForce))]
+        off_gbsa_forces = [
+            force
+            for force in off_omm_system.getForces()
+            if (
+                isinstance(force, openmm.GBSAOBCForce)
+                or isinstance(force, openmm.openmm.CustomGBForce)
+            )
+        ]
         assert len(off_gbsa_forces) == 1
         off_gbsa_force = off_gbsa_forces[0]
-        amber_gbsa_forces = [force for force in amber_omm_system.getForces() if
-                                 (isinstance(force, openmm.GBSAOBCForce) or
-                                  isinstance(force, openmm.openmm.CustomGBForce))]
+        amber_gbsa_forces = [
+            force
+            for force in amber_omm_system.getForces()
+            if (
+                isinstance(force, openmm.GBSAOBCForce)
+                or isinstance(force, openmm.openmm.CustomGBForce)
+            )
+        ]
         assert len(amber_gbsa_forces) == 1
         amber_gbsa_force = amber_gbsa_forces[0]
 
         # We get radius and screen values from each model's getStandardParameters method
-        if gbsa_model == 'HCT':
-            gb_params = openmm.app.internal.customgbforces.GBSAHCTForce.getStandardParameters(omm_top)
-        elif gbsa_model == 'OBC1':
-            gb_params = openmm.app.internal.customgbforces.GBSAOBC1Force.getStandardParameters(omm_top)
-        elif gbsa_model == 'OBC2':
-            gb_params = openmm.app.internal.customgbforces.GBSAOBC2Force.getStandardParameters(omm_top)
+        if gbsa_model == "HCT":
+            gb_params = openmm.app.internal.customgbforces.GBSAHCTForce.getStandardParameters(
+                omm_top
+            )
+        elif gbsa_model == "OBC1":
+            gb_params = openmm.app.internal.customgbforces.GBSAOBC1Force.getStandardParameters(
+                omm_top
+            )
+        elif gbsa_model == "OBC2":
+            gb_params = openmm.app.internal.customgbforces.GBSAOBC2Force.getStandardParameters(
+                omm_top
+            )
 
         # Use GB params from OpenMM GBSA classes to populate parameters
         for idx, (radius, screen) in enumerate(gb_params):
@@ -2305,8 +3018,9 @@ class TestForceFieldParameterAssignment:
                 # setParticleParameters, we have to apply the offset and scale BEFORE setting
                 # parameters, whereas in addParticle, it is applied afterwards, and the particle
                 # parameters are not set until an auxillary finalize() method is called. !!!
-                amber_gbsa_force.setParticleParameters(idx, (q, radius - 0.009, screen * (radius - 0.009)))
-
+                amber_gbsa_force.setParticleParameters(
+                    idx, (q, radius - 0.009, screen * (radius - 0.009))
+                )
 
         # Put the GBSA force into a separate group so we can specifically compare GBSA energies
         amber_gbsa_force.setForceGroup(1)
@@ -2322,13 +3036,15 @@ class TestForceFieldParameterAssignment:
 
         # Not sure if zeroing the switching width is essential -- This might only make a difference
         # in the energy if we tested on a molecule larger than the 9A cutoff
-        #off_nonbonded_force.setSwitchingDistance(0)
+        # off_nonbonded_force.setSwitchingDistance(0)
 
         # Create Contexts
         integrator = openmm.VerletIntegrator(1.0 * unit.femtoseconds)
-        platform = Platform.getPlatformByName('Reference')
+        platform = Platform.getPlatformByName("Reference")
         amber_context = openmm.Context(amber_omm_system, integrator, platform)
-        off_context = openmm.Context(off_omm_system, copy.deepcopy(integrator), platform)
+        off_context = openmm.Context(
+            off_omm_system, copy.deepcopy(integrator), platform
+        )
 
         # Get context energies
         amber_energy = get_context_potential_energy(amber_context, positions)
@@ -2338,97 +3054,134 @@ class TestForceFieldParameterAssignment:
         # print(openmm.XmlSerializer.serialize(off_gbsa_force))
         # print(openmm.XmlSerializer.serialize(amber_gbsa_force))
 
-
         # Ensure that the GBSA energies (which we put into ForceGroup 1) are identical
         # For Platform=OpenCL, we do get "=="-level identical numbers, but for "Reference", we don't.
-        #assert amber_energy[1] == off_energy[1]
-        assert abs(amber_energy[1] - off_energy[1]) < 1e-5 * unit.kilojoule/unit.mole
+        # assert amber_energy[1] == off_energy[1]
+        assert abs(amber_energy[1] - off_energy[1]) < 1e-5 * unit.kilojoule / unit.mole
 
         # Ensure that all system energies are the same
-        compare_system_energies(off_omm_system, amber_omm_system, positions, by_force_type=False)
+        compare_system_energies(
+            off_omm_system, amber_omm_system, positions, by_force_type=False
+        )
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(),
-                        reason='Test requires OE toolkit to read mol2 files')
-    @pytest.mark.parametrize('zero_charges', [True, False])
-    @pytest.mark.parametrize(('gbsa_model'), ['HCT', 'OBC1', 'OBC2'])
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(),
+        reason="Test requires OE toolkit to read mol2 files",
+    )
+    @pytest.mark.parametrize("zero_charges", [True, False])
+    @pytest.mark.parametrize(("gbsa_model"), ["HCT", "OBC1", "OBC2"])
     def test_molecule_energy_gb_no_sa(self, zero_charges, gbsa_model):
         """Test creating a GBSA system without a surface energy term, and validate its energy
         against the same system made using OpenMM's AMBER GBSA functionality"""
-        from openforcefield.tests.utils import (compare_system_energies, create_system_from_amber,
-                                                get_context_potential_energy
-                                                )
+        from openforcefield.tests.utils import (
+            compare_system_energies,
+            create_system_from_amber,
+            get_context_potential_energy,
+        )
         import parmed as pmd
         from simtk import openmm
         from simtk.openmm import Platform
         import numpy as np
 
         # Load an arbitrary molecule from the freesolv set
-        molecule = Molecule.from_file(get_data_file_path('molecules/FreeSolv/mol2files_sybyl/mobley_1036761.mol2'))
+        molecule = Molecule.from_file(
+            get_data_file_path("molecules/FreeSolv/mol2files_sybyl/mobley_1036761.mol2")
+        )
 
-        molecule.name = 'mobley_1036761' # Name the molecule, otherwise OpenMM will complain
+        molecule.name = (
+            "mobley_1036761"  # Name the molecule, otherwise OpenMM will complain
+        )
         if zero_charges:
-            molecule.partial_charges = np.zeros(molecule.n_atoms) * unit.elementary_charge
+            molecule.partial_charges = (
+                np.zeros(molecule.n_atoms) * unit.elementary_charge
+            )
 
         # Give each atom a unique name, otherwise OpenMM will complain
         for idx, atom in enumerate(molecule.atoms):
-            atom.name = f'{atom.element.symbol}{idx}'
+            atom.name = f"{atom.element.symbol}{idx}"
 
-        positions = np.concatenate((molecule.conformers[0], molecule.conformers[0] + (10 * unit.angstrom)))
+        positions = np.concatenate(
+            (molecule.conformers[0], molecule.conformers[0] + (10 * unit.angstrom))
+        )
         # Create OpenFF System with the current toolkit.
 
-        off_gbsas  = {'HCT': 'test_forcefields/GBSA_HCT-1.0.offxml',
-                      'OBC1': 'test_forcefields/GBSA_OBC1-1.0.offxml',
-                      'OBC2': 'test_forcefields/GBSA_OBC2-1.0.offxml'
-                      }
+        off_gbsas = {
+            "HCT": "test_forcefields/GBSA_HCT-1.0.offxml",
+            "OBC1": "test_forcefields/GBSA_OBC1-1.0.offxml",
+            "OBC2": "test_forcefields/GBSA_OBC2-1.0.offxml",
+        }
 
-        ff = ForceField('test_forcefields/smirnoff99Frosst.offxml',
-                        off_gbsas[gbsa_model])
-        ff.get_parameter_handler('GBSA').sa_model = None
+        ff = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml", off_gbsas[gbsa_model]
+        )
+        ff.get_parameter_handler("GBSA").sa_model = None
         off_top = Topology.from_molecules([molecule, molecule])
-        off_omm_system = ff.create_openmm_system(off_top, charge_from_molecules=[molecule])
+        off_omm_system = ff.create_openmm_system(
+            off_top, charge_from_molecules=[molecule]
+        )
 
         omm_top = off_top.to_openmm()
         pmd_struct = pmd.openmm.load_topology(omm_top, off_omm_system, positions)
-        prmtop_file = NamedTemporaryFile(suffix='.prmtop')
-        inpcrd_file = NamedTemporaryFile(suffix='.inpcrd')
+        prmtop_file = NamedTemporaryFile(suffix=".prmtop")
+        inpcrd_file = NamedTemporaryFile(suffix=".inpcrd")
         pmd_struct.save(prmtop_file.name, overwrite=True)
         pmd_struct.save(inpcrd_file.name, overwrite=True)
 
-        openmm_gbsas = {'HCT': openmm.app.HCT,
-                        'OBC1': openmm.app.OBC1,
-                        'OBC2': openmm.app.OBC2,
-                        }
+        openmm_gbsas = {
+            "HCT": openmm.app.HCT,
+            "OBC1": openmm.app.OBC1,
+            "OBC2": openmm.app.OBC2,
+        }
 
-        (amber_omm_system,
-         amber_omm_topology,
-         amber_positions) = create_system_from_amber(prmtop_file.name,
-                                                     inpcrd_file.name,
-                                                     implicitSolvent=openmm_gbsas[gbsa_model],
-                                                     nonbondedMethod = openmm.app.forcefield.NoCutoff,
-                                                     nonbondedCutoff=None,
-                                                     gbsaModel=None,
-                                                     implicitSolventKappa=0.,
-                                                     )
+        (
+            amber_omm_system,
+            amber_omm_topology,
+            amber_positions,
+        ) = create_system_from_amber(
+            prmtop_file.name,
+            inpcrd_file.name,
+            implicitSolvent=openmm_gbsas[gbsa_model],
+            nonbondedMethod=openmm.app.forcefield.NoCutoff,
+            nonbondedCutoff=None,
+            gbsaModel=None,
+            implicitSolventKappa=0.0,
+        )
 
         # Retrieve the GBSAForce from both the AMBER and OpenForceField systems
-        off_gbsa_forces = [force for force in off_omm_system.getForces() if
-                              (isinstance(force, openmm.GBSAOBCForce) or
-                               isinstance(force, openmm.openmm.CustomGBForce))]
+        off_gbsa_forces = [
+            force
+            for force in off_omm_system.getForces()
+            if (
+                isinstance(force, openmm.GBSAOBCForce)
+                or isinstance(force, openmm.openmm.CustomGBForce)
+            )
+        ]
         assert len(off_gbsa_forces) == 1
         off_gbsa_force = off_gbsa_forces[0]
-        amber_gbsa_forces = [force for force in amber_omm_system.getForces() if
-                                 (isinstance(force, openmm.GBSAOBCForce) or
-                                  isinstance(force, openmm.openmm.CustomGBForce))]
+        amber_gbsa_forces = [
+            force
+            for force in amber_omm_system.getForces()
+            if (
+                isinstance(force, openmm.GBSAOBCForce)
+                or isinstance(force, openmm.openmm.CustomGBForce)
+            )
+        ]
         assert len(amber_gbsa_forces) == 1
         amber_gbsa_force = amber_gbsa_forces[0]
 
         # We get radius and screen values from each model's getStandardParameters method
-        if gbsa_model == 'HCT':
-            gb_params = openmm.app.internal.customgbforces.GBSAHCTForce.getStandardParameters(omm_top)
-        elif gbsa_model == 'OBC1':
-            gb_params = openmm.app.internal.customgbforces.GBSAOBC1Force.getStandardParameters(omm_top)
-        elif gbsa_model == 'OBC2':
-            gb_params = openmm.app.internal.customgbforces.GBSAOBC2Force.getStandardParameters(omm_top)
+        if gbsa_model == "HCT":
+            gb_params = openmm.app.internal.customgbforces.GBSAHCTForce.getStandardParameters(
+                omm_top
+            )
+        elif gbsa_model == "OBC1":
+            gb_params = openmm.app.internal.customgbforces.GBSAOBC1Force.getStandardParameters(
+                omm_top
+            )
+        elif gbsa_model == "OBC2":
+            gb_params = openmm.app.internal.customgbforces.GBSAOBC2Force.getStandardParameters(
+                omm_top
+            )
             # This is only necessary until https://github.com/openmm/openmm/pull/2362 is bundled into a conda release
             amber_gbsa_force.setSurfaceAreaEnergy(0)
 
@@ -2448,18 +3201,21 @@ class TestForceFieldParameterAssignment:
                 # setParticleParameters, we have to apply the offset and scale BEFORE setting
                 # parameters, whereas in addParticle, it is applied afterwards, and the particle
                 # parameters are not set until an auxillary finalize() method is called. !!!
-                amber_gbsa_force.setParticleParameters(idx, (q, radius - 0.009, screen * (radius - 0.009)))
+                amber_gbsa_force.setParticleParameters(
+                    idx, (q, radius - 0.009, screen * (radius - 0.009))
+                )
 
         # Put the GBSA force into a separate group so we can specifically compare GBSA energies
         amber_gbsa_force.setForceGroup(1)
         off_gbsa_force.setForceGroup(1)
 
-
         # Create Contexts
         integrator = openmm.VerletIntegrator(1.0 * unit.femtoseconds)
-        platform = Platform.getPlatformByName('Reference')
+        platform = Platform.getPlatformByName("Reference")
         amber_context = openmm.Context(amber_omm_system, integrator, platform)
-        off_context = openmm.Context(off_omm_system, copy.deepcopy(integrator), platform)
+        off_context = openmm.Context(
+            off_omm_system, copy.deepcopy(integrator), platform
+        )
 
         # Get context energies
         amber_energy = get_context_potential_energy(amber_context, positions)
@@ -2471,63 +3227,79 @@ class TestForceFieldParameterAssignment:
 
         # Ensure that the GBSA energies (which we put into ForceGroup 1) are identical
         # For Platform=OpenCL, we do get "=="-level identical numbers, but for "Reference", we don't.
-        #assert amber_energy[1] == off_energy[1]
-        assert abs(amber_energy[1] - off_energy[1]) < 1e-5 * unit.kilojoule/unit.mole
+        # assert amber_energy[1] == off_energy[1]
+        assert abs(amber_energy[1] - off_energy[1]) < 1e-5 * unit.kilojoule / unit.mole
 
         # If charges are zero, the GB energy component should be 0, so the total GBSA energy should be 0
         if zero_charges:
-            assert amber_energy[1] == 0. * unit.kilojoule / unit.mole
+            assert amber_energy[1] == 0.0 * unit.kilojoule / unit.mole
         else:
-            assert amber_energy[1] != 0. * unit.kilojoule / unit.mole
+            assert amber_energy[1] != 0.0 * unit.kilojoule / unit.mole
 
         # Ensure that all system energies are the same
-        compare_system_energies(off_omm_system, amber_omm_system, positions, by_force_type=False)
+        compare_system_energies(
+            off_omm_system, amber_omm_system, positions, by_force_type=False
+        )
 
     @pytest.mark.slow
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(),
-                        reason='Test requires OE toolkit to read mol2 files')
-    @pytest.mark.parametrize("toolkit_registry,registry_description", toolkit_registries)
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(),
+        reason="Test requires OE toolkit to read mol2 files",
+    )
+    @pytest.mark.parametrize(
+        "toolkit_registry,registry_description", toolkit_registries
+    )
     def test_parameterize_protein(self, toolkit_registry, registry_description):
         """Test that ForceField assigns parameters correctly for a protein
         """
 
-        mol_path = get_data_file_path('proteins/T4-protein.mol2')
+        mol_path = get_data_file_path("proteins/T4-protein.mol2")
         molecule = Molecule.from_file(mol_path, allow_undefined_stereo=False)
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
+        forcefield = ForceField("test_forcefields/smirnoff99Frosst.offxml")
         topology = Topology.from_molecules(molecule)
 
-
         labels = forcefield.label_molecules(topology)[0]
-        assert len(labels["Bonds"]) ==            2654
-        assert len(labels["Angles"]) ==           4789
-        assert len(labels["ProperTorsions"]) ==   6973
+        assert len(labels["Bonds"]) == 2654
+        assert len(labels["Angles"]) == 4789
+        assert len(labels["ProperTorsions"]) == 6973
         assert len(labels["ImproperTorsions"]) == 528
 
         fn = forcefield.create_openmm_system
-        omm_system = fn(topology,
-                        charge_from_molecules=[molecule],
-                        toolkit_registry=toolkit_registry,
-                        allow_nonintegral_charges=False)
+        omm_system = fn(
+            topology,
+            charge_from_molecules=[molecule],
+            toolkit_registry=toolkit_registry,
+            allow_nonintegral_charges=False,
+        )
 
     @pytest.mark.parametrize(
-            ('get_molecule', 'k_interpolated', 'central_atoms'),
-            [(create_ethanol, 4.953856, (1, 2)), (create_reversed_ethanol, 4.953856, (7, 6))])
+        ("get_molecule", "k_interpolated", "central_atoms"),
+        [
+            (create_ethanol, 4.953856, (1, 2)),
+            (create_reversed_ethanol, 4.953856, (7, 6)),
+        ],
+    )
     def test_fractional_bondorder(self, get_molecule, k_interpolated, central_atoms):
         """Test the fractional bond orders are used to interpolate k values as we expect"""
 
         mol = get_molecule()
 
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml',
-                                xml_ff_torsion_bo)
+        forcefield = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml", xml_ff_torsion_bo
+        )
         topology = Topology.from_molecules(mol)
 
         omm_system = forcefield.create_openmm_system(
-                topology,
-                charge_from_molecules=[mol],
-                partial_bond_orders_from_molecules=[mol])
+            topology,
+            charge_from_molecules=[mol],
+            partial_bond_orders_from_molecules=[mol],
+        )
 
-        off_torsion_force = [force for force in omm_system.getForces() if
-                               isinstance(force, openmm.PeriodicTorsionForce)][0]
+        off_torsion_force = [
+            force
+            for force in omm_system.getForces()
+            if isinstance(force, openmm.PeriodicTorsionForce)
+        ][0]
 
         for idx in range(off_torsion_force.getNumTorsions()):
             params = off_torsion_force.getTorsionParameters(idx)
@@ -2535,10 +3307,11 @@ class TestForceFieldParameterAssignment:
             atom2, atom3 = params[1], params[2]
             atom2_mol, atom3_mol = central_atoms
 
-            if (((atom2 == atom2_mol) and (atom3 == atom3_mol)) or
-                    ((atom2 == atom3_mol) and (atom3 == atom2_mol))):
+            if ((atom2 == atom2_mol) and (atom3 == atom3_mol)) or (
+                (atom2 == atom3_mol) and (atom3 == atom2_mol)
+            ):
                 k = params[-1]
-                assert_almost_equal(k/k.unit, k_interpolated)
+                assert_almost_equal(k / k.unit, k_interpolated)
 
     def test_fractional_bondorder_multiple_same_mol(self):
         """Check that an error is thrown when essentially the same molecule is entered more than once
@@ -2547,20 +3320,25 @@ class TestForceFieldParameterAssignment:
         mol = create_ethanol()
         mol2 = create_reversed_ethanol()
 
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml',
-                                xml_ff_torsion_bo)
+        forcefield = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml", xml_ff_torsion_bo
+        )
         topology = Topology.from_molecules([mol, mol2])
 
         with pytest.raises(ValueError):
             omm_system = forcefield.create_openmm_system(
-                    topology,
-                    charge_from_molecules=[mol],
-                    partial_bond_orders_from_molecules=[mol, mol2])
+                topology,
+                charge_from_molecules=[mol],
+                partial_bond_orders_from_molecules=[mol, mol2],
+            )
 
     @pytest.mark.parametrize(
-            ('get_molecule', 'central_atoms'),
-            [(create_ethanol, (1, 2)), (create_reversed_ethanol, (7, 6))])
-    def test_fractional_bondorder_superseded_by_standard_torsion(self, get_molecule, central_atoms):
+        ("get_molecule", "central_atoms"),
+        [(create_ethanol, (1, 2)), (create_reversed_ethanol, (7, 6))],
+    )
+    def test_fractional_bondorder_superseded_by_standard_torsion(
+        self, get_molecule, central_atoms
+    ):
         """Test that matching rules are still respected with fractional bondorder parameters.
 
         We check here that a standard torsion parameter can still get priority on a match
@@ -2569,17 +3347,23 @@ class TestForceFieldParameterAssignment:
 
         mol = get_molecule()
 
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml',
-                                xml_ff_torsion_bo_standard_supersede)
+        forcefield = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml",
+            xml_ff_torsion_bo_standard_supersede,
+        )
         topology = Topology.from_molecules([mol])
 
         omm_system = forcefield.create_openmm_system(
-                topology,
-                charge_from_molecules=[mol],
-                partial_bond_orders_from_molecules=[mol])
+            topology,
+            charge_from_molecules=[mol],
+            partial_bond_orders_from_molecules=[mol],
+        )
 
-        off_torsion_force = [force for force in omm_system.getForces() if
-                               isinstance(force, openmm.PeriodicTorsionForce)][0]
+        off_torsion_force = [
+            force
+            for force in omm_system.getForces()
+            if isinstance(force, openmm.PeriodicTorsionForce)
+        ][0]
 
         for idx in range(off_torsion_force.getNumTorsions()):
             params = off_torsion_force.getTorsionParameters(idx)
@@ -2587,44 +3371,60 @@ class TestForceFieldParameterAssignment:
             atom2, atom3 = params[1], params[2]
             atom2_mol, atom3_mol = central_atoms
 
-            if (((atom2 == atom2_mol) and (atom3 == atom3_mol)) or
-                    ((atom2 == atom3_mol) and (atom3 == atom2_mol))):
+            if ((atom2 == atom2_mol) and (atom3 == atom3_mol)) or (
+                (atom2 == atom3_mol) and (atom3 == atom2_mol)
+            ):
                 k = params[-1]
-                assert_almost_equal(k/k.unit, 5.0208)
+                assert_almost_equal(k / k.unit, 5.0208)
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='Test requires RDKit toolkit')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="Test requires RDKit toolkit"
+    )
     @pytest.mark.parametrize(
-            ('get_molecule', 'k_interpolated', 'central_atoms'),
-            [(create_ethanol, 4.953856, (1, 2)), (create_reversed_ethanol, 4.953856, (7, 6))])
-    def test_fractional_bondorder_calculated_rdkit(self, get_molecule, k_interpolated, central_atoms):
+        ("get_molecule", "k_interpolated", "central_atoms"),
+        [
+            (create_ethanol, 4.953856, (1, 2)),
+            (create_reversed_ethanol, 4.953856, (7, 6)),
+        ],
+    )
+    def test_fractional_bondorder_calculated_rdkit(
+        self, get_molecule, k_interpolated, central_atoms
+    ):
         """Test that torsion barrier heights interpolated from fractional bond
         orders calculated with the Amber toolkit are assigned within our
         expectations.
 
         """
 
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[RDKitToolkitWrapper, AmberToolsToolkitWrapper])
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[RDKitToolkitWrapper, AmberToolsToolkitWrapper]
+        )
         mol = get_molecule()
 
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml',
-                                xml_ff_torsion_bo)
+        forcefield = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml", xml_ff_torsion_bo
+        )
         topology = Topology.from_molecules([mol])
 
         omm_system, ret_top = forcefield.create_openmm_system(
-                topology,
-                charge_from_molecules=[mol],
-                return_topology=True,
-                toolkit_registry=toolkit_registry)
+            topology,
+            charge_from_molecules=[mol],
+            return_topology=True,
+            toolkit_registry=toolkit_registry,
+        )
 
-        off_torsion_force = [force for force in omm_system.getForces() if
-                               isinstance(force, openmm.PeriodicTorsionForce)][0]
+        off_torsion_force = [
+            force
+            for force in omm_system.getForces()
+            if isinstance(force, openmm.PeriodicTorsionForce)
+        ][0]
 
         ret_mol = list(ret_top.reference_molecules)[0]
         bond = ret_mol.get_bond_between(*central_atoms)
 
         # ambertools appears to yield around 1.0009 for this bond
-        assert abs(bond.fractional_bond_order - 1.) > 1.e-6
-        assert .95 < bond.fractional_bond_order < 1.05
+        assert abs(bond.fractional_bond_order - 1.0) > 1.0e-6
+        assert 0.95 < bond.fractional_bond_order < 1.05
 
         for idx in range(off_torsion_force.getNumTorsions()):
             params = off_torsion_force.getTorsionParameters(idx)
@@ -2632,25 +3432,34 @@ class TestForceFieldParameterAssignment:
             atom2, atom3 = params[1], params[2]
             atom2_mol, atom3_mol = central_atoms
 
-            if (((atom2 == atom2_mol) and (atom3 == atom3_mol)) or
-                    ((atom2 == atom3_mol) and (atom3 == atom2_mol))):
+            if ((atom2 == atom2_mol) and (atom3 == atom3_mol)) or (
+                (atom2 == atom3_mol) and (atom3 == atom2_mol)
+            ):
                 k = params[-1]
 
                 # do a hand calculation as a sanity check
-                slope = (7.5312 - 4.184)/(1.8 - 1.0)
+                slope = (7.5312 - 4.184) / (1.8 - 1.0)
                 k_interpolated_ret = slope * (bond.fractional_bond_order - 1.0) + 4.184
-                assert_almost_equal(k_interpolated_ret, k/k.unit, 2)
+                assert_almost_equal(k_interpolated_ret, k / k.unit, 2)
 
                 # check that we *are not* matching the values we'd get if we
                 # had offered our molecules to `partial_bond_orders_from_molecules`
                 with pytest.raises(AssertionError):
-                    assert_almost_equal(k/k.unit, k_interpolated)
+                    assert_almost_equal(k / k.unit, k_interpolated)
 
-    @pytest.mark.skipif( not(OpenEyeToolkitWrapper.is_available()), reason='Test requires OE toolkit')
+    @pytest.mark.skipif(
+        not (OpenEyeToolkitWrapper.is_available()), reason="Test requires OE toolkit"
+    )
     @pytest.mark.parametrize(
-            ('get_molecule', 'k_interpolated', 'central_atoms'),
-            [(create_ethanol, 4.953856, (1, 2)), (create_reversed_ethanol, 4.953856, (7, 6))])
-    def test_fractional_bondorder_calculated_openeye(self, get_molecule, k_interpolated, central_atoms):
+        ("get_molecule", "k_interpolated", "central_atoms"),
+        [
+            (create_ethanol, 4.953856, (1, 2)),
+            (create_reversed_ethanol, 4.953856, (7, 6)),
+        ],
+    )
+    def test_fractional_bondorder_calculated_openeye(
+        self, get_molecule, k_interpolated, central_atoms
+    ):
         """Test that torsion barrier heights interpolated from fractional bond
         orders calculated with the OpenEye toolkit are assigned within our
         expectations.
@@ -2660,25 +3469,30 @@ class TestForceFieldParameterAssignment:
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper])
         mol = get_molecule()
 
-        forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml',
-                                xml_ff_torsion_bo)
+        forcefield = ForceField(
+            "test_forcefields/smirnoff99Frosst.offxml", xml_ff_torsion_bo
+        )
         topology = Topology.from_molecules([mol])
 
         omm_system, ret_top = forcefield.create_openmm_system(
-                topology,
-                charge_from_molecules=[mol],
-                return_topology=True,
-                toolkit_registry=toolkit_registry)
+            topology,
+            charge_from_molecules=[mol],
+            return_topology=True,
+            toolkit_registry=toolkit_registry,
+        )
 
-        off_torsion_force = [force for force in omm_system.getForces() if
-                               isinstance(force, openmm.PeriodicTorsionForce)][0]
+        off_torsion_force = [
+            force
+            for force in omm_system.getForces()
+            if isinstance(force, openmm.PeriodicTorsionForce)
+        ][0]
 
         ret_mol = list(ret_top.reference_molecules)[0]
         bond = ret_mol.get_bond_between(*central_atoms)
 
         # openeye toolkit appears to yield around .9945 for this bond
-        assert abs(bond.fractional_bond_order - 1.) > 1.e-6
-        assert .95 < bond.fractional_bond_order < 1.05
+        assert abs(bond.fractional_bond_order - 1.0) > 1.0e-6
+        assert 0.95 < bond.fractional_bond_order < 1.05
 
         for idx in range(off_torsion_force.getNumTorsions()):
             params = off_torsion_force.getTorsionParameters(idx)
@@ -2686,29 +3500,35 @@ class TestForceFieldParameterAssignment:
             atom2, atom3 = params[1], params[2]
             atom2_mol, atom3_mol = central_atoms
 
-            if (((atom2 == atom2_mol) and (atom3 == atom3_mol)) or
-                    ((atom2 == atom3_mol) and (atom3 == atom2_mol))):
+            if ((atom2 == atom2_mol) and (atom3 == atom3_mol)) or (
+                (atom2 == atom3_mol) and (atom3 == atom2_mol)
+            ):
                 k = params[-1]
 
                 # do a hand calculation as a sanity check
-                slope = (7.5312 - 4.184)/(1.8 - 1.0)
+                slope = (7.5312 - 4.184) / (1.8 - 1.0)
                 k_interpolated_ret = slope * (bond.fractional_bond_order - 1.0) + 4.184
-                assert_almost_equal(k_interpolated_ret, k/k.unit, 2)
+                assert_almost_equal(k_interpolated_ret, k / k.unit, 2)
 
                 # check that we *are not* matching the values we'd get if we
                 # had offered our molecules to `partial_bond_orders_from_molecules`
                 with pytest.raises(AssertionError):
-                    assert_almost_equal(k/k.unit, k_interpolated)
+                    assert_almost_equal(k / k.unit, k_interpolated)
 
 
 class TestSmirnoffVersionConverter:
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(),
-                        reason='Test requires OE toolkit to read mol2 files')
-    @pytest.mark.parametrize(('freesolv_id', 'forcefield_version', 'allow_undefined_stereo'),
-                             generate_freesolv_parameters_assignment_cases())
-    @pytest.mark.parametrize(('spec'), ['0_1', '0_2', '0_3'])
-    def test_read_smirnoff_spec_freesolv(self, freesolv_id, forcefield_version, allow_undefined_stereo, spec):
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(),
+        reason="Test requires OE toolkit to read mol2 files",
+    )
+    @pytest.mark.parametrize(
+        ("freesolv_id", "forcefield_version", "allow_undefined_stereo"),
+        generate_freesolv_parameters_assignment_cases(),
+    )
+    @pytest.mark.parametrize(("spec"), ["0_1", "0_2", "0_3"])
+    def test_read_smirnoff_spec_freesolv(
+        self, freesolv_id, forcefield_version, allow_undefined_stereo, spec
+    ):
         """
         Test reading an 0.2 smirnoff spec file, by reading an 0.1 spec representation of a set of parameters,
         and ensuring that it parameterizes molecules identically to the same FF in the most recent spec
@@ -2722,69 +3542,92 @@ class TestSmirnoffVersionConverter:
         tested separately. Currently, test_freesolv_parameters_assignment
         does the job.
         """
-        from openforcefield.tests.utils import get_freesolv_file_path, compare_system_parameters
+        from openforcefield.tests.utils import (
+            get_freesolv_file_path,
+            compare_system_parameters,
+        )
 
-        mol2_file_path, xml_file_path = get_freesolv_file_path(freesolv_id, forcefield_version)
+        mol2_file_path, xml_file_path = get_freesolv_file_path(
+            freesolv_id, forcefield_version
+        )
 
         # Load molecules.
-        molecule = Molecule.from_file(mol2_file_path, allow_undefined_stereo=allow_undefined_stereo)
+        molecule = Molecule.from_file(
+            mol2_file_path, allow_undefined_stereo=allow_undefined_stereo
+        )
 
         # Create OpenFF System with the current toolkit.
-        #forcefield_file_path = 'test_forcefields/old/smirnoff99Frosst_1_0_8_spec_0_2.offxml'
-        forcefield_file_path = f'test_forcefields/old/test_ff_{forcefield_version}_spec_{spec}.offxml'
-        ff = ForceField(forcefield_file_path, 'test_forcefields/old/hbonds.offxml')
+        # forcefield_file_path = 'test_forcefields/old/smirnoff99Frosst_1_0_8_spec_0_2.offxml'
+        forcefield_file_path = (
+            f"test_forcefields/old/test_ff_{forcefield_version}_spec_{spec}.offxml"
+        )
+        ff = ForceField(forcefield_file_path, "test_forcefields/old/hbonds.offxml")
         ff_system = ff.create_openmm_system(molecule.to_topology())
 
         # Load OpenMM System created with the 0.1 version of the toolkit.
         from simtk import openmm
-        with open(xml_file_path, 'r') as f:
+
+        with open(xml_file_path, "r") as f:
             xml_system = openmm.XmlSerializer.deserialize(f.read())
 
         # Compare parameters. We ignore the improper folds as in 0.0.3 we
         # used a six-fold implementation while we now use a three-fold way.
         # TODO: Reactivate charge comparison once we'll be able to read them from file.
-        compare_system_parameters(ff_system, xml_system,
-                                  systems_labels=('current OpenFF', 'SMIRNOFF 0.0.4'),
-                                  ignore_charges=True, ignore_improper_folds=True)
+        compare_system_parameters(
+            ff_system,
+            xml_system,
+            systems_labels=("current OpenFF", "SMIRNOFF 0.0.4"),
+            ignore_charges=True,
+            ignore_improper_folds=True,
+        )
 
 
-
-
-@pytest.mark.skip(reason='Needs to be updated for 0.2.0 syntax')
+@pytest.mark.skip(reason="Needs to be updated for 0.2.0 syntax")
 def test_electrostatics_options(self):
     """Test parameter assignment using smirnoff99Frosst on laromustine with various long-range electrostatics options.
     """
-    molecules_file_path = get_data_file_path('molecules/laromustine_tripos.mol2')
+    molecules_file_path = get_data_file_path("molecules/laromustine_tripos.mol2")
     molecule = openforcefield.topology.Molecule.from_file(molecules_file_path)
-    forcefield = ForceField([smirnoff99Frosst_offxml_file_path, charge_increment_offxml_file_path])
-    for method in ['PME', 'reaction-field', 'Coulomb']:
+    forcefield = ForceField(
+        [smirnoff99Frosst_offxml_file_path, charge_increment_offxml_file_path]
+    )
+    for method in ["PME", "reaction-field", "Coulomb"]:
         # Change electrostatics method
-        forcefield.forces['Electrostatics'].method = method
+        forcefield.forces["Electrostatics"].method = method
         f = partial(check_system_creation_from_molecule, forcefield, molecule)
-        f.description = 'Testing {} parameter assignment using molecule {}'.format(offxml_file_path, molecule.name)
-        #yield f
+        f.description = "Testing {} parameter assignment using molecule {}".format(
+            offxml_file_path, molecule.name
+        )
+        # yield f
     # TODO: Implement a similar test, where we compare OpenMM energy evals from an
     #       AMBER-parameterized system to OFF-parameterized systems
 
-@pytest.mark.skip(reason='Needs to be updated for 0.2.0 syntax')
+
+@pytest.mark.skip(reason="Needs to be updated for 0.2.0 syntax")
 def test_charge_increment(self):
     """Test parameter assignment using smirnoff99Frosst on laromustine with ChargeIncrementModel.
     """
-    molecules_file_path = get_data_file_path('molecules/laromustine_tripos.mol2')
+    molecules_file_path = get_data_file_path("molecules/laromustine_tripos.mol2")
     molecule = openforcefield.topology.Molecule.from_file(molecules_file_path)
-    forcefield = ForceField(['test_forcefields/smirnoff99Frosst.offxml', 'chargeincrement-test'])
+    forcefield = ForceField(
+        ["test_forcefields/smirnoff99Frosst.offxml", "chargeincrement-test"]
+    )
     check_system_creation_from_molecule(forcefield, molecule)
     # TODO: We can't implement a test for chargeincrement yet because we
     #       haven't settled on a SMIRNOFF spec for chargeincrementmodel
 
 
-@pytest.mark.skip(reason='Needs to be updated for 0.2.0 syntax')
+@pytest.mark.skip(reason="Needs to be updated for 0.2.0 syntax")
 def test_create_system_molecules_parmatfrosst_gbsa(self):
     """Test creation of a System object from small molecules to test parm@frosst forcefield with GBSA support.
     """
-    molecules_file_path = get_data_file_path('molecules/AlkEthOH_test_filt1_tripos.mol2')
+    molecules_file_path = get_data_file_path(
+        "molecules/AlkEthOH_test_filt1_tripos.mol2"
+    )
     check_parameter_assignment(
-        offxml_file_path='test_forcefields/Frosst_AlkEthOH_GBSA.offxml', molecules_file_path=molecules_file_path)
+        offxml_file_path="test_forcefields/Frosst_AlkEthOH_GBSA.offxml",
+        molecules_file_path=molecules_file_path,
+    )
     # TODO: Figure out if we just want to check that energy is finite (this is what the original test did,
     #       or compare numerically to a reference system.
 

--- a/openforcefield/tests/test_io.py
+++ b/openforcefield/tests/test_io.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#=============================================================================================
+# =============================================================================================
 # MODULE DOCSTRING
-#=============================================================================================
+# =============================================================================================
 
 """
 Test classes and function in module openforcefield.typing.engines.smirnoff.io.
@@ -10,21 +10,21 @@ Test classes and function in module openforcefield.typing.engines.smirnoff.io.
 """
 
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import pytest
 
 from openforcefield.typing.engines.smirnoff.io import XMLParameterIOHandler
 
 
-#=============================================================================================
+# =============================================================================================
 # QUANTITY PARSING UTILITIES
-#=============================================================================================
+# =============================================================================================
+
 
 class TestXMLParameterIOHandler:
-
     def test_from_string(self):
         pass
 
@@ -32,7 +32,7 @@ class TestXMLParameterIOHandler:
         """Raise FileNotFoundError when the file doesn't exist."""
         io_handler = XMLParameterIOHandler()
         with pytest.raises(FileNotFoundError):
-            io_handler.parse_file('nonexisting_file.xml')
+            io_handler.parse_file("nonexisting_file.xml")
 
     #
     # Tests for ForceField writing to XML files
@@ -40,25 +40,31 @@ class TestXMLParameterIOHandler:
 
     # TODO: Remove ForceField from this whole file. All tests should be for converting between hierarchical SMIRNOFF
     #       dicts and XML
-    @pytest.mark.skip(reason='Needs to be updated for 1.0.0 syntax')
+    @pytest.mark.skip(reason="Needs to be updated for 1.0.0 syntax")
     def test_save(self):
         """Test writing and reading of SMIRNOFF in XML format.
         """
         forcefield = ForceField(smirnoff99Frosst_offxml_filename)
         # Write XML to a file
         with TemporaryDirectory() as tmpdir:
-            offxml_tmpfile = os.path.join(tmpdir, 'forcefield.offxml')
+            offxml_tmpfile = os.path.join(tmpdir, "forcefield.offxml")
             forcefield.save(offxml_tmpfile)
             forcefield2 = ForceField(offxml_tmpfile)
-            assert_forcefields_equal(cls.forcefield, forcefield2,
-                                     "ForceField written to .offxml does not match original ForceField")
+            assert_forcefields_equal(
+                cls.forcefield,
+                forcefield2,
+                "ForceField written to .offxml does not match original ForceField",
+            )
 
-    @pytest.mark.skip(reason='Needs to be updated for 1.0.0 syntax')
+    @pytest.mark.skip(reason="Needs to be updated for 1.0.0 syntax")
     def test_to_xml(self):
         forcefield = ForceField(smirnoff99Frosst_offxml_filename)
         # Retrieve XML as a string
         xml = forcefield.to_xml()
         # Restore ForceField from XML
         forcefield2 = ForceField(xml)
-        assert_forcefields_equal(cls.forcefield, forcefield2,
-                                 "ForceField serialized to XML does not match original ForceField")
+        assert_forcefields_equal(
+            cls.forcefield,
+            forcefield2,
+            "ForceField serialized to XML does not match original ForceField",
+        )

--- a/openforcefield/tests/test_links.py
+++ b/openforcefield/tests/test_links.py
@@ -5,11 +5,11 @@ from urllib.request import Request, urlopen
 import pytest
 
 
-#======================================================================
+# ======================================================================
 # TEST UTILITIES
-#======================================================================
+# ======================================================================
 
-ROOT_DIR_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..')
+ROOT_DIR_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..")
 
 
 def find_readme_links():
@@ -20,29 +20,31 @@ def find_readme_links():
     readme_examples : List[str]
         The list of links included in the README.md file.
     """
-    readme_file_path = os.path.join(ROOT_DIR_PATH, 'README.md')
-    with open(readme_file_path, 'r') as f:
+    readme_file_path = os.path.join(ROOT_DIR_PATH, "README.md")
+    with open(readme_file_path, "r") as f:
         readme_content = f.read()
-    return re.findall('http[s]?://(?:[0-9a-zA-Z]|[-/.%:_])+', readme_content)
+    return re.findall("http[s]?://(?:[0-9a-zA-Z]|[-/.%:_])+", readme_content)
 
 
-#======================================================================
+# ======================================================================
 # TESTS
-#======================================================================
+# ======================================================================
 
 
-@pytest.mark.parametrize('readme_link', find_readme_links())
+@pytest.mark.parametrize("readme_link", find_readme_links())
 def test_readme_links(readme_link):
     """Test URLs in README are reachable"""
     # Some websites do not accept requests that don't specify the
     # client and the type of accepted documents so we add fake info
     # to avoid the response being an error.
-    headers = {'User-Agent':'Mozilla/5.0',
-               'Accept': 'application/xhtml+xml,text/html,application/xml;q=0.9,*/*;q=0.8',}
+    headers = {
+        "User-Agent": "Mozilla/5.0",
+        "Accept": "application/xhtml+xml,text/html,application/xml;q=0.9,*/*;q=0.8",
+    }
     request = Request(readme_link, headers=headers)
 
     # Some DOI-based links are now behind DDoS protections, so skip them
-    if 'doi.org' in readme_link:
+    if "doi.org" in readme_link:
         pytest.skip("DOI links are behind DDoS protection and do not resolve")
 
     # Try to connect 5 times, keeping track of exceptions so useful feedback can be provided.
@@ -55,5 +57,5 @@ def test_readme_links(readme_link):
             break
         except Exception as e:
             exception = e
-    if not(success):
+    if not (success):
         raise exception

--- a/openforcefield/tests/test_molecule.py
+++ b/openforcefield/tests/test_molecule.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#=============================================================================================
+# =============================================================================================
 # MODULE DOCSTRING
-#=============================================================================================
+# =============================================================================================
 
 """
 Tests for molecular topology representations
@@ -18,9 +18,9 @@ TODO:
 
 """
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import copy
 import os
@@ -33,19 +33,33 @@ from simtk import unit
 
 from openforcefield.topology.molecule import Molecule, Atom, InvalidConformerError
 from openforcefield.utils import get_data_file_path
+
 # TODO: Will the ToolkitWrapper allow us to pare that down?
-from openforcefield.utils.toolkits import OpenEyeToolkitWrapper, RDKitToolkitWrapper, AmberToolsToolkitWrapper, ToolkitRegistry
-from openforcefield.tests.test_forcefield import create_ethanol, create_reversed_ethanol, create_acetaldehyde, \
-    create_benzene_no_aromatic, create_cyclohexane, create_cis_1_2_dichloroethene
+from openforcefield.utils.toolkits import (
+    OpenEyeToolkitWrapper,
+    RDKitToolkitWrapper,
+    AmberToolsToolkitWrapper,
+    ToolkitRegistry,
+)
+from openforcefield.tests.test_forcefield import (
+    create_ethanol,
+    create_reversed_ethanol,
+    create_acetaldehyde,
+    create_benzene_no_aromatic,
+    create_cyclohexane,
+    create_cis_1_2_dichloroethene,
+)
 
-#=============================================================================================
+# =============================================================================================
 # TEST UTILITIES
-#=============================================================================================
+# =============================================================================================
 
-requires_openeye = pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(),
-                                      reason='Test requires OE toolkit')
-requires_rdkit = pytest.mark.skipif(not RDKitToolkitWrapper.is_available(),
-                                    reason='Test requires RDKit')
+requires_openeye = pytest.mark.skipif(
+    not OpenEyeToolkitWrapper.is_available(), reason="Test requires OE toolkit"
+)
+requires_rdkit = pytest.mark.skipif(
+    not RDKitToolkitWrapper.is_available(), reason="Test requires RDKit"
+)
 
 
 def assert_molecule_is_equal(molecule1, molecule2, msg):
@@ -59,7 +73,7 @@ def assert_molecule_is_equal(molecule1, molecule2, msg):
         Message to include if molecules fail to match.
 
     """
-    if not(molecule1.is_isomorphic_with(molecule2)):
+    if not (molecule1.is_isomorphic_with(molecule2)):
         raise AssertionError(msg)
 
 
@@ -71,9 +85,9 @@ def is_four_memebered_ring_torsion(torsion):
     is_four_membered_ring = True
     for i in range(4):
         # The atom is bonded to the next one.
-        is_four_membered_ring &= torsion[i].is_bonded_to(torsion[i+1])
+        is_four_membered_ring &= torsion[i].is_bonded_to(torsion[i + 1])
         # The atom is not bonded to the atom on its diagonal.
-        is_four_membered_ring &= not torsion[i].is_bonded_to(torsion[i+2])
+        is_four_membered_ring &= not torsion[i].is_bonded_to(torsion[i + 2])
 
     return is_four_membered_ring
 
@@ -95,8 +109,10 @@ def is_three_memebered_ring_torsion(torsion):
     for atom in torsion:
         for bond in atom.bonds:
             # Consider the bond only if both atoms are in the torsion.
-            if (bond.atom1_index in torsion_atom_indices and
-                        bond.atom2_index in torsion_atom_indices):
+            if (
+                bond.atom1_index in torsion_atom_indices
+                and bond.atom2_index in torsion_atom_indices
+            ):
                 bonds_by_atom_idx[bond.atom1_index].add(bond.atom2_index)
                 bonds_by_atom_idx[bond.atom2_index].add(bond.atom1_index)
 
@@ -108,28 +124,36 @@ def is_three_memebered_ring_torsion(torsion):
 
     # Find the atom outside the ring.
     atom_indices = [i for i in torsion_atom_indices if len(bonds_by_atom_idx[i]) == 1]
-    if len(atom_indices) != 1 or central_atom_idx not in bonds_by_atom_idx[atom_indices[0]]:
+    if (
+        len(atom_indices) != 1
+        or central_atom_idx not in bonds_by_atom_idx[atom_indices[0]]
+    ):
         return False
     outside_atom_idx = atom_indices[0]
 
     # Check that the remaining two atoms are non-central atoms in the membered ring.
-    atom1, atom2 = [i for i in torsion_atom_indices if i not in [central_atom_idx, outside_atom_idx]]
+    atom1, atom2 = [
+        i for i in torsion_atom_indices if i not in [central_atom_idx, outside_atom_idx]
+    ]
     # The two atoms are bonded to each other.
     if atom2 not in bonds_by_atom_idx[atom1] or atom1 not in bonds_by_atom_idx[atom2]:
         return False
     # Check that they are both bonded to the central atom and none other.
     for atom_idx in [atom1, atom2]:
-        if (central_atom_idx not in bonds_by_atom_idx[atom_idx] or
-                    len(bonds_by_atom_idx[atom_idx]) != 2):
+        if (
+            central_atom_idx not in bonds_by_atom_idx[atom_idx]
+            or len(bonds_by_atom_idx[atom_idx]) != 2
+        ):
             return False
 
     # This is a torsion including a three-membered ring.
     return True
 
 
-#=============================================================================================
+# =============================================================================================
 # FIXTURES
-#=============================================================================================
+# =============================================================================================
+
 
 def mini_drug_bank(xfail_mols=None, wip_mols=None):
     """Load the full MiniDrugBank into Molecule objects.
@@ -149,14 +173,14 @@ def mini_drug_bank(xfail_mols=None, wip_mols=None):
         molecules = mini_drug_bank.molecules
     else:
         # Load the dataset.
-        file_path = get_data_file_path('molecules/MiniDrugBank_tripos.mol2')
+        file_path = get_data_file_path("molecules/MiniDrugBank_tripos.mol2")
         try:
             # We need OpenEye to parse the molecules, but pytest execute this
             # whether or not the test class is skipped so if OE is not available
             # we just return an empty list of test cases as a workaround.
             molecules = Molecule.from_file(file_path, allow_undefined_stereo=True)
         except NotImplementedError as e:
-            assert 'No toolkits in registry can read file' in str(e)
+            assert "No toolkits in registry can read file" in str(e)
             mini_drug_bank.molecules = []
             return []
         else:
@@ -189,35 +213,57 @@ def mini_drug_bank(xfail_mols=None, wip_mols=None):
 
     return molecules
 
+
 # Use a "static" variable as a workaround as fixtures cannot be
 # used inside pytest.mark.parametrize (see issue #349 in pytest).
 mini_drug_bank.molecules = None
 
 # All the molecules that raise UndefinedStereochemistryError when read by OETK()
-openeye_drugbank_undefined_stereo_mols = {'DrugBank_1634', 'DrugBank_1700', 'DrugBank_1962',
-                                          'DrugBank_2519', 'DrugBank_2987', 'DrugBank_3502',
-                                          'DrugBank_3930', 'DrugBank_4161', 'DrugBank_4162',
-                                          'DrugBank_5043', 'DrugBank_5418', 'DrugBank_6531'}
+openeye_drugbank_undefined_stereo_mols = {
+    "DrugBank_1634",
+    "DrugBank_1700",
+    "DrugBank_1962",
+    "DrugBank_2519",
+    "DrugBank_2987",
+    "DrugBank_3502",
+    "DrugBank_3930",
+    "DrugBank_4161",
+    "DrugBank_4162",
+    "DrugBank_5043",
+    "DrugBank_5418",
+    "DrugBank_6531",
+}
 
 # All the molecules that raise UndefinedStereochemistryError when read by OETK().
 # Note that this list is different from that for OEMol,
 # since the toolkits have different definitions of "stereogenic"
-rdkit_drugbank_undefined_stereo_mols = {'DrugBank_1634', 'DrugBank_1962', 'DrugBank_2519',
-                                        'DrugBank_3930', 'DrugBank_5043', 'DrugBank_5418'}
+rdkit_drugbank_undefined_stereo_mols = {
+    "DrugBank_1634",
+    "DrugBank_1962",
+    "DrugBank_2519",
+    "DrugBank_3930",
+    "DrugBank_5043",
+    "DrugBank_5418",
+}
 
 
 # Missing stereo in OE but not RDK:  'DrugBank_2987', 'DrugBank_3502', 'DrugBank_4161',
 # 'DrugBank_4162', 'DrugBank_6531', 'DrugBank_1700',
-drugbank_stereogenic_in_rdkit_but_not_openeye = {'DrugBank_5329'}
+drugbank_stereogenic_in_rdkit_but_not_openeye = {"DrugBank_5329"}
 
 # Some molecules are _valid_ in both OETK and RDKit, but will fail if you try
 # to convert from one to the other, since OE adds stereo that RDKit doesn't
-drugbank_stereogenic_in_oe_but_not_rdkit = {'DrugBank_1598', 'DrugBank_4346', 'DrugBank_1849',
-                                            'DrugBank_2141'}
+drugbank_stereogenic_in_oe_but_not_rdkit = {
+    "DrugBank_1598",
+    "DrugBank_4346",
+    "DrugBank_1849",
+    "DrugBank_2141",
+}
 
-#=============================================================================================
+# =============================================================================================
 # TESTS
-#=============================================================================================
+# =============================================================================================
+
 
 class TestAtom:
     """Test Atom class."""
@@ -230,25 +276,34 @@ class TestAtom:
         assert atom1.formal_charge == 0 * unit.elementary_charge
 
         # Create a chiral carbon atom
-        atom2 = Atom(6, 0, False, stereochemistry='R', name='CT')
+        atom2 = Atom(6, 0, False, stereochemistry="R", name="CT")
         assert atom1.stereochemistry != atom2.stereochemistry
 
         # Ensure that formal charge can also be set as a Quantity
-        atom1 = Atom(6, 1*unit.elementary_charge, False)
+        atom1 = Atom(6, 1 * unit.elementary_charge, False)
         assert atom1.formal_charge == 1 * unit.elementary_charge
-
 
     def test_atom_properties(self):
         """Test that atom properties are correctly populated and gettable"""
         from simtk.openmm.app import element
+
         formal_charge = 0 * unit.elementary_charge
         is_aromatic = False
         # Attempt to create all elements supported by OpenMM
-        elements = [getattr(element, name) for name in dir(element) if (type(getattr(element, name)) == element.Element)]
+        elements = [
+            getattr(element, name)
+            for name in dir(element)
+            if (type(getattr(element, name)) == element.Element)
+        ]
         # The above runs into a problem with deuterium (fails name assertion)
         elements.remove(element.deuterium)
         for this_element in elements:
-            atom = Atom(this_element.atomic_number, formal_charge, is_aromatic, name=this_element.name)
+            atom = Atom(
+                this_element.atomic_number,
+                formal_charge,
+                is_aromatic,
+                name=this_element.name,
+            )
             assert atom.atomic_number == this_element.atomic_number
             assert atom.element == this_element
             assert atom.mass == this_element.mass
@@ -265,42 +320,42 @@ class TestMolecule:
 
     # Test serialization {to|from}_{dict|yaml|toml|json|bson|xml|messagepack|pickle}
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_dict_serialization(self, molecule):
         """Test serialization of a molecule object to and from dict."""
         serialized = molecule.to_dict()
         molecule_copy = Molecule.from_dict(serialized)
         assert molecule == molecule_copy
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_yaml_serialization(self, molecule):
         """Test serialization of a molecule object to and from YAML."""
         serialized = molecule.to_yaml()
         molecule_copy = Molecule.from_yaml(serialized)
         assert molecule == molecule_copy
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_toml_serialization(self, molecule):
         """Test serialization of a molecule object to and from TOML."""
         # TODO: Test round-trip when implemented
         with pytest.raises(NotImplementedError):
             molecule.to_toml()
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_bson_serialization(self, molecule):
         """Test serialization of a molecule object to and from BSON."""
         serialized = molecule.to_bson()
         molecule_copy = Molecule.from_bson(serialized)
         assert molecule == molecule_copy
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_json_serialization(self, molecule):
         """Test serialization of a molecule object to and from JSON."""
         # TODO: Test round-trip when to_json bug is fixed
         with pytest.raises(TypeError):
             molecule.to_json()
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_xml_serialization(self, molecule):
         """Test serialization of a molecule object to and from XML."""
         # TODO: Test round-trip when from_xml is implemented
@@ -308,14 +363,14 @@ class TestMolecule:
         with pytest.raises(NotImplementedError):
             Molecule.from_xml(serialized)
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_messagepack_serialization(self, molecule):
         """Test serialization of a molecule object to and from messagepack."""
         serialized = molecule.to_messagepack()
         molecule_copy = Molecule.from_messagepack(serialized)
         assert molecule == molecule_copy
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_pickle_serialization(self, molecule):
         """Test round-trip pickling of a molecule object."""
         serialized = pickle.dumps(molecule)
@@ -324,7 +379,7 @@ class TestMolecule:
 
     def test_serialization_no_conformers(self):
         """Test round-trip serialization when molecules have no conformers or partial charges."""
-        mol = Molecule.from_smiles('CCO')
+        mol = Molecule.from_smiles("CCO")
 
         dict_copy = Molecule.from_dict(mol.to_dict())
         assert mol == dict_copy
@@ -350,7 +405,6 @@ class TestMolecule:
         pickle_copy = pickle.loads(pickle.dumps(mol))
         assert mol == pickle_copy
 
-
     # ----------------------------------------------------
     # Test Molecule constructors and conversion utilities.
     # ----------------------------------------------------
@@ -361,25 +415,27 @@ class TestMolecule:
         assert len(molecule.atoms) == 0
         assert len(molecule.bonds) == 0
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_create_copy(self, molecule):
         """Test copy constructor."""
         molecule_copy = Molecule(molecule)
         assert molecule_copy == molecule
 
-    @pytest.mark.parametrize('toolkit', [OpenEyeToolkitWrapper, RDKitToolkitWrapper])
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("toolkit", [OpenEyeToolkitWrapper, RDKitToolkitWrapper])
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_from_smiles(self, molecule, toolkit):
         """Test round-trip creation from SMILES"""
         if not toolkit.is_available():
-            pytest.skip('Required toolkit is unavailable')
+            pytest.skip("Required toolkit is unavailable")
 
         if toolkit == RDKitToolkitWrapper:
             # Skip the test if OpenEye assigns stereochemistry but RDKit doesn't (since then, the
             # OFF molecule will be loaded, but fail to convert in to_rdkit)
             if molecule.name in drugbank_stereogenic_in_oe_but_not_rdkit:
-                pytest.skip('Molecule is stereogenic in OpenEye (which loaded this dataset), but not RDKit, so it '
-                            'is impossible to make a valid RDMol in this test')
+                pytest.skip(
+                    "Molecule is stereogenic in OpenEye (which loaded this dataset), but not RDKit, so it "
+                    "is impossible to make a valid RDMol in this test"
+                )
             undefined_stereo_mols = rdkit_drugbank_undefined_stereo_mols
         elif toolkit == OpenEyeToolkitWrapper:
             undefined_stereo_mols = openeye_drugbank_undefined_stereo_mols
@@ -389,82 +445,126 @@ class TestMolecule:
         undefined_stereo = molecule.name in undefined_stereo_mols
         # Since OpenEye did the original reading of MiniDrugBank, if OPENEYE doesn't
         # think a feature is stereogenic, then "molecule" won't have stereochemistry defined
-        stereogenic_in_rdk_but_not_openeye = molecule.name in drugbank_stereogenic_in_rdkit_but_not_openeye
+        stereogenic_in_rdk_but_not_openeye = (
+            molecule.name in drugbank_stereogenic_in_rdkit_but_not_openeye
+        )
 
         smiles1 = molecule.to_smiles(toolkit_registry=toolkit_wrapper)
-        if undefined_stereo or ((toolkit is RDKitToolkitWrapper) and stereogenic_in_rdk_but_not_openeye):
-            molecule2 = Molecule.from_smiles(smiles1,
-                                             allow_undefined_stereo=True,
-                                             toolkit_registry=toolkit_wrapper)
+        if undefined_stereo or (
+            (toolkit is RDKitToolkitWrapper) and stereogenic_in_rdk_but_not_openeye
+        ):
+            molecule2 = Molecule.from_smiles(
+                smiles1, allow_undefined_stereo=True, toolkit_registry=toolkit_wrapper
+            )
         else:
-            molecule2 = Molecule.from_smiles(smiles1,
-                                             toolkit_registry=toolkit_wrapper)
+            molecule2 = Molecule.from_smiles(smiles1, toolkit_registry=toolkit_wrapper)
 
         smiles2 = molecule2.to_smiles(toolkit_registry=toolkit_wrapper)
-        assert (smiles1 == smiles2)
+        assert smiles1 == smiles2
 
-    smiles_types = [{'isomeric': True, 'explicit_hydrogens': True, 'mapped': True, 'error': None},
-                    {'isomeric': False, 'explicit_hydrogens': True, 'mapped': True, 'error': None},
-                    {'isomeric': True, 'explicit_hydrogens': False, 'mapped': True, 'error': AssertionError},
-                    {'isomeric': True, 'explicit_hydrogens': True, 'mapped': False, 'error': None},
-                    {'isomeric': True, 'explicit_hydrogens': False, 'mapped': False, 'error': None},
-                    {'isomeric': False, 'explicit_hydrogens': True, 'mapped': False, 'error': None},
-                    {'isomeric': False, 'explicit_hydrogens': False, 'mapped': True, 'error': AssertionError},
-                    {'isomeric': False, 'explicit_hydrogens': False, 'mapped': False, 'error': None},
-                    ]
+    smiles_types = [
+        {"isomeric": True, "explicit_hydrogens": True, "mapped": True, "error": None},
+        {"isomeric": False, "explicit_hydrogens": True, "mapped": True, "error": None},
+        {
+            "isomeric": True,
+            "explicit_hydrogens": False,
+            "mapped": True,
+            "error": AssertionError,
+        },
+        {"isomeric": True, "explicit_hydrogens": True, "mapped": False, "error": None},
+        {"isomeric": True, "explicit_hydrogens": False, "mapped": False, "error": None},
+        {"isomeric": False, "explicit_hydrogens": True, "mapped": False, "error": None},
+        {
+            "isomeric": False,
+            "explicit_hydrogens": False,
+            "mapped": True,
+            "error": AssertionError,
+        },
+        {
+            "isomeric": False,
+            "explicit_hydrogens": False,
+            "mapped": False,
+            "error": None,
+        },
+    ]
 
-    @pytest.mark.parametrize('toolkit_class', [OpenEyeToolkitWrapper, RDKitToolkitWrapper])
-    @pytest.mark.parametrize('data', smiles_types)
+    @pytest.mark.parametrize(
+        "toolkit_class", [OpenEyeToolkitWrapper, RDKitToolkitWrapper]
+    )
+    @pytest.mark.parametrize("data", smiles_types)
     def test_smiles_types(self, data, toolkit_class):
         """Test that the toolkit is passing the correct args to the toolkit backends across different combinations."""
 
         if toolkit_class.is_available():
             toolkit = toolkit_class()
             mol = create_cis_1_2_dichloroethene()
-            isomeric, explicit_hs, mapped = data['isomeric'], data['explicit_hydrogens'], data['mapped']
-            if data['error'] is not None:
-                with pytest.raises(data['error']):
-                    mol.to_smiles(isomeric=isomeric, explicit_hydrogens=explicit_hs,
-                                  mapped=mapped, toolkit_registry=toolkit)
+            isomeric, explicit_hs, mapped = (
+                data["isomeric"],
+                data["explicit_hydrogens"],
+                data["mapped"],
+            )
+            if data["error"] is not None:
+                with pytest.raises(data["error"]):
+                    mol.to_smiles(
+                        isomeric=isomeric,
+                        explicit_hydrogens=explicit_hs,
+                        mapped=mapped,
+                        toolkit_registry=toolkit,
+                    )
 
             else:
 
                 # make the smiles then do some checks on it
-                output_smiles = mol.to_smiles(isomeric=isomeric,
-                                              explicit_hydrogens=explicit_hs,
-                                              mapped=mapped, toolkit_registry=toolkit)
+                output_smiles = mol.to_smiles(
+                    isomeric=isomeric,
+                    explicit_hydrogens=explicit_hs,
+                    mapped=mapped,
+                    toolkit_registry=toolkit,
+                )
                 if isomeric:
-                    assert '\\' in output_smiles
+                    assert "\\" in output_smiles
                 if explicit_hs:
-                    assert 'H' in output_smiles
+                    assert "H" in output_smiles
                 if mapped:
-                    for i in range(1,7):
-                        assert f':{i}' in output_smiles
+                    for i in range(1, 7):
+                        assert f":{i}" in output_smiles
                     # if the molecule is mapped make it using the mapping
-                    mol2 = Molecule.from_mapped_smiles(mapped_smiles=output_smiles,
-                                                       toolkit_registry=toolkit,
-                                                       allow_undefined_stereo=not isomeric)
+                    mol2 = Molecule.from_mapped_smiles(
+                        mapped_smiles=output_smiles,
+                        toolkit_registry=toolkit,
+                        allow_undefined_stereo=not isomeric,
+                    )
                 else:
                     # make a molecule from a standard smiles
-                    mol2 = Molecule.from_smiles(smiles=output_smiles,
-                                                allow_undefined_stereo=not isomeric,
-                                                toolkit_registry=toolkit)
+                    mol2 = Molecule.from_smiles(
+                        smiles=output_smiles,
+                        allow_undefined_stereo=not isomeric,
+                        toolkit_registry=toolkit,
+                    )
 
-                isomorphic, atom_map = Molecule.are_isomorphic(mol, mol2, return_atom_map=True,
-                                                               aromatic_matching=True,
-                                                               formal_charge_matching=True,
-                                                               bond_order_matching=True,
-                                                               atom_stereochemistry_matching=isomeric,
-                                                               bond_stereochemistry_matching=isomeric)
+                isomorphic, atom_map = Molecule.are_isomorphic(
+                    mol,
+                    mol2,
+                    return_atom_map=True,
+                    aromatic_matching=True,
+                    formal_charge_matching=True,
+                    bond_order_matching=True,
+                    atom_stereochemistry_matching=isomeric,
+                    bond_stereochemistry_matching=isomeric,
+                )
 
                 assert isomorphic is True
                 if mapped:
                     assert {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5} == atom_map
 
         else:
-            pytest.skip(f'The required toolkit ({toolkit_class.toolkit_name}) is not available.')
+            pytest.skip(
+                f"The required toolkit ({toolkit_class.toolkit_name}) is not available."
+            )
 
-    @pytest.mark.parametrize('toolkit_class', [OpenEyeToolkitWrapper, RDKitToolkitWrapper])
+    @pytest.mark.parametrize(
+        "toolkit_class", [OpenEyeToolkitWrapper, RDKitToolkitWrapper]
+    )
     def test_smiles_cache(self, toolkit_class):
         """Make sure that the smiles cache is being used correctly."""
 
@@ -476,93 +576,143 @@ class TestMolecule:
             # now lets populate the cache with a test result
             # first we need to make the cache key for the default input
             isomeric, explicit_hydrogens, mapped = True, True, False
-            cache_key = toolkit.to_smiles.__qualname__ + str(isomeric) + str(explicit_hydrogens) + str(mapped)
-            cache_key += str(mol._properties.get('atom_map', None))
+            cache_key = (
+                toolkit.to_smiles.__qualname__
+                + str(isomeric)
+                + str(explicit_hydrogens)
+                + str(mapped)
+            )
+            cache_key += str(mol._properties.get("atom_map", None))
             mol._cached_smiles = {cache_key: None}
-            assert mol.to_smiles(isomeric=isomeric, toolkit_registry=toolkit,
-                                 explicit_hydrogens=explicit_hydrogens, mapped=mapped) is None
+            assert (
+                mol.to_smiles(
+                    isomeric=isomeric,
+                    toolkit_registry=toolkit,
+                    explicit_hydrogens=explicit_hydrogens,
+                    mapped=mapped,
+                )
+                is None
+            )
 
             # now make sure the cache is not used if we change an input arg
-            assert mol.to_smiles(isomeric=True, explicit_hydrogens=True,
-                                 mapped=True, toolkit_registry=toolkit) is not None
+            assert (
+                mol.to_smiles(
+                    isomeric=True,
+                    explicit_hydrogens=True,
+                    mapped=True,
+                    toolkit_registry=toolkit,
+                )
+                is not None
+            )
 
             # now make sure the cache was updated
             assert mol._cached_smiles != {cache_key: None}
             assert len(mol._cached_smiles) == 2
 
         else:
-            pytest.skip(f'The required toolkit ({toolkit_class.toolkit_name}) is not available.')
+            pytest.skip(
+                f"The required toolkit ({toolkit_class.toolkit_name}) is not available."
+            )
 
-    mapped_types = [{'atom_map': None},
-                    {'atom_map': {0: 0}},
-                    {'atom_map': {0: 0, 1: 0, 2: 0, 3: 0}},
-                    {'atom_map': {0: 0, 1: 1, 2: 2, 3: 3}},
-                    {'atom_map': {0: 1, 1: 2, 2: 3, 3: 4}}]
+    mapped_types = [
+        {"atom_map": None},
+        {"atom_map": {0: 0}},
+        {"atom_map": {0: 0, 1: 0, 2: 0, 3: 0}},
+        {"atom_map": {0: 0, 1: 1, 2: 2, 3: 3}},
+        {"atom_map": {0: 1, 1: 2, 2: 3, 3: 4}},
+    ]
 
-    @pytest.mark.parametrize('toolkit_class', [OpenEyeToolkitWrapper, RDKitToolkitWrapper])
-    @pytest.mark.parametrize('data', mapped_types)
+    @pytest.mark.parametrize(
+        "toolkit_class", [OpenEyeToolkitWrapper, RDKitToolkitWrapper]
+    )
+    @pytest.mark.parametrize("data", mapped_types)
     def test_partial_mapped_smiles(self, toolkit_class, data):
 
         if toolkit_class.is_available():
             toolkit = toolkit_class()
             mol = create_cis_1_2_dichloroethene()
-            mol._properties['atom_map'] = data['atom_map']
+            mol._properties["atom_map"] = data["atom_map"]
 
-            smiles = mol.to_smiles(isomeric=True, explicit_hydrogens=True,
-                                   mapped=True, toolkit_registry=toolkit)
+            smiles = mol.to_smiles(
+                isomeric=True,
+                explicit_hydrogens=True,
+                mapped=True,
+                toolkit_registry=toolkit,
+            )
 
             # now we just need to check the smiles generated
-            if data['atom_map'] is None:
+            if data["atom_map"] is None:
                 for i, atom in enumerate(mol.atoms, 1):
-                    assert f'[{atom.element.symbol}:{i}]' in smiles
+                    assert f"[{atom.element.symbol}:{i}]" in smiles
             else:
-                if 0 in data['atom_map'].values():
+                if 0 in data["atom_map"].values():
                     increment = True
                 else:
                     increment = False
 
-                for atom, index in data['atom_map'].items():
-                    assert f'[{mol.atoms[atom].element.symbol}:{index + 1 if increment else index}]'
+                for atom, index in data["atom_map"].items():
+                    assert f"[{mol.atoms[atom].element.symbol}:{index + 1 if increment else index}]"
 
         else:
-            pytest.skip(f'The required toolkit ({toolkit_class.toolkit_name}) is not available.')
+            pytest.skip(
+                f"The required toolkit ({toolkit_class.toolkit_name}) is not available."
+            )
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_unique_atom_names(self, molecule):
         """Test molecules have unique atom names"""
         # The dataset we load in has atom names, so let's strip them first
         # to ensure that we can fail the uniqueness check
         for atom in molecule.atoms:
-            atom.name = ''
-        assert not(molecule.has_unique_atom_names)
+            atom.name = ""
+        assert not (molecule.has_unique_atom_names)
         # Then genreate unique atom names using the built in algorithm
         molecule.generate_unique_atom_names()
         # Check that the molecule has unique atom names
         assert molecule.has_unique_atom_names
         # Check molecule.has_unique_atom_names is working correctly
-        assert ((len(set([atom.name for atom in molecule.atoms])) == molecule.n_atoms) == molecule.has_unique_atom_names)
-        molecule.atoms[1].name = molecule.atoms[0].name # no longer unique
-        assert ((len(set([atom.name for atom in molecule.atoms])) == molecule.n_atoms) == molecule.has_unique_atom_names)
+        assert (
+            len(set([atom.name for atom in molecule.atoms])) == molecule.n_atoms
+        ) == molecule.has_unique_atom_names
+        molecule.atoms[1].name = molecule.atoms[0].name  # no longer unique
+        assert (
+            len(set([atom.name for atom in molecule.atoms])) == molecule.n_atoms
+        ) == molecule.has_unique_atom_names
 
-    inchi_data = [{'molecule': create_ethanol(), 'standard_inchi': 'InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3',
-                   'fixed_hydrogen_inchi': 'InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3'},
-                  {'molecule': create_reversed_ethanol(), 'standard_inchi': 'InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3',
-                   'fixed_hydrogen_inchi': 'InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3'},
-                  {'molecule': create_acetaldehyde(), 'standard_inchi': 'InChI=1S/C2H4O/c1-2-3/h2H,1H3',
-                   'fixed_hydrogen_inchi': 'InChI=1/C2H4O/c1-2-3/h2H,1H3'},
-                  {'molecule': create_cyclohexane(), 'standard_inchi': 'InChI=1S/C6H12/c1-2-4-6-5-3-1/h1-6H2',
-                   'fixed_hydrogen_inchi': 'InChI=1/C6H12/c1-2-4-6-5-3-1/h1-6H2'}
-                  ]
+    inchi_data = [
+        {
+            "molecule": create_ethanol(),
+            "standard_inchi": "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3",
+            "fixed_hydrogen_inchi": "InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3",
+        },
+        {
+            "molecule": create_reversed_ethanol(),
+            "standard_inchi": "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3",
+            "fixed_hydrogen_inchi": "InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3",
+        },
+        {
+            "molecule": create_acetaldehyde(),
+            "standard_inchi": "InChI=1S/C2H4O/c1-2-3/h2H,1H3",
+            "fixed_hydrogen_inchi": "InChI=1/C2H4O/c1-2-3/h2H,1H3",
+        },
+        {
+            "molecule": create_cyclohexane(),
+            "standard_inchi": "InChI=1S/C6H12/c1-2-4-6-5-3-1/h1-6H2",
+            "fixed_hydrogen_inchi": "InChI=1/C6H12/c1-2-4-6-5-3-1/h1-6H2",
+        },
+    ]
 
-    @pytest.mark.parametrize('data', inchi_data)
+    @pytest.mark.parametrize("data", inchi_data)
     def test_from_inchi(self, data):
         """Test building a molecule from standard and non-standard InChI strings."""
 
         toolkit = OpenEyeToolkitWrapper()
-        ref_mol = data['molecule']
+        ref_mol = data["molecule"]
         # make a molecule from inchi
-        inchi_mol = Molecule.from_inchi(data['standard_inchi'], toolkit_registry=toolkit)
-        assert inchi_mol.to_inchi(toolkit_registry=toolkit) == data['standard_inchi']
+        inchi_mol = Molecule.from_inchi(
+            data["standard_inchi"], toolkit_registry=toolkit
+        )
+        assert inchi_mol.to_inchi(toolkit_registry=toolkit) == data["standard_inchi"]
 
         def compare_mols(ref_mol, inchi_mol):
             assert ref_mol.n_atoms == inchi_mol.n_atoms
@@ -574,9 +724,15 @@ class TestMolecule:
         compare_mols(ref_mol, inchi_mol)
 
         # now make the molecule from the non-standard inchi and compare
-        nonstandard_inchi_mol = Molecule.from_inchi(data['fixed_hydrogen_inchi'], toolkit_registry=toolkit)
-        assert nonstandard_inchi_mol.to_inchi(fixed_hydrogens=True, toolkit_registry=toolkit) == data[
-            'fixed_hydrogen_inchi']
+        nonstandard_inchi_mol = Molecule.from_inchi(
+            data["fixed_hydrogen_inchi"], toolkit_registry=toolkit
+        )
+        assert (
+            nonstandard_inchi_mol.to_inchi(
+                fixed_hydrogens=True, toolkit_registry=toolkit
+            )
+            == data["fixed_hydrogen_inchi"]
+        )
 
         compare_mols(ref_mol, nonstandard_inchi_mol)
 
@@ -585,45 +741,50 @@ class TestMolecule:
     def test_create_from_file(self):
         """Test standard constructor taking a filename or file-like object."""
         # TODO: Expand test to both openeye and rdkit toolkits
-        filename = get_data_file_path('molecules/toluene.mol2')
+        filename = get_data_file_path("molecules/toluene.mol2")
 
         molecule1 = Molecule(filename, allow_undefined_stereo=True)
-        with open(filename, 'r') as infile:
-            molecule2 = Molecule(infile, file_format='MOL2', allow_undefined_stereo=True)
+        with open(filename, "r") as infile:
+            molecule2 = Molecule(
+                infile, file_format="MOL2", allow_undefined_stereo=True
+            )
         assert molecule1 == molecule2
 
         import gzip
-        with gzip.GzipFile(filename + '.gz', 'r') as infile:
-            molecule3 = Molecule(infile, file_format='MOL2', allow_undefined_stereo=True)
+
+        with gzip.GzipFile(filename + ".gz", "r") as infile:
+            molecule3 = Molecule(
+                infile, file_format="MOL2", allow_undefined_stereo=True
+            )
         assert molecule3 == molecule1
 
         # Ensure that attempting to initialize a single Molecule from a file
         # containing multiple molecules raises a ValueError
         with pytest.raises(ValueError) as exc_info:
-            filename = get_data_file_path('molecules/zinc-subset-tripos.mol2.gz')
+            filename = get_data_file_path("molecules/zinc-subset-tripos.mol2.gz")
             molecule = Molecule(filename, allow_undefined_stereo=True)
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_create_from_serialized(self, molecule):
         """Test standard constructor taking the output of __getstate__()."""
         serialized_molecule = molecule.__getstate__()
         molecule_copy = Molecule(serialized_molecule)
         assert molecule == molecule_copy
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_from_dict(self, molecule):
         """Test that conversion/creation of a molecule to and from a dict is consistent."""
         serialized = molecule.to_dict()
         molecule_copy = Molecule.from_dict(serialized)
         assert molecule == molecule_copy
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_networkx(self, molecule):
         """Test conversion to NetworkX graph."""
         graph = molecule.to_networkx()
 
     @requires_rdkit
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_from_rdkit(self, molecule):
         """Test that conversion/creation of a molecule to and from an RDKit rdmol is consistent.
         """
@@ -653,7 +814,9 @@ class TestMolecule:
         assert molecule_smiles == test_mol_smiles
 
         # Check that the two topologies are isomorphic.
-        assert_molecule_is_equal(molecule, test_mol, 'Molecule.to_rdkit()/Molecule(rdmol) round trip failed')
+        assert_molecule_is_equal(
+            molecule, test_mol, "Molecule.to_rdkit()/Molecule(rdmol) round trip failed"
+        )
 
         # Second, test making a molecule using the Molecule.from_openeye(oemol) method
 
@@ -670,30 +833,32 @@ class TestMolecule:
         assert molecule_smiles == test_mol_smiles
 
         # Check that the two topologies are isomorphic.
-        assert_molecule_is_equal(molecule, test_mol, 'Molecule.to_rdkit()/from_rdkit() round trip failed')
-
+        assert_molecule_is_equal(
+            molecule, test_mol, "Molecule.to_rdkit()/from_rdkit() round trip failed"
+        )
 
     # TODO: Should there be an equivalent toolkit test and leave this as an integration test?
     @requires_openeye
-    @pytest.mark.parametrize('molecule', mini_drug_bank(
-        xfail_mols={
-            'DrugBank_2397': 'OpenEye cannot generate a correct IUPAC name and raises a "Warning: Incorrect name:" or simply return "BLAH".',
-            'DrugBank_2543': 'OpenEye cannot generate a correct IUPAC name and raises a "Warning: Incorrect name:" or simply return "BLAH".',
-            'DrugBank_2642': 'OpenEye cannot generate a correct IUPAC name and raises a "Warning: Incorrect name:" or simply return "BLAH".',
-        },
-        wip_mols={
-            'DrugBank_1212': 'the roundtrip generates molecules with very different IUPAC/SMILES!',
-            'DrugBank_2210': 'the roundtrip generates molecules with very different IUPAC/SMILES!',
-            'DrugBank_4584': 'the roundtrip generates molecules with very different IUPAC/SMILES!',
-
-            'DrugBank_390': 'raises warning "Unable to make OFFMol from OEMol: OEMol has unspecified stereochemistry."',
-            'DrugBank_810': 'raises warning "Unable to make OFFMol from OEMol: OEMol has unspecified stereochemistry."',
-            'DrugBank_4316': 'raises warning "Unable to make OFFMol from OEMol: OEMol has unspecified stereochemistry."',
-            'DrugBank_7124': 'raises warning "Unable to make OFFMol from OEMol: OEMol has unspecified stereochemistry."',
-
-            'DrugBank_4346': 'raises warning "Failed to parse name:"',
-        }
-    ))
+    @pytest.mark.parametrize(
+        "molecule",
+        mini_drug_bank(
+            xfail_mols={
+                "DrugBank_2397": 'OpenEye cannot generate a correct IUPAC name and raises a "Warning: Incorrect name:" or simply return "BLAH".',
+                "DrugBank_2543": 'OpenEye cannot generate a correct IUPAC name and raises a "Warning: Incorrect name:" or simply return "BLAH".',
+                "DrugBank_2642": 'OpenEye cannot generate a correct IUPAC name and raises a "Warning: Incorrect name:" or simply return "BLAH".',
+            },
+            wip_mols={
+                "DrugBank_1212": "the roundtrip generates molecules with very different IUPAC/SMILES!",
+                "DrugBank_2210": "the roundtrip generates molecules with very different IUPAC/SMILES!",
+                "DrugBank_4584": "the roundtrip generates molecules with very different IUPAC/SMILES!",
+                "DrugBank_390": 'raises warning "Unable to make OFFMol from OEMol: OEMol has unspecified stereochemistry."',
+                "DrugBank_810": 'raises warning "Unable to make OFFMol from OEMol: OEMol has unspecified stereochemistry."',
+                "DrugBank_4316": 'raises warning "Unable to make OFFMol from OEMol: OEMol has unspecified stereochemistry."',
+                "DrugBank_7124": 'raises warning "Unable to make OFFMol from OEMol: OEMol has unspecified stereochemistry."',
+                "DrugBank_4346": 'raises warning "Failed to parse name:"',
+            },
+        ),
+    )
     def test_to_from_iupac(self, molecule):
         """Test that conversion/creation of a molecule to and from a IUPAC name is consistent."""
         from openforcefield.utils.toolkits import UndefinedStereochemistryError
@@ -701,21 +866,53 @@ class TestMolecule:
         # All the molecules that raise UndefinedStereochemistryError in Molecule.from_iupac()
         # (This is a larger list than the normal group of undefined stereo mols, probably has
         # something to do with IUPAC information content)
-        iupac_problem_mols = {'DrugBank_977', 'DrugBank_1634', 'DrugBank_1700', 'DrugBank_1962',
-                              'DrugBank_2148', 'DrugBank_2178', 'DrugBank_2186', 'DrugBank_2208',
-                              'DrugBank_2519', 'DrugBank_2538', 'DrugBank_2592', 'DrugBank_2651',
-                              'DrugBank_2987', 'DrugBank_3332', 'DrugBank_3502', 'DrugBank_3622',
-                              'DrugBank_3726', 'DrugBank_3844', 'DrugBank_3930', 'DrugBank_4161',
-                              'DrugBank_4162', 'DrugBank_4778', 'DrugBank_4593', 'DrugBank_4959',
-                              'DrugBank_5043', 'DrugBank_5076', 'DrugBank_5176', 'DrugBank_5418',
-                              'DrugBank_5737', 'DrugBank_5902', 'DrugBank_6295', 'DrugBank_6304',
-                              'DrugBank_6305', 'DrugBank_6329', 'DrugBank_6355', 'DrugBank_6401',
-                              'DrugBank_6509', 'DrugBank_6531', 'DrugBank_6647',
-
-                              # These test cases are allowed to fail.
-                              'DrugBank_390', 'DrugBank_810', 'DrugBank_4316', 'DrugBank_4346',
-                              'DrugBank_7124'
-                              }
+        iupac_problem_mols = {
+            "DrugBank_977",
+            "DrugBank_1634",
+            "DrugBank_1700",
+            "DrugBank_1962",
+            "DrugBank_2148",
+            "DrugBank_2178",
+            "DrugBank_2186",
+            "DrugBank_2208",
+            "DrugBank_2519",
+            "DrugBank_2538",
+            "DrugBank_2592",
+            "DrugBank_2651",
+            "DrugBank_2987",
+            "DrugBank_3332",
+            "DrugBank_3502",
+            "DrugBank_3622",
+            "DrugBank_3726",
+            "DrugBank_3844",
+            "DrugBank_3930",
+            "DrugBank_4161",
+            "DrugBank_4162",
+            "DrugBank_4778",
+            "DrugBank_4593",
+            "DrugBank_4959",
+            "DrugBank_5043",
+            "DrugBank_5076",
+            "DrugBank_5176",
+            "DrugBank_5418",
+            "DrugBank_5737",
+            "DrugBank_5902",
+            "DrugBank_6295",
+            "DrugBank_6304",
+            "DrugBank_6305",
+            "DrugBank_6329",
+            "DrugBank_6355",
+            "DrugBank_6401",
+            "DrugBank_6509",
+            "DrugBank_6531",
+            "DrugBank_6647",
+            # These test cases are allowed to fail.
+            "DrugBank_390",
+            "DrugBank_810",
+            "DrugBank_4316",
+            "DrugBank_4346",
+            "DrugBank_7124",
+        }
         undefined_stereo = molecule.name in iupac_problem_mols
 
         iupac = molecule.to_iupac()
@@ -724,11 +921,14 @@ class TestMolecule:
             with pytest.raises(UndefinedStereochemistryError):
                 Molecule.from_iupac(iupac)
 
-        molecule_copy = Molecule.from_iupac(iupac, allow_undefined_stereo=undefined_stereo)
-        assert molecule.is_isomorphic_with(molecule_copy,
-                                           atom_stereochemistry_matching=not undefined_stereo)
+        molecule_copy = Molecule.from_iupac(
+            iupac, allow_undefined_stereo=undefined_stereo
+        )
+        assert molecule.is_isomorphic_with(
+            molecule_copy, atom_stereochemistry_matching=not undefined_stereo
+        )
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_from_topology(self, molecule):
         """Test that conversion/creation of a molecule to and from a Topology is consistent."""
         topology = molecule.to_topology()
@@ -739,7 +939,9 @@ class TestMolecule:
         """Test writing out a molecule with multiple conformations to an xyz file"""
 
         # load in an SDF of butane with multiple conformers in it
-        molecules = Molecule.from_file(get_data_file_path('molecules/butane_multi.sdf'), 'sdf')
+        molecules = Molecule.from_file(
+            get_data_file_path("molecules/butane_multi.sdf"), "sdf"
+        )
         # now we want to combine the conformers to one molecule
         butane = molecules[0]
         for mol in molecules[1:]:
@@ -747,9 +949,9 @@ class TestMolecule:
 
         # make sure we have the 7 conformers
         assert butane.n_conformers == 7
-        with NamedTemporaryFile(suffix='.xyz') as iofile:
+        with NamedTemporaryFile(suffix=".xyz") as iofile:
             # try and write out the xyz file
-            butane.to_file(iofile.name, 'xyz')
+            butane.to_file(iofile.name, "xyz")
 
             # now lets check whats in the file
             with open(iofile.name) as xyz_data:
@@ -757,18 +959,20 @@ class TestMolecule:
                 # make sure we have the correct amount of lines writen
                 assert len(data) == 112
                 # make sure all headers and frame data was writen
-                assert data.count('14\n') == 7
+                assert data.count("14\n") == 7
                 for i in range(1, 8):
-                    assert f'C4H10 Frame {i}\n' in data
+                    assert f"C4H10 Frame {i}\n" in data
 
                 # now make sure the first line of the coordinates are correct in every frame
-                coords = ['C        1.8902000189    0.0425999984    0.2431000024\n',
-                          'C        1.8976000547   -0.0232999995    0.2845999897\n',
-                          'C       -1.8794000149   -0.1792999953   -0.2565000057\n',
-                          'C       -1.5205999613   -0.0164999999    0.2786999941\n',
-                          'C       -1.4889999628   -0.2619000077    0.4871000051\n',
-                          'C       -1.4940999746   -0.2249000072   -0.0957999974\n',
-                          'C       -1.8826999664   -0.0372000001    0.1937000006\n']
+                coords = [
+                    "C        1.8902000189    0.0425999984    0.2431000024\n",
+                    "C        1.8976000547   -0.0232999995    0.2845999897\n",
+                    "C       -1.8794000149   -0.1792999953   -0.2565000057\n",
+                    "C       -1.5205999613   -0.0164999999    0.2786999941\n",
+                    "C       -1.4889999628   -0.2619000077    0.4871000051\n",
+                    "C       -1.4940999746   -0.2249000072   -0.0957999974\n",
+                    "C       -1.8826999664   -0.0372000001    0.1937000006\n",
+                ]
                 for coord in coords:
                     assert coord in data
 
@@ -776,13 +980,13 @@ class TestMolecule:
         """Test writing to a single frame xyz file"""
 
         # load a molecule with a single conformation
-        toluene = Molecule.from_file(get_data_file_path('molecules/toluene.sdf'), 'sdf')
+        toluene = Molecule.from_file(get_data_file_path("molecules/toluene.sdf"), "sdf")
         # make sure it has one conformer
         assert toluene.n_conformers == 1
 
-        with NamedTemporaryFile(suffix='.xyz') as iofile:
+        with NamedTemporaryFile(suffix=".xyz") as iofile:
             # try and write out the xyz file
-            toluene.to_file(iofile.name, 'xyz')
+            toluene.to_file(iofile.name, "xyz")
 
             # now lets check the file contents
             with open(iofile.name) as xyz_data:
@@ -790,11 +994,13 @@ class TestMolecule:
                 # make sure we have the correct amount of lines writen
                 assert len(data) == 17
                 # make sure all headers and frame data was writen
-                assert data.count('15\n') == 1
-                assert data.count('C7H8\n') == 1
+                assert data.count("15\n") == 1
+                assert data.count("C7H8\n") == 1
                 # now check that we can find the first and last coords
-                coords = ['C        0.0000000000    0.0000000000    0.0000000000\n',
-                          'H       -0.0000000000    3.7604000568    0.0000000000\n']
+                coords = [
+                    "C        0.0000000000    0.0000000000    0.0000000000\n",
+                    "H       -0.0000000000    3.7604000568    0.0000000000\n",
+                ]
                 for coord in coords:
                     assert coord in data
 
@@ -805,9 +1011,9 @@ class TestMolecule:
         ethanol = create_ethanol()
         assert ethanol.n_conformers == 0
 
-        with NamedTemporaryFile(suffix='.xyz') as iofile:
+        with NamedTemporaryFile(suffix=".xyz") as iofile:
             # try and write out the xyz file
-            ethanol.to_file(iofile.name, 'xyz')
+            ethanol.to_file(iofile.name, "xyz")
 
             # now lets check the file contents
             with open(iofile.name) as xyz_data:
@@ -815,46 +1021,63 @@ class TestMolecule:
                 # make sure we have the correct amount of lines writen
                 assert len(data) == 11
                 # make sure all headers and frame data was writen
-                assert data.count('9\n') == 1
-                assert data.count('C2H6O\n') == 1
+                assert data.count("9\n") == 1
+                assert data.count("C2H6O\n") == 1
                 # now check that all coords are 0
-                coords = ['0.0000000000', '0.0000000000', '0.0000000000']
+                coords = ["0.0000000000", "0.0000000000", "0.0000000000"]
                 for atom_coords in data[2:]:
                     assert atom_coords.split()[1:] == coords
 
     # TODO: Should there be an equivalent toolkit test and leave this as an integration test?
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
-    @pytest.mark.parametrize('format', [
-        'mol2',
-        'sdf',
-        pytest.param('pdb', marks=pytest.mark.wip(reason='Read from pdb has not been implemented properly yet'))
-    ])
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
+    @pytest.mark.parametrize(
+        "format",
+        [
+            "mol2",
+            "sdf",
+            pytest.param(
+                "pdb",
+                marks=pytest.mark.wip(
+                    reason="Read from pdb has not been implemented properly yet"
+                ),
+            ),
+        ],
+    )
     def test_to_from_file(self, molecule, format):
         """Test that conversion/creation of a molecule to and from a file is consistent."""
         from openforcefield.utils.toolkits import UndefinedStereochemistryError
+
         # TODO: Test all file capabilities; the current test is minimal
 
         # TODO: This is only for OE. Expand to both OE and RDKit toolkits.
         # Molecules that are known to raise UndefinedStereochemistryError.
-        undefined_stereo_mols = {'DrugBank_1700', 'DrugBank_2987', 'DrugBank_3502', 'DrugBank_4161',
-                                 'DrugBank_4162', 'DrugBank_6531'}
+        undefined_stereo_mols = {
+            "DrugBank_1700",
+            "DrugBank_2987",
+            "DrugBank_3502",
+            "DrugBank_4161",
+            "DrugBank_4162",
+            "DrugBank_6531",
+        }
         undefined_stereo = molecule.name in undefined_stereo_mols
 
         # The file is automatically deleted outside the with-clause.
-        with NamedTemporaryFile(suffix='.' + format) as iofile:
+        with NamedTemporaryFile(suffix="." + format) as iofile:
             # If this has undefined stereo, check that the exception is raised.
             extension = os.path.splitext(iofile.name)[1][1:]
             molecule.to_file(iofile.name, extension)
             if undefined_stereo:
                 with pytest.raises(UndefinedStereochemistryError):
                     Molecule.from_file(iofile.name)
-            molecule2 = Molecule.from_file(iofile.name, allow_undefined_stereo=undefined_stereo)
+            molecule2 = Molecule.from_file(
+                iofile.name, allow_undefined_stereo=undefined_stereo
+            )
             assert molecule == molecule2
             # TODO: Test to make sure properties are preserved?
             # NOTE: We can't read pdb files and expect chemical information to be preserved
 
     @requires_openeye
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_from_oemol(self, molecule):
         """Test that conversion/creation of a molecule to and from a OEMol is consistent."""
         from openforcefield.utils.toolkits import UndefinedStereochemistryError
@@ -890,7 +1113,11 @@ class TestMolecule:
         assert molecule_smiles == test_mol_smiles
 
         # Check that the two topologies are isomorphic.
-        assert_molecule_is_equal(molecule, test_mol, 'Molecule.to_openeye()/Molecule(oemol) round trip failed')
+        assert_molecule_is_equal(
+            molecule,
+            test_mol,
+            "Molecule.to_openeye()/Molecule(oemol) round trip failed",
+        )
 
         # Second, test making a molecule using the Molecule.from_openeye(oemol) method
 
@@ -907,8 +1134,9 @@ class TestMolecule:
         assert molecule_smiles == test_mol_smiles
 
         # Check that the two topologies are isomorphic.
-        assert_molecule_is_equal(molecule, test_mol, 'Molecule.to_openeye()/from_openeye() round trip failed')
-
+        assert_molecule_is_equal(
+            molecule, test_mol, "Molecule.to_openeye()/from_openeye() round trip failed"
+        )
 
     # ----------------------------------------------------
     # Test properties.
@@ -920,10 +1148,10 @@ class TestMolecule:
         molecule1.name = None
 
         molecule2 = Molecule()
-        molecule2.name = ''
+        molecule2.name = ""
         assert molecule1.name == molecule2.name
 
-        name = 'benzene'
+        name = "benzene"
         molecule = Molecule()
         molecule.name = name
         assert molecule.name == name
@@ -932,30 +1160,32 @@ class TestMolecule:
         """Test that making the hill formula is consistent between input methods and ordering"""
         # make sure smiles match reference
         molecule_smiles = create_ethanol()
-        assert molecule_smiles.hill_formula == 'C2H6O'
+        assert molecule_smiles.hill_formula == "C2H6O"
         # make sure is not order dependent
         molecule_smiles_reverse = create_reversed_ethanol()
         assert molecule_smiles.hill_formula == molecule_smiles_reverse.hill_formula
         # make sure single element names are put first
-        order_mol = Molecule.from_smiles('C(Br)CB')
-        assert order_mol.hill_formula == 'C2H6BBr'
+        order_mol = Molecule.from_smiles("C(Br)CB")
+        assert order_mol.hill_formula == "C2H6BBr"
         # test molecule with no carbon
-        no_carb_mol = Molecule.from_smiles('OS(=O)(=O)O')
-        assert no_carb_mol.hill_formula == 'H2O4S'
+        no_carb_mol = Molecule.from_smiles("OS(=O)(=O)O")
+        assert no_carb_mol.hill_formula == "H2O4S"
         # test no carbon and hydrogen
-        br_i = Molecule.from_smiles('BrI')
-        assert br_i.hill_formula == 'BrI'
+        br_i = Molecule.from_smiles("BrI")
+        assert br_i.hill_formula == "BrI"
         # make sure files and smiles match
-        molecule_file = Molecule.from_file(get_data_file_path('molecules/ethanol.sdf'))
+        molecule_file = Molecule.from_file(get_data_file_path("molecules/ethanol.sdf"))
         assert molecule_smiles.hill_formula == molecule_file.hill_formula
         # make sure the topology molecule gives the same formula
         from openforcefield.topology.topology import TopologyMolecule, Topology
+
         topology = Topology.from_molecules(molecule_smiles)
         topmol = TopologyMolecule(molecule_smiles, topology)
         assert molecule_smiles.hill_formula == Molecule.to_hill_formula(topmol)
         # make sure the networkx matches
-        assert molecule_smiles.hill_formula == Molecule.to_hill_formula(molecule_smiles.to_networkx())
-
+        assert molecule_smiles.hill_formula == Molecule.to_hill_formula(
+            molecule_smiles.to_networkx()
+        )
 
     def test_isomorphic_general(self):
         """Test the matching using different input types"""
@@ -969,92 +1199,164 @@ class TestMolecule:
         assert ethanol.is_isomorphic_with(ethanol_reverse) is True
         # check a reference mapping between ethanol and ethanol_reverse matches that calculated
         ref_mapping = {0: 8, 1: 7, 2: 6, 3: 3, 4: 4, 5: 5, 6: 1, 7: 2, 8: 0}
-        assert Molecule.are_isomorphic(ethanol, ethanol_reverse, return_atom_map=True)[1] == ref_mapping
+        assert (
+            Molecule.are_isomorphic(ethanol, ethanol_reverse, return_atom_map=True)[1]
+            == ref_mapping
+        )
         # check matching with nx.Graph atomic numbers and connectivity only
-        assert Molecule.are_isomorphic(ethanol, ethanol_reverse.to_networkx(), aromatic_matching=False,
-                                       formal_charge_matching=False, bond_order_matching=False,
-                                       atom_stereochemistry_matching=False,
-                                       bond_stereochemistry_matching=False)[0] is True
+        assert (
+            Molecule.are_isomorphic(
+                ethanol,
+                ethanol_reverse.to_networkx(),
+                aromatic_matching=False,
+                formal_charge_matching=False,
+                bond_order_matching=False,
+                atom_stereochemistry_matching=False,
+                bond_stereochemistry_matching=False,
+            )[0]
+            is True
+        )
         # check matching with nx.Graph with full matching
         assert ethanol.is_isomorphic_with(ethanol_reverse.to_networkx()) is True
         # check matching with a TopologyMolecule class
         from openforcefield.topology.topology import TopologyMolecule, Topology
+
         topology = Topology.from_molecules(ethanol)
         topmol = TopologyMolecule(ethanol, topology)
-        assert Molecule.are_isomorphic(ethanol, topmol, aromatic_matching=False, formal_charge_matching=False,
-                                       bond_order_matching=False, atom_stereochemistry_matching=False,
-                                       bond_stereochemistry_matching=False)[0] is True
+        assert (
+            Molecule.are_isomorphic(
+                ethanol,
+                topmol,
+                aromatic_matching=False,
+                formal_charge_matching=False,
+                bond_order_matching=False,
+                atom_stereochemistry_matching=False,
+                bond_stereochemistry_matching=False,
+            )[0]
+            is True
+        )
         # test hill formula passes but isomorphic fails
-        mol1 = Molecule.from_smiles('Fc1ccc(F)cc1')
-        mol2 = Molecule.from_smiles('Fc1ccccc1F')
+        mol1 = Molecule.from_smiles("Fc1ccc(F)cc1")
+        mol2 = Molecule.from_smiles("Fc1ccccc1F")
         assert mol1.is_isomorphic_with(mol2) is False
         assert mol2.is_isomorphic_with(mol1) is False
 
-    isomorphic_permutations = [{'aromatic_matching': True, 'formal_charge_matching': True, 'bond_order_matching': True,
-                                'atom_stereochemistry_matching': True, 'bond_stereochemistry_matching': True,
-                                'result': False},
-                               {'aromatic_matching': False, 'formal_charge_matching': True, 'bond_order_matching': True,
-                                'atom_stereochemistry_matching': True, 'bond_stereochemistry_matching': True,
-                                'result': False},
-                               {'aromatic_matching': True, 'formal_charge_matching': False, 'bond_order_matching': True,
-                                'atom_stereochemistry_matching': True, 'bond_stereochemistry_matching': True,
-                                'result': False},
-                               {'aromatic_matching': True, 'formal_charge_matching': True, 'bond_order_matching': False,
-                                'atom_stereochemistry_matching': True, 'bond_stereochemistry_matching': True,
-                                'result': False},
-                               {'aromatic_matching': True, 'formal_charge_matching': True, 'bond_order_matching': True,
-                                'atom_stereochemistry_matching': False, 'bond_stereochemistry_matching': True,
-                                'result': False},
-                               {'aromatic_matching': True, 'formal_charge_matching': True, 'bond_order_matching': True,
-                                'atom_stereochemistry_matching': True, 'bond_stereochemistry_matching': False,
-                                'result': False},
-                               {'aromatic_matching': False, 'formal_charge_matching': False, 'bond_order_matching': False,
-                                'atom_stereochemistry_matching': False, 'bond_stereochemistry_matching': False,
-                                'result': True},
-                               {'aromatic_matching': False, 'formal_charge_matching': True, 'bond_order_matching': False,
-                                'atom_stereochemistry_matching': True, 'bond_stereochemistry_matching': True,
-                                'result': True},
-                               {'aromatic_matching': False, 'formal_charge_matching': False, 'bond_order_matching': False,
-                                'atom_stereochemistry_matching': True, 'bond_stereochemistry_matching': True,
-                                'result': True},
-                               ]
+    isomorphic_permutations = [
+        {
+            "aromatic_matching": True,
+            "formal_charge_matching": True,
+            "bond_order_matching": True,
+            "atom_stereochemistry_matching": True,
+            "bond_stereochemistry_matching": True,
+            "result": False,
+        },
+        {
+            "aromatic_matching": False,
+            "formal_charge_matching": True,
+            "bond_order_matching": True,
+            "atom_stereochemistry_matching": True,
+            "bond_stereochemistry_matching": True,
+            "result": False,
+        },
+        {
+            "aromatic_matching": True,
+            "formal_charge_matching": False,
+            "bond_order_matching": True,
+            "atom_stereochemistry_matching": True,
+            "bond_stereochemistry_matching": True,
+            "result": False,
+        },
+        {
+            "aromatic_matching": True,
+            "formal_charge_matching": True,
+            "bond_order_matching": False,
+            "atom_stereochemistry_matching": True,
+            "bond_stereochemistry_matching": True,
+            "result": False,
+        },
+        {
+            "aromatic_matching": True,
+            "formal_charge_matching": True,
+            "bond_order_matching": True,
+            "atom_stereochemistry_matching": False,
+            "bond_stereochemistry_matching": True,
+            "result": False,
+        },
+        {
+            "aromatic_matching": True,
+            "formal_charge_matching": True,
+            "bond_order_matching": True,
+            "atom_stereochemistry_matching": True,
+            "bond_stereochemistry_matching": False,
+            "result": False,
+        },
+        {
+            "aromatic_matching": False,
+            "formal_charge_matching": False,
+            "bond_order_matching": False,
+            "atom_stereochemistry_matching": False,
+            "bond_stereochemistry_matching": False,
+            "result": True,
+        },
+        {
+            "aromatic_matching": False,
+            "formal_charge_matching": True,
+            "bond_order_matching": False,
+            "atom_stereochemistry_matching": True,
+            "bond_stereochemistry_matching": True,
+            "result": True,
+        },
+        {
+            "aromatic_matching": False,
+            "formal_charge_matching": False,
+            "bond_order_matching": False,
+            "atom_stereochemistry_matching": True,
+            "bond_stereochemistry_matching": True,
+            "result": True,
+        },
+    ]
 
-    @pytest.mark.parametrize('inputs', isomorphic_permutations)
+    @pytest.mark.parametrize("inputs", isomorphic_permutations)
     def test_isomorphic_perumtations(self, inputs):
         """Test all of the different combinations of matching levels between benzene with and without the aromatic bonds
         defined"""
         # get benzene with all aromatic atoms/bonds labeled
-        benzene = Molecule.from_smiles('c1ccccc1')
+        benzene = Molecule.from_smiles("c1ccccc1")
         # get benzene with no aromatic labels
         benzene_no_aromatic = create_benzene_no_aromatic()
         # now test all of the variations
-        assert Molecule.are_isomorphic(benzene, benzene_no_aromatic, aromatic_matching=inputs['aromatic_matching'],
-                                       formal_charge_matching=inputs['formal_charge_matching'],
-                                       bond_order_matching=inputs['bond_order_matching'],
-                                       atom_stereochemistry_matching=inputs['atom_stereochemistry_matching'],
-                                       bond_stereochemistry_matching=inputs['bond_stereochemistry_matching'])[0] is inputs['result']
+        assert (
+            Molecule.are_isomorphic(
+                benzene,
+                benzene_no_aromatic,
+                aromatic_matching=inputs["aromatic_matching"],
+                formal_charge_matching=inputs["formal_charge_matching"],
+                bond_order_matching=inputs["bond_order_matching"],
+                atom_stereochemistry_matching=inputs["atom_stereochemistry_matching"],
+                bond_stereochemistry_matching=inputs["bond_stereochemistry_matching"],
+            )[0]
+            is inputs["result"]
+        )
 
     def test_strip_atom_stereochemistry(self):
         """Test the basic behavior of strip_atom_stereochemistry"""
-        mol = Molecule.from_smiles('CCC[N@@](C)CC')
+        mol = Molecule.from_smiles("CCC[N@@](C)CC")
 
-        nitrogen_idx = [atom.molecule_atom_index for atom in mol.atoms if atom.element.symbol == 'N'][0]
+        nitrogen_idx = [
+            atom.molecule_atom_index for atom in mol.atoms if atom.element.symbol == "N"
+        ][0]
 
-        assert mol.atoms[nitrogen_idx].stereochemistry == 'S'
-        mol.strip_atom_stereochemistry(smarts='[N+0X3:1](-[*])(-[*])(-[*])')
+        assert mol.atoms[nitrogen_idx].stereochemistry == "S"
+        mol.strip_atom_stereochemistry(smarts="[N+0X3:1](-[*])(-[*])(-[*])")
         assert mol.atoms[nitrogen_idx].stereochemistry is None
 
-        mol = Molecule.from_smiles('CCC[N@@](C)CC')
+        mol = Molecule.from_smiles("CCC[N@@](C)CC")
 
-        assert mol.atoms[nitrogen_idx].stereochemistry == 'S'
-        mol.strip_atom_stereochemistry(smarts='[N+0X3:1](-[*])(-[*])(-[*])')
+        assert mol.atoms[nitrogen_idx].stereochemistry == "S"
+        mol.strip_atom_stereochemistry(smarts="[N+0X3:1](-[*])(-[*])(-[*])")
         assert mol.atoms[nitrogen_idx].stereochemistry is None
 
-    @pytest.mark.parametrize('mol_smiles',
-        [
-            ('C[N+](CC)(CC)CC'),
-            ('c1cnc[nH]1')
-        ])
+    @pytest.mark.parametrize("mol_smiles", [("C[N+](CC)(CC)CC"), ("c1cnc[nH]1")])
     def test_do_not_strip_atom_stereochemsitry(self, mol_smiles):
         """
         Test special cases in which we do not want nitrogen stereochemistry stripped:
@@ -1062,7 +1364,7 @@ class TestMolecule:
         """
         mol = Molecule.from_smiles(mol_smiles)
         mol_mod = copy.deepcopy(mol)
-        mol_mod.strip_atom_stereochemistry('[N+0X3:1](-[*])(-[*])(-[*])')
+        mol_mod.strip_atom_stereochemistry("[N+0X3:1](-[*])(-[*])(-[*])")
 
         # Inspect each atom's stereochemistry instead of relying on __eq__
         for before, after in zip(mol.atoms, mol_mod.atoms):
@@ -1070,8 +1372,8 @@ class TestMolecule:
 
     def test_isomorphic_striped_stereochemistry(self):
         """Test that the equality operator disregards an edge case of nitrogen stereocenters"""
-        mol1 = Molecule.from_smiles('CCC[N@](C)CC')
-        mol2 = Molecule.from_smiles('CCC[N@@](C)CC')
+        mol1 = Molecule.from_smiles("CCC[N@](C)CC")
+        mol2 = Molecule.from_smiles("CCC[N@@](C)CC")
 
         # Ensure default value is respected and order does not matter
         assert Molecule.are_isomorphic(mol1, mol2, strip_pyrimidal_n_atom_stereo=True)
@@ -1079,10 +1381,12 @@ class TestMolecule:
         assert Molecule.are_isomorphic(mol2, mol1)
 
         assert mol1 == mol2
-        assert Molecule.from_smiles('CCC[N@](C)CC') == Molecule.from_smiles('CCC[N@@](C)CC')
+        assert Molecule.from_smiles("CCC[N@](C)CC") == Molecule.from_smiles(
+            "CCC[N@@](C)CC"
+        )
 
-        mol1 = Molecule.from_smiles('CCC[N@](C)CC')
-        mol2 = Molecule.from_smiles('CCC[N@@](C)CC')
+        mol1 = Molecule.from_smiles("CCC[N@](C)CC")
+        mol2 = Molecule.from_smiles("CCC[N@@](C)CC")
 
         assert not Molecule.are_isomorphic(
             mol1,
@@ -1116,7 +1420,9 @@ class TestMolecule:
                 assert atoms[0].to_dict() == atoms[1].to_dict()
             # bonds will not be in the same order in the molecule and the atom1 and atom2 indecies could be out of order
             # make a dict to compare them both
-            remapped_bonds = dict(((bond.atom1_index, bond.atom2_index), bond) for bond in mol2.bonds)
+            remapped_bonds = dict(
+                ((bond.atom1_index, bond.atom2_index), bond) for bond in mol2.bonds
+            )
             for bond in mol1.bonds:
                 key = (bond.atom1_index, bond.atom2_index)
                 if key not in remapped_bonds:
@@ -1124,11 +1430,11 @@ class TestMolecule:
                 assert key in remapped_bonds
                 # now compare each attribute of the bond except the atom indexes
                 bond_dict = bond.to_dict()
-                del bond_dict['atom1']
-                del bond_dict['atom2']
+                del bond_dict["atom1"]
+                del bond_dict["atom2"]
                 remapped_bond_dict = remapped_bonds[key].to_dict()
-                del remapped_bond_dict['atom1']
-                del remapped_bond_dict['atom2']
+                del remapped_bond_dict["atom1"]
+                del remapped_bond_dict["atom2"]
             assert mol1.n_bonds == mol2.n_bonds
             assert mol1.n_angles == mol2.n_angles
             assert mol1.n_propers == mol2.n_propers
@@ -1142,7 +1448,9 @@ class TestMolecule:
 
         # test round trip (double remapping a molecule)
         new_ethanol = ethanol.remap(mapping, current_to_new=True)
-        isomorphic, round_trip_mapping = Molecule.are_isomorphic(new_ethanol, ethanol, return_atom_map=True)
+        isomorphic, round_trip_mapping = Molecule.are_isomorphic(
+            new_ethanol, ethanol, return_atom_map=True
+        )
         assert isomorphic is True
         round_trip_ethanol = new_ethanol.remap(round_trip_mapping, current_to_new=True)
         assert_molecules_match_after_remap(round_trip_ethanol, ethanol)
@@ -1160,8 +1468,10 @@ class TestMolecule:
         # get the canonical ordering
         canonical_ethanol = reversed_ethanol.canonical_order_atoms(openeye)
         # make sure the mapping between the ethanol and the openeye ref canonical form is the same
-        assert (True, {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8}) == Molecule.are_isomorphic(canonical_ethanol,
-                                                                                                         ethanol, True)
+        assert (
+            True,
+            {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8},
+        ) == Molecule.are_isomorphic(canonical_ethanol, ethanol, True)
 
     @requires_rdkit
     def test_canonical_ordering_rdkit(self):
@@ -1176,13 +1486,14 @@ class TestMolecule:
         # get the canonical ordering
         canonical_ethanol = reversed_ethanol.canonical_order_atoms(rdkit)
         # make sure the mapping between the ethanol and the rdkit ref canonical form is the same
-        assert (True, {0: 2, 1: 0, 2: 1, 3: 8, 4: 3, 5: 4, 6: 5, 7: 6, 8: 7}) == Molecule.are_isomorphic(canonical_ethanol,
-                                                                                                         ethanol,
-                                                                                                         True)
+        assert (
+            True,
+            {0: 2, 1: 0, 2: 1, 3: 8, 4: 3, 5: 4, 6: 5, 7: 6, 8: 7},
+        ) == Molecule.are_isomorphic(canonical_ethanol, ethanol, True)
 
     def test_too_small_remap(self):
         """Make sure remap fails if we do not supply enough indexes"""
-        ethanol = Molecule.from_file(get_data_file_path('molecules/ethanol.sdf'))
+        ethanol = Molecule.from_file(get_data_file_path("molecules/ethanol.sdf"))
         # catch mappings that are the wrong size
         too_small_mapping = {0: 1}
         with pytest.raises(ValueError):
@@ -1190,28 +1501,38 @@ class TestMolecule:
 
     def test_wrong_index_mapping(self):
         """Make sure the remap fails when the indexing starts from the wrong value"""
-        ethanol = Molecule.from_file(get_data_file_path('molecules/ethanol.sdf'))
+        ethanol = Molecule.from_file(get_data_file_path("molecules/ethanol.sdf"))
         mapping = {0: 2, 1: 1, 2: 0, 3: 6, 4: 7, 5: 8, 6: 4, 7: 5, 8: 3}
-        wrong_index_mapping = dict((i + 10, new_id) for i, new_id in enumerate(mapping.values()))
+        wrong_index_mapping = dict(
+            (i + 10, new_id) for i, new_id in enumerate(mapping.values())
+        )
         with pytest.raises(IndexError):
             new_ethanol = ethanol.remap(wrong_index_mapping, current_to_new=True)
 
-    tautomer_data = [{'molecule': 'Oc1c(cccc3)c3nc2ccncc12', 'tautomers': 2},
-                     {'molecule': 'CN=c1nc[nH]cc1', 'tautomers': 2},
-                     {'molecule': 'c1[nH]c2c(=O)[nH]c(nc2n1)N', 'tautomers': 14}]
+    tautomer_data = [
+        {"molecule": "Oc1c(cccc3)c3nc2ccncc12", "tautomers": 2},
+        {"molecule": "CN=c1nc[nH]cc1", "tautomers": 2},
+        {"molecule": "c1[nH]c2c(=O)[nH]c(nc2n1)N", "tautomers": 14},
+    ]
 
-    @pytest.mark.parametrize('toolkit_class', [OpenEyeToolkitWrapper, RDKitToolkitWrapper])
-    @pytest.mark.parametrize('molecule_data', tautomer_data)
+    @pytest.mark.parametrize(
+        "toolkit_class", [OpenEyeToolkitWrapper, RDKitToolkitWrapper]
+    )
+    @pytest.mark.parametrize("molecule_data", tautomer_data)
     def test_enumerating_tautomers(self, molecule_data, toolkit_class):
         """Test the ability of each toolkit to produce tautomers of an input molecule."""
 
         if toolkit_class.is_available():
             toolkit = toolkit_class()
-            mol = Molecule.from_smiles(molecule_data['molecule'], allow_undefined_stereo=True, toolkit_registry=toolkit)
+            mol = Molecule.from_smiles(
+                molecule_data["molecule"],
+                allow_undefined_stereo=True,
+                toolkit_registry=toolkit,
+            )
 
             tautomers = mol.enumerate_tautomers(toolkit_registry=toolkit)
 
-            assert len(tautomers) == molecule_data['tautomers']
+            assert len(tautomers) == molecule_data["tautomers"]
             assert mol not in tautomers
             # check that the molecules are not isomorphic of the input
             for taut in tautomers:
@@ -1219,41 +1540,51 @@ class TestMolecule:
                 assert mol.is_isomorphic_with(taut) is False
 
         else:
-            pytest.skip('Required toolkit is unavailable')
+            pytest.skip("Required toolkit is unavailable")
 
-    @pytest.mark.parametrize('toolkit_class', [OpenEyeToolkitWrapper, RDKitToolkitWrapper])
+    @pytest.mark.parametrize(
+        "toolkit_class", [OpenEyeToolkitWrapper, RDKitToolkitWrapper]
+    )
     def test_enumerating_tautomers_options(self, toolkit_class):
         """Test the enumeration options"""
 
         if toolkit_class.is_available():
             toolkit = toolkit_class()
             # test the max molecules option
-            mol = Molecule.from_smiles('c1[nH]c2c(=O)[nH]c(nc2n1)N', toolkit_registry=toolkit, allow_undefined_stereo=True)
+            mol = Molecule.from_smiles(
+                "c1[nH]c2c(=O)[nH]c(nc2n1)N",
+                toolkit_registry=toolkit,
+                allow_undefined_stereo=True,
+            )
 
             tauts_no = 5
-            tautomers = mol.enumerate_tautomers(max_states=tauts_no, toolkit_registry=toolkit)
+            tautomers = mol.enumerate_tautomers(
+                max_states=tauts_no, toolkit_registry=toolkit
+            )
             assert len(tautomers) <= tauts_no
             assert mol not in tautomers
 
-    @pytest.mark.parametrize('toolkit_class', [RDKitToolkitWrapper, OpenEyeToolkitWrapper])
+    @pytest.mark.parametrize(
+        "toolkit_class", [RDKitToolkitWrapper, OpenEyeToolkitWrapper]
+    )
     def test_enumerating_no_tautomers(self, toolkit_class):
         """Test that the toolkits return an empty list if there are no tautomers to enumerate."""
 
         if toolkit_class.is_available():
             toolkit = toolkit_class()
-            mol = Molecule.from_smiles('CC', toolkit_registry=toolkit)
+            mol = Molecule.from_smiles("CC", toolkit_registry=toolkit)
 
             tautomers = mol.enumerate_tautomers(toolkit_registry=toolkit)
             assert tautomers == []
 
         else:
-            pytest.skip('Required toolkit is unavailable')
+            pytest.skip("Required toolkit is unavailable")
 
     @requires_openeye
     def test_enumerating_no_protomers(self):
         """Make sure no protomers are returned."""
 
-        mol = Molecule.from_smiles('CC')
+        mol = Molecule.from_smiles("CC")
 
         assert mol.enumerate_protomers() == []
 
@@ -1261,7 +1592,7 @@ class TestMolecule:
     def test_enumerating_protomers(self):
         """Test enumerating the formal charges."""
 
-        mol = Molecule.from_smiles('Oc2ccc(c1ccncc1)cc2')
+        mol = Molecule.from_smiles("Oc2ccc(c1ccncc1)cc2")
 
         # there should be three protomers for this molecule so restrict the output
         protomers = mol.enumerate_protomers(max_states=2)
@@ -1279,13 +1610,17 @@ class TestMolecule:
         unique_protomers = set(protomers)
         assert len(protomers) == len(unique_protomers)
 
-    @pytest.mark.parametrize('toolkit_class', [OpenEyeToolkitWrapper, RDKitToolkitWrapper])
+    @pytest.mark.parametrize(
+        "toolkit_class", [OpenEyeToolkitWrapper, RDKitToolkitWrapper]
+    )
     def test_enumerating_stereobonds(self, toolkit_class):
         """Test the backend toolkits in enumerating the stereo bonds in a molecule."""
 
         if toolkit_class.is_available():
             toolkit = toolkit_class()
-            mol = Molecule.from_smiles('ClC=CCl', allow_undefined_stereo=True, toolkit_registry=toolkit)
+            mol = Molecule.from_smiles(
+                "ClC=CCl", allow_undefined_stereo=True, toolkit_registry=toolkit
+            )
 
             # use the default options
             isomers = mol.enumerate_stereoisomers()
@@ -1294,22 +1629,34 @@ class TestMolecule:
             assert mol not in isomers
             # make sure the input molecule is only different by bond stereo
             for ismol in isomers:
-                assert Molecule.are_isomorphic(mol, ismol, return_atom_map=False, bond_stereochemistry_matching=False)[0] is True
+                assert (
+                    Molecule.are_isomorphic(
+                        mol,
+                        ismol,
+                        return_atom_map=False,
+                        bond_stereochemistry_matching=False,
+                    )[0]
+                    is True
+                )
                 assert mol.is_isomorphic_with(ismol) is False
 
             # make sure the isomers are different
             assert isomers[0].is_isomorphic_with(isomers[1]) is False
 
         else:
-            pytest.skip('Required toolkit is unavailable')
+            pytest.skip("Required toolkit is unavailable")
 
-    @pytest.mark.parametrize('toolkit_class', [OpenEyeToolkitWrapper, RDKitToolkitWrapper])
+    @pytest.mark.parametrize(
+        "toolkit_class", [OpenEyeToolkitWrapper, RDKitToolkitWrapper]
+    )
     def test_enumerating_stereocenters(self, toolkit_class):
         """Test the backend toolkits in enumerating the stereo centers in a molecule."""
 
         if toolkit_class.is_available():
             toolkit = toolkit_class()
-            mol = Molecule.from_smiles('NC(Cl)(F)O', toolkit_registry=toolkit, allow_undefined_stereo=True)
+            mol = Molecule.from_smiles(
+                "NC(Cl)(F)O", toolkit_registry=toolkit, allow_undefined_stereo=True
+            )
 
             isomers = mol.enumerate_stereoisomers(toolkit_registry=toolkit)
 
@@ -1318,16 +1665,26 @@ class TestMolecule:
             assert mol not in isomers
             for ismol in isomers:
                 assert ismol.n_conformers != 0
-                assert Molecule.are_isomorphic(mol, ismol, return_atom_map=False, atom_stereochemistry_matching=False)[0] is True
+                assert (
+                    Molecule.are_isomorphic(
+                        mol,
+                        ismol,
+                        return_atom_map=False,
+                        atom_stereochemistry_matching=False,
+                    )[0]
+                    is True
+                )
                 assert mol.is_isomorphic_with(ismol) is False
 
             # make sure the two isomers are different
             assert isomers[0].is_isomorphic_with(isomers[1]) is False
 
         else:
-            pytest.skip('Required toolkit is unavailable')
+            pytest.skip("Required toolkit is unavailable")
 
-    @pytest.mark.parametrize('toolkit_class', [OpenEyeToolkitWrapper, RDKitToolkitWrapper])
+    @pytest.mark.parametrize(
+        "toolkit_class", [OpenEyeToolkitWrapper, RDKitToolkitWrapper]
+    )
     def test_enumerating_stereo_options(self, toolkit_class):
         """Test the enumerating stereo chem options"""
 
@@ -1335,53 +1692,82 @@ class TestMolecule:
             toolkit = toolkit_class()
 
             # test undefined only
-            mol = Molecule.from_smiles('ClC=CCl', toolkit_registry=toolkit, allow_undefined_stereo=True)
-            isomers = mol.enumerate_stereoisomers(undefined_only=True, rationalise=False)
+            mol = Molecule.from_smiles(
+                "ClC=CCl", toolkit_registry=toolkit, allow_undefined_stereo=True
+            )
+            isomers = mol.enumerate_stereoisomers(
+                undefined_only=True, rationalise=False
+            )
 
             assert len(isomers) == 2
             for isomer in isomers:
                 assert isomer.n_conformers == 0
 
-            mol = Molecule.from_smiles('Cl/C=C\Cl', toolkit_registry=toolkit, allow_undefined_stereo=True)
-            isomers = mol.enumerate_stereoisomers(undefined_only=True, rationalise=False)
+            mol = Molecule.from_smiles(
+                "Cl/C=C\Cl", toolkit_registry=toolkit, allow_undefined_stereo=True
+            )
+            isomers = mol.enumerate_stereoisomers(
+                undefined_only=True, rationalise=False
+            )
 
             assert isomers == []
 
-            mol = Molecule.from_smiles('Cl/C=C\Cl', toolkit_registry=toolkit, allow_undefined_stereo=True)
-            isomers = mol.enumerate_stereoisomers(undefined_only=False, rationalise=False)
+            mol = Molecule.from_smiles(
+                "Cl/C=C\Cl", toolkit_registry=toolkit, allow_undefined_stereo=True
+            )
+            isomers = mol.enumerate_stereoisomers(
+                undefined_only=False, rationalise=False
+            )
 
             assert len(isomers) == 1
 
             # test max isomers
-            mol = Molecule.from_smiles('BrC=C[C@H]1OC(C2)(F)C2(Cl)C1', toolkit_registry=toolkit, allow_undefined_stereo=True)
-            isomers = mol.enumerate_stereoisomers(max_isomers=5, undefined_only=True, toolkit_registry=toolkit, rationalise=True)
+            mol = Molecule.from_smiles(
+                "BrC=C[C@H]1OC(C2)(F)C2(Cl)C1",
+                toolkit_registry=toolkit,
+                allow_undefined_stereo=True,
+            )
+            isomers = mol.enumerate_stereoisomers(
+                max_isomers=5,
+                undefined_only=True,
+                toolkit_registry=toolkit,
+                rationalise=True,
+            )
 
             assert len(isomers) <= 5
             for isomer in isomers:
                 assert isomer.n_conformers == 1
 
         else:
-            pytest.skip('Required toolkit is unavailable')
+            pytest.skip("Required toolkit is unavailable")
 
     @requires_rdkit
     def test_from_pdb_and_smiles(self):
         """Test the ability to make a valid molecule using RDKit and SMILES together"""
         # try and make a molecule from a pdb and smiles that don't match
         with pytest.raises(InvalidConformerError):
-            mol = Molecule.from_pdb_and_smiles(get_data_file_path('molecules/toluene.pdb'), 'CC')
+            mol = Molecule.from_pdb_and_smiles(
+                get_data_file_path("molecules/toluene.pdb"), "CC"
+            )
 
         # make a molecule from the toluene pdb file and the correct smiles
-        mol = Molecule.from_pdb_and_smiles(get_data_file_path('molecules/toluene.pdb'), 'Cc1ccccc1')
+        mol = Molecule.from_pdb_and_smiles(
+            get_data_file_path("molecules/toluene.pdb"), "Cc1ccccc1"
+        )
 
         # make toluene from the sdf file
-        mol_sdf = Molecule.from_file(get_data_file_path('molecules/toluene.sdf'))
+        mol_sdf = Molecule.from_file(get_data_file_path("molecules/toluene.sdf"))
         # get the mapping between them and compare the properties
-        isomorphic, atom_map = Molecule.are_isomorphic(mol, mol_sdf, return_atom_map=True)
+        isomorphic, atom_map = Molecule.are_isomorphic(
+            mol, mol_sdf, return_atom_map=True
+        )
         assert isomorphic is True
         for pdb_atom, sdf_atom in atom_map.items():
             assert mol.atoms[pdb_atom].to_dict() == mol_sdf.atoms[sdf_atom].to_dict()
         # check bonds match, however there order might not
-        sdf_bonds = dict(((bond.atom1_index, bond.atom2_index), bond) for bond in mol_sdf.bonds)
+        sdf_bonds = dict(
+            ((bond.atom1_index, bond.atom2_index), bond) for bond in mol_sdf.bonds
+        )
         for bond in mol.bonds:
             key = (atom_map[bond.atom1_index], atom_map[bond.atom2_index])
             if key not in sdf_bonds:
@@ -1394,12 +1780,12 @@ class TestMolecule:
     def test_to_qcschema(self):
         """Test the ability to make and validate qcschema with extras"""
         # the molecule has no coordinates so this should fail
-        ethanol = Molecule.from_smiles('CCO')
+        ethanol = Molecule.from_smiles("CCO")
         with pytest.raises(InvalidConformerError):
             qcschema = ethanol.to_qcschema()
 
         # now remake the molecule from the sdf
-        ethanol = Molecule.from_file(get_data_file_path('molecules/ethanol.sdf'))
+        ethanol = Molecule.from_file(get_data_file_path("molecules/ethanol.sdf"))
         # make sure that requests to missing conformers are caught
         with pytest.raises(InvalidConformerError):
             qcschema = ethanol.to_qcschema(conformer=1)
@@ -1407,14 +1793,26 @@ class TestMolecule:
         qcschema = ethanol.to_qcschema(extras={"test_tag": "test"})
         # make sure the properties match
         charge = 0
-        connectivity = [(0, 1, 1.0), (0, 4, 1.0), (0, 5, 1.0), (0, 6, 1.0), (1, 2, 1.0), (1, 7, 1.0), (1, 8, 1.0), (2, 3, 1.0)]
-        symbols = ['C', 'C', 'O', 'H', 'H', 'H', 'H', 'H', 'H']
+        connectivity = [
+            (0, 1, 1.0),
+            (0, 4, 1.0),
+            (0, 5, 1.0),
+            (0, 6, 1.0),
+            (1, 2, 1.0),
+            (1, 7, 1.0),
+            (1, 8, 1.0),
+            (2, 3, 1.0),
+        ]
+        symbols = ["C", "C", "O", "H", "H", "H", "H", "H", "H"]
 
         def assert_check():
             assert charge == qcschema.molecular_charge
             assert connectivity == qcschema.connectivity
             assert symbols == qcschema.symbols.tolist()
-            assert qcschema.geometry.all() == ethanol.conformers[0].in_units_of(unit.bohr).all()
+            assert (
+                qcschema.geometry.all()
+                == ethanol.conformers[0].in_units_of(unit.bohr).all()
+            )
 
         assert_check()
         assert qcschema.extras["test_tag"] == "test"
@@ -1430,61 +1828,91 @@ class TestMolecule:
 
         # As the method can take a record instance or a dict with JSON encoding test both
         # test incomplete dict
-        example_dict = {'name': 'CH4'}
+        example_dict = {"name": "CH4"}
         with pytest.raises(KeyError):
             mol = Molecule.from_qcschema(example_dict)
 
         # test an object that is not a record
-        wrong_object = 'CH4'
+        wrong_object = "CH4"
         with pytest.raises(AttributeError):
             mol = Molecule.from_qcschema(wrong_object)
 
-        with open(get_data_file_path('molecules/qcportal_molecules.json')) as json_file:
+        with open(get_data_file_path("molecules/qcportal_molecules.json")) as json_file:
             # test loading the dict representation from a json file
             json_mol = json.load(json_file)
             mol = Molecule.from_qcschema(json_mol)
             # now make a molecule from the canonical smiles and make sure they are isomorphic
-            can_mol = Molecule.from_smiles(json_mol['attributes']['canonical_isomeric_smiles'])
+            can_mol = Molecule.from_smiles(
+                json_mol["attributes"]["canonical_isomeric_smiles"]
+            )
             assert mol.is_isomorphic_with(can_mol) is True
 
-    client_examples = [{'dataset': 'TorsionDriveDataset', 'name': 'Fragment Stability Benchmark', 'index':
-                        'CC(=O)Nc1cc2c(cc1OC)nc[n:4][c:3]2[NH:2][c:1]3ccc(c(c3)Cl)F'},
-                       {'dataset': 'TorsionDriveDataset', 'name': 'OpenFF Fragmenter Phenyl Benchmark', 'index':
-                        'c1c[ch:1][c:2](cc1)[c:3](=[o:4])o'},
-                       {'dataset': 'TorsionDriveDataset', 'name': 'OpenFF Full TorsionDrive Benchmark 1', 'index':
-                        '0'},
-                       {'dataset': 'TorsionDriveDataset', 'name': 'OpenFF Group1 Torsions', 'index':
-                        'c1c[ch:1][c:2](cc1)[ch2:3][c:4]2ccccc2'},
-                       {'dataset': 'OptimizationDataset', 'name': 'Kinase Inhibitors: WBO Distributions', 'index':
-                        'cc1ccc(cc1nc2nccc(n2)c3cccnc3)nc(=o)c4ccc(cc4)cn5ccn(cc5)c-0'},
-                       {'dataset': 'OptimizationDataset', 'name': 'SMIRNOFF Coverage Set 1', 'index':
-                        'coc(o)oc-0'},
-                       {'dataset': 'GridOptimizationDataset', 'name': 'OpenFF Trivalent Nitrogen Set 1', 'index':
-                        'b1(c2c(ccs2)-c3ccsc3n1)c4c(c(c(c(c4f)f)f)f)f'},
-                       {'dataset': 'GridOptimizationDataset', 'name': 'OpenFF Trivalent Nitrogen Set 1', 'index':
-                       'C(#N)N'}
-                       ]
+    client_examples = [
+        {
+            "dataset": "TorsionDriveDataset",
+            "name": "Fragment Stability Benchmark",
+            "index": "CC(=O)Nc1cc2c(cc1OC)nc[n:4][c:3]2[NH:2][c:1]3ccc(c(c3)Cl)F",
+        },
+        {
+            "dataset": "TorsionDriveDataset",
+            "name": "OpenFF Fragmenter Phenyl Benchmark",
+            "index": "c1c[ch:1][c:2](cc1)[c:3](=[o:4])o",
+        },
+        {
+            "dataset": "TorsionDriveDataset",
+            "name": "OpenFF Full TorsionDrive Benchmark 1",
+            "index": "0",
+        },
+        {
+            "dataset": "TorsionDriveDataset",
+            "name": "OpenFF Group1 Torsions",
+            "index": "c1c[ch:1][c:2](cc1)[ch2:3][c:4]2ccccc2",
+        },
+        {
+            "dataset": "OptimizationDataset",
+            "name": "Kinase Inhibitors: WBO Distributions",
+            "index": "cc1ccc(cc1nc2nccc(n2)c3cccnc3)nc(=o)c4ccc(cc4)cn5ccn(cc5)c-0",
+        },
+        {
+            "dataset": "OptimizationDataset",
+            "name": "SMIRNOFF Coverage Set 1",
+            "index": "coc(o)oc-0",
+        },
+        {
+            "dataset": "GridOptimizationDataset",
+            "name": "OpenFF Trivalent Nitrogen Set 1",
+            "index": "b1(c2c(ccs2)-c3ccsc3n1)c4c(c(c(c(c4f)f)f)f)f",
+        },
+        {
+            "dataset": "GridOptimizationDataset",
+            "name": "OpenFF Trivalent Nitrogen Set 1",
+            "index": "C(#N)N",
+        },
+    ]
 
-    @pytest.mark.parametrize('input_data', client_examples)
+    @pytest.mark.parametrize("input_data", client_examples)
     def test_from_qcschema_with_client(self, input_data):
         """For each of the examples try and make a offmol using the instance and dict and check they match"""
 
         import qcportal as ptl
+
         client = ptl.FractalClient()
-        ds = client.get_collection(input_data['dataset'], input_data['name'])
-        entry = ds.get_entry(input_data['index'])
+        ds = client.get_collection(input_data["dataset"], input_data["name"])
+        entry = ds.get_entry(input_data["index"])
         # now make the molecule from the record instance with and without the geometry
-        mol_from_dict = Molecule.from_qcschema(entry.dict(encoding='json'))
+        mol_from_dict = Molecule.from_qcschema(entry.dict(encoding="json"))
         # make the molecule again with the geometries attached
         mol_from_instance = Molecule.from_qcschema(entry, client)
-        if hasattr(entry, 'initial_molecules'):
+        if hasattr(entry, "initial_molecules"):
             assert mol_from_instance.n_conformers == len(entry.initial_molecules)
         else:
             # opt records have one initial molecule
             assert mol_from_instance.n_conformers == 1
 
         # now make a molecule from the smiles and make sure they are isomorphic
-        mol_from_smiles = Molecule.from_smiles(entry.attributes['canonical_explicit_hydrogen_smiles'], True)
+        mol_from_smiles = Molecule.from_smiles(
+            entry.attributes["canonical_explicit_hydrogen_smiles"], True
+        )
 
         assert mol_from_dict.is_isomorphic_with(mol_from_smiles) is True
 
@@ -1493,10 +1921,11 @@ class TestMolecule:
 
         # get a molecule qcschema
         import qcportal as ptl
+
         client = ptl.FractalClient()
-        ds = client.get_collection('OptimizationDataset', 'SMIRNOFF Coverage Set 1')
+        ds = client.get_collection("OptimizationDataset", "SMIRNOFF Coverage Set 1")
         # grab an entry from the optimization data set
-        entry = ds.get_entry('coc(o)oc-0')
+        entry = ds.get_entry("coc(o)oc-0")
         # now make the molecule from the record instance with the geometry
         mol = Molecule.from_qcschema(entry, client)
         # now grab the initial molecule record
@@ -1507,7 +1936,9 @@ class TestMolecule:
         assert qcschema.atom_labels.tolist() == qca_mol.atom_labels.tolist()
         assert qcschema.symbols.tolist() == qca_mol.symbols.tolist()
         # due to conversion useing different programs there is a slight difference here
-        assert qcschema.geometry.flatten().tolist() == pytest.approx(qca_mol.geometry.flatten().tolist(), rel=1.0e-5)
+        assert qcschema.geometry.flatten().tolist() == pytest.approx(
+            qca_mol.geometry.flatten().tolist(), rel=1.0e-5
+        )
         assert qcschema.connectivity == qca_mol.connectivity
         assert qcschema.atomic_numbers.tolist() == qca_mol.atomic_numbers.tolist()
         assert qcschema.fragment_charges == qca_mol.fragment_charges
@@ -1525,44 +1956,46 @@ class TestMolecule:
         is fixed."""
 
         # there should be no undefined sterochmeistry error when making the molecule
-        mol = Molecule.from_mapped_smiles('[H:14][c:1]1[c:3]([c:7]([c:11]([c:8]([c:4]1[H:17])[H:21])[C:13]([H:24])([H:25])[c:12]2[c:9]([c:5]([c:2]([c:6]([c:10]2[H:23])[H:19])[H:15])[H:18])[H:22])[H:20])[H:16]')
+        mol = Molecule.from_mapped_smiles(
+            "[H:14][c:1]1[c:3]([c:7]([c:11]([c:8]([c:4]1[H:17])[H:21])[C:13]([H:24])([H:25])[c:12]2[c:9]([c:5]([c:2]([c:6]([c:10]2[H:23])[H:19])[H:15])[H:18])[H:22])[H:20])[H:16]"
+        )
         assert mol.n_atoms == 25
         # make sure the atom map is not exposed
         with pytest.raises(KeyError):
-            mapping = mol._properties['atom_map']
+            mapping = mol._properties["atom_map"]
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_n_particles(self, molecule):
         """Test n_particles property"""
         n_particles = sum([1 for particle in molecule.particles])
         assert n_particles == molecule.n_particles
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_n_atoms(self, molecule):
         """Test n_atoms property"""
         n_atoms = sum([1 for atom in molecule.atoms])
         assert n_atoms == molecule.n_atoms
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_n_virtual_sites(self, molecule):
         """Test n_virtual_sites property"""
         n_virtual_sites = sum([1 for virtual_site in molecule.virtual_sites])
         assert n_virtual_sites == molecule.n_virtual_sites
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_n_bonds(self, molecule):
         """Test n_bonds property"""
         n_bonds = sum([1 for bond in molecule.bonds])
         assert n_bonds == molecule.n_bonds
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_angles(self, molecule):
         """Test angles property"""
         for angle in molecule.angles:
             assert angle[0].is_bonded_to(angle[1])
             assert angle[1].is_bonded_to(angle[2])
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_propers(self, molecule):
         """Test propers property"""
         for proper in molecule.propers:
@@ -1575,11 +2008,13 @@ class TestMolecule:
             is_chain &= not proper[0].is_bonded_to(proper[3])
             is_chain &= not proper[1].is_bonded_to(proper[3])
 
-            assert (is_chain or
-                    is_three_memebered_ring_torsion(proper) or
-                    is_four_memebered_ring_torsion(proper))
+            assert (
+                is_chain
+                or is_three_memebered_ring_torsion(proper)
+                or is_four_memebered_ring_torsion(proper)
+            )
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_impropers(self, molecule):
         """Test impropers property"""
         for improper in molecule.impropers:
@@ -1589,12 +2024,14 @@ class TestMolecule:
 
             # The non-central atoms can be connected only if
             # the improper atoms form a three-membered ring.
-            is_not_cyclic = not((improper[0].is_bonded_to(improper[2])) or
-                                (improper[0].is_bonded_to(improper[3])) or
-                                (improper[2].is_bonded_to(improper[3])))
+            is_not_cyclic = not (
+                (improper[0].is_bonded_to(improper[2]))
+                or (improper[0].is_bonded_to(improper[3]))
+                or (improper[2].is_bonded_to(improper[3]))
+            )
             assert is_not_cyclic or is_three_memebered_ring_torsion(improper)
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_torsions(self, molecule):
         """Test torsions property"""
         # molecule.torsions should be exactly equal to the union of propers and impropers.
@@ -1607,7 +2044,7 @@ class TestMolecule:
             for torsion in common_torsions:
                 assert is_three_memebered_ring_torsion(torsion)
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_total_charge(self, molecule):
         """Test total charge"""
         charge_sum = 0 * unit.elementary_charge
@@ -1625,7 +2062,7 @@ class TestMolecule:
         nmolecules = len(molecules)
         # TODO: Performance improvements should let us un-restrict this test
         for i in range(nmolecules):
-            for j in range(i, min(i+3, nmolecules)):
+            for j in range(i, min(i + 3, nmolecules)):
                 assert (molecules[i] == molecules[j]) == (i == j)
 
     # ----------------------
@@ -1636,9 +2073,10 @@ class TestMolecule:
         """Test addition of conformers to a molecule"""
         import numpy as np
         from simtk import unit
+
         # Define a methane molecule
         molecule = Molecule()
-        molecule.name = 'methane'
+        molecule.name = "methane"
         C = molecule.add_atom(6, 0, False)
         H1 = molecule.add_atom(1, 0, False)
         H2 = molecule.add_atom(1, 0, False)
@@ -1651,85 +2089,168 @@ class TestMolecule:
 
         assert molecule.n_conformers == 0
         # Add a conformer that should work
-        conf1 = unit.Quantity(np.array([[ 1., 2.,3.] ,[4. ,5. ,6.],[7., 8., 9.],
-                                        [10.,11.,12.],[13.,14.,15]]),
-                              unit.angstrom)
+        conf1 = unit.Quantity(
+            np.array(
+                [
+                    [1.0, 2.0, 3.0],
+                    [4.0, 5.0, 6.0],
+                    [7.0, 8.0, 9.0],
+                    [10.0, 11.0, 12.0],
+                    [13.0, 14.0, 15],
+                ]
+            ),
+            unit.angstrom,
+        )
         molecule.add_conformer(conf1)
         assert molecule.n_conformers == 1
 
-        conf2 = unit.Quantity(np.array([[101., 102. ,103.], [104. ,105. ,106.], [107., 108., 109.],
-                                        [110.,111.,112.],   [113.,114.,115]]),
-                              unit.angstrom)
+        conf2 = unit.Quantity(
+            np.array(
+                [
+                    [101.0, 102.0, 103.0],
+                    [104.0, 105.0, 106.0],
+                    [107.0, 108.0, 109.0],
+                    [110.0, 111.0, 112.0],
+                    [113.0, 114.0, 115],
+                ]
+            ),
+            unit.angstrom,
+        )
         molecule.add_conformer(conf2)
         assert molecule.n_conformers == 2
 
         # Add conformers with too few coordinates
-        conf_missing_z = unit.Quantity(np.array([[101., 102. ,103.], [104. ,105. ,106.], [107., 108., 109.],
-                                        [110.,111.,112.],   [113.,114.]]),
-                                        unit.angstrom)
+        conf_missing_z = unit.Quantity(
+            np.array(
+                [
+                    [101.0, 102.0, 103.0],
+                    [104.0, 105.0, 106.0],
+                    [107.0, 108.0, 109.0],
+                    [110.0, 111.0, 112.0],
+                    [113.0, 114.0],
+                ]
+            ),
+            unit.angstrom,
+        )
         with pytest.raises(Exception) as excinfo:
             molecule.add_conformer(conf_missing_z)
 
-        conf_too_few_atoms = unit.Quantity(np.array([[101., 102. ,103.], [104. ,105. ,106.], [107., 108., 109.],
-                                                     [110.,111.,112.]]),
-                                                     unit.angstrom)
+        conf_too_few_atoms = unit.Quantity(
+            np.array(
+                [
+                    [101.0, 102.0, 103.0],
+                    [104.0, 105.0, 106.0],
+                    [107.0, 108.0, 109.0],
+                    [110.0, 111.0, 112.0],
+                ]
+            ),
+            unit.angstrom,
+        )
         with pytest.raises(Exception) as excinfo:
             molecule.add_conformer(conf_too_few_atoms)
 
-
         # Add a conformer with too many coordinates
-        conf_too_many_atoms = unit.Quantity(np.array([[101., 102., 103.], [104., 105., 106.], [107., 108., 109.],
-                                                      [110., 111., 112.], [113., 114., 115.], [116., 117., 118.]]),
-                                            unit.angstrom)
+        conf_too_many_atoms = unit.Quantity(
+            np.array(
+                [
+                    [101.0, 102.0, 103.0],
+                    [104.0, 105.0, 106.0],
+                    [107.0, 108.0, 109.0],
+                    [110.0, 111.0, 112.0],
+                    [113.0, 114.0, 115.0],
+                    [116.0, 117.0, 118.0],
+                ]
+            ),
+            unit.angstrom,
+        )
         with pytest.raises(Exception) as excinfo:
             molecule.add_conformer(conf_too_many_atoms)
 
         # Add a conformer with no coordinates
-        conf_no_coordinates = unit.Quantity(np.array([]),
-                                            unit.angstrom)
+        conf_no_coordinates = unit.Quantity(np.array([]), unit.angstrom)
         with pytest.raises(Exception) as excinfo:
             molecule.add_conformer(conf_no_coordinates)
 
         # Add a conforer with units of nanometers
-        conf3 = unit.Quantity(np.array([[ 1., 2.,3.] ,[4. ,5. ,6.],[7., 8., 9.],
-                                        [10.,11.,12.],[13.,14.,15]]),
-                              unit.nanometer)
+        conf3 = unit.Quantity(
+            np.array(
+                [
+                    [1.0, 2.0, 3.0],
+                    [4.0, 5.0, 6.0],
+                    [7.0, 8.0, 9.0],
+                    [10.0, 11.0, 12.0],
+                    [13.0, 14.0, 15],
+                ]
+            ),
+            unit.nanometer,
+        )
         molecule.add_conformer(conf3)
         assert molecule.n_conformers == 3
-        assert molecule.conformers[2][0][0] == 10. * unit.angstrom
+        assert molecule.conformers[2][0][0] == 10.0 * unit.angstrom
 
         # Add a conformer with units of nanometers
-        conf_nonsense_units = unit.Quantity(np.array([[ 1., 2.,3.] ,[4. ,5. ,6.],[7., 8., 9.],
-                                        [10.,11.,12.],[13.,14.,15]]),
-                              unit.joule)
+        conf_nonsense_units = unit.Quantity(
+            np.array(
+                [
+                    [1.0, 2.0, 3.0],
+                    [4.0, 5.0, 6.0],
+                    [7.0, 8.0, 9.0],
+                    [10.0, 11.0, 12.0],
+                    [13.0, 14.0, 15],
+                ]
+            ),
+            unit.joule,
+        )
         with pytest.raises(Exception) as excinfo:
             molecule.add_conformer(conf_nonsense_units)
 
         # Add a conformer with no units
-        conf_unitless = np.array([[ 1., 2.,3.] ,[4. ,5. ,6.],[7., 8., 9.],
-                                  [10.,11.,12.],[13.,14.,15]])
+        conf_unitless = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [4.0, 5.0, 6.0],
+                [7.0, 8.0, 9.0],
+                [10.0, 11.0, 12.0],
+                [13.0, 14.0, 15],
+            ]
+        )
         with pytest.raises(Exception) as excinfo:
             molecule.add_conformer(conf_unitless)
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_add_atoms_and_bonds(self, molecule):
         """Test the creation of a molecule from the addition of atoms and bonds"""
         molecule_copy = Molecule()
         for atom in molecule.atoms:
-            molecule_copy.add_atom(atom.atomic_number, atom.formal_charge, atom.is_aromatic, stereochemistry=atom.stereochemistry)
+            molecule_copy.add_atom(
+                atom.atomic_number,
+                atom.formal_charge,
+                atom.is_aromatic,
+                stereochemistry=atom.stereochemistry,
+            )
         for bond in molecule.bonds:
-            molecule_copy.add_bond(bond.atom1_index, bond.atom2_index, bond.bond_order, bond.is_aromatic,
-                                   stereochemistry=bond.stereochemistry,
-                                   fractional_bond_order=bond.fractional_bond_order)
+            molecule_copy.add_bond(
+                bond.atom1_index,
+                bond.atom2_index,
+                bond.bond_order,
+                bond.is_aromatic,
+                stereochemistry=bond.stereochemistry,
+                fractional_bond_order=bond.fractional_bond_order,
+            )
         # Try to add the final bond twice, which should raise an Exception
         with pytest.raises(Exception) as excinfo:
-            molecule_copy.add_bond(bond.atom1_index, bond.atom2_index, bond.bond_order, bond.is_aromatic,
-                                   stereochemistry=bond.stereochemistry,
-                                   fractional_bond_order=bond.fractional_bond_order)
+            molecule_copy.add_bond(
+                bond.atom1_index,
+                bond.atom2_index,
+                bond.bond_order,
+                bond.is_aromatic,
+                stereochemistry=bond.stereochemistry,
+                fractional_bond_order=bond.fractional_bond_order,
+            )
 
         assert molecule == molecule_copy
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_add_virtual_site_units(self, molecule):
         """
         Tests the unit type checking of the VirtualSite base class
@@ -1759,39 +2280,69 @@ class TestMolecule:
 
         # Try to feed in unitless sigma
         with pytest.raises(Exception) as excinfo:
-            molecule.add_bond_charge_virtual_site([atom1, atom2, atom3], distance, epsilon=epsilon, sigma=sigma_unitless)
+            molecule.add_bond_charge_virtual_site(
+                [atom1, atom2, atom3], distance, epsilon=epsilon, sigma=sigma_unitless
+            )
 
         # Try to feed in unitless rmin_half
         with pytest.raises(Exception) as excinfo:
-            molecule.add_bond_charge_virtual_site([atom1, atom2, atom3], distance, epsilon=epsilon, rmin_half=rmin_half_unitless)
+            molecule.add_bond_charge_virtual_site(
+                [atom1, atom2, atom3],
+                distance,
+                epsilon=epsilon,
+                rmin_half=rmin_half_unitless,
+            )
 
         # Try to feed in unitless epsilon
         with pytest.raises(Exception) as excinfo:
-            molecule.add_bond_charge_virtual_site([atom1, atom2, atom3], distance, epsilon=epsilon_unitless, sigma=sigma, rmin_half=rmin_half)
+            molecule.add_bond_charge_virtual_site(
+                [atom1, atom2, atom3],
+                distance,
+                epsilon=epsilon_unitless,
+                sigma=sigma,
+                rmin_half=rmin_half,
+            )
 
         # Try to feed in unitless charges
         with pytest.raises(Exception) as excinfo:
-            molecule.add_bond_charge_virtual_site([atom1, atom2, atom3, atom4], distance, charge_incrtements=charge_increments_unitless)
-
+            molecule.add_bond_charge_virtual_site(
+                [atom1, atom2, atom3, atom4],
+                distance,
+                charge_incrtements=charge_increments_unitless,
+            )
 
         # We shouldn't be able to give both rmin_half and sigma VdW parameters.
         with pytest.raises(Exception) as excinfo:
-            molecule.add_bond_charge_virtual_site([atom1, atom2, atom3], distance, epsilon=epsilon, sigma=sigma, rmin_half=rmin_half)
+            molecule.add_bond_charge_virtual_site(
+                [atom1, atom2, atom3],
+                distance,
+                epsilon=epsilon,
+                sigma=sigma,
+                rmin_half=rmin_half,
+            )
 
         # Try creating virtual site from sigma+epsilon
-        vsite1_index = molecule.add_bond_charge_virtual_site([atom1, atom2, atom3], distance, epsilon=epsilon, sigma=sigma)
+        vsite1_index = molecule.add_bond_charge_virtual_site(
+            [atom1, atom2, atom3], distance, epsilon=epsilon, sigma=sigma
+        )
         # Try creating virutal site from rmin_half+epsilon
-        vsite2_index = molecule.add_bond_charge_virtual_site([atom1, atom2, atom3], distance, epsilon=epsilon, rmin_half=rmin_half)
+        vsite2_index = molecule.add_bond_charge_virtual_site(
+            [atom1, atom2, atom3], distance, epsilon=epsilon, rmin_half=rmin_half
+        )
 
         # TODO: Test the @property getters for sigma, epsilon, and rmin_half
 
         # We should have to give as many charge increments as atoms (len(charge_increments)) = 4
         with pytest.raises(Exception) as excinfo:
-            molecule.add_bond_charge_virtual_site([atom1, atom2, atom3], distance, charge_increments=charge_increments)
+            molecule.add_bond_charge_virtual_site(
+                [atom1, atom2, atom3], distance, charge_increments=charge_increments
+            )
 
-        vsite3_index = molecule.add_bond_charge_virtual_site([atom1, atom2, atom3, atom4], distance, charge_increments=charge_increments)
+        vsite3_index = molecule.add_bond_charge_virtual_site(
+            [atom1, atom2, atom3, atom4], distance, charge_increments=charge_increments
+        )
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_add_bond_charge_virtual_site(self, molecule):
         """Test the addition of a BondChargeVirtualSite to a molecule.
            Also tests many of the inputs of the parent VirtualSite class
@@ -1808,13 +2359,15 @@ class TestMolecule:
         distance_unitless = 0.4
         distance = distance_unitless * unit.angstrom
 
-
         # Try to feed in a unitless distance
         with pytest.raises(AssertionError) as excinfo:
-            vsite1_index = molecule.add_bond_charge_virtual_site([atom1, atom2, atom3], distance_unitless)
+            vsite1_index = molecule.add_bond_charge_virtual_site(
+                [atom1, atom2, atom3], distance_unitless
+            )
 
-
-        vsite1_index = molecule.add_bond_charge_virtual_site([atom1, atom2, atom3], distance)
+        vsite1_index = molecule.add_bond_charge_virtual_site(
+            [atom1, atom2, atom3], distance
+        )
         vsite1 = molecule.virtual_sites[vsite1_index]
         assert atom1 in vsite1.atoms
         assert atom2 in vsite1.atoms
@@ -1825,13 +2378,15 @@ class TestMolecule:
         assert vsite1.distance == distance
 
         # Make an "everything bagel" virtual site
-        vsite2_index = molecule.add_bond_charge_virtual_site([atom1, atom2, atom3],
-                                                             distance,
-                                                             sigma=0.1*unit.angstrom,
-                                                             epsilon=1.0*unit.kilojoule_per_mole,
-                                                             charge_increments=unit.Quantity(np.array([0.1, 0.2, 0.3]),
-                                                                                             unit.elementary_charge)
-                                                             )
+        vsite2_index = molecule.add_bond_charge_virtual_site(
+            [atom1, atom2, atom3],
+            distance,
+            sigma=0.1 * unit.angstrom,
+            epsilon=1.0 * unit.kilojoule_per_mole,
+            charge_increments=unit.Quantity(
+                np.array([0.1, 0.2, 0.3]), unit.elementary_charge
+            ),
+        )
         vsite2 = molecule.virtual_sites[vsite2_index]
 
         # test serialization
@@ -1846,7 +2401,7 @@ class TestMolecule:
 
     # TODO: Make a test for to_dict and from_dict for VirtualSites (even though they're currently just unloaded using
     #      (for example) Molecule._add_bond_virtual_site functions
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_add_monovalent_lone_pair_virtual_site(self, molecule):
         """Test addition of a MonovalentLonePairVirtualSite to the Molecule"""
         # Do not modify the original molecule.
@@ -1867,28 +2422,38 @@ class TestMolecule:
 
         # Try passing in a unitless distance
         with pytest.raises(AssertionError) as excinfo:
-            vsite1_index = molecule.add_monovalent_lone_pair_virtual_site([atom1, atom2], distance_unitless, out_of_plane_angle, in_plane_angle)
+            vsite1_index = molecule.add_monovalent_lone_pair_virtual_site(
+                [atom1, atom2], distance_unitless, out_of_plane_angle, in_plane_angle
+            )
 
         # Try passing in a unitless out_of_plane_angle
         with pytest.raises(AssertionError) as excinfo:
-            vsite1_index = molecule.add_monovalent_lone_pair_virtual_site([atom1, atom2], distance, out_of_plane_angle_unitless, in_plane_angle)
+            vsite1_index = molecule.add_monovalent_lone_pair_virtual_site(
+                [atom1, atom2], distance, out_of_plane_angle_unitless, in_plane_angle
+            )
 
         # Try passing in a unitless in_plane_angle
         with pytest.raises(AssertionError) as excinfo:
-            vsite1_index = molecule.add_monovalent_lone_pair_virtual_site([atom1, atom2], distance, out_of_plane_angle, in_plane_angle_unitless)
+            vsite1_index = molecule.add_monovalent_lone_pair_virtual_site(
+                [atom1, atom2], distance, out_of_plane_angle, in_plane_angle_unitless
+            )
 
         # Try giving two atoms
         with pytest.raises(AssertionError) as excinfo:
-            vsite1_index = molecule.add_monovalent_lone_pair_virtual_site([atom1, atom2], distance, out_of_plane_angle, in_plane_angle)
+            vsite1_index = molecule.add_monovalent_lone_pair_virtual_site(
+                [atom1, atom2], distance, out_of_plane_angle, in_plane_angle
+            )
 
         # Successfully make a virtual site
-        vsite1_index = molecule.add_monovalent_lone_pair_virtual_site([atom1, atom2, atom3], distance, out_of_plane_angle, in_plane_angle)
+        vsite1_index = molecule.add_monovalent_lone_pair_virtual_site(
+            [atom1, atom2, atom3], distance, out_of_plane_angle, in_plane_angle
+        )
         # TODO: Check if we get the same values back out from the @properties
         molecule_dict = molecule.to_dict()
         molecule2 = Molecule.from_dict(molecule_dict)
         assert molecule.to_dict() == molecule2.to_dict()
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_add_divalent_lone_pair_virtual_site(self, molecule):
         """Test addition of a DivalentLonePairVirtualSite to the Molecule"""
         # Do not modify the original molecule.
@@ -1901,14 +2466,18 @@ class TestMolecule:
         distance = 0.3 * unit.angstrom
         out_of_plane_angle = 30 * unit.degree
         in_plane_angle = 0.2 * unit.radian
-        vsite1_index = molecule.add_divalent_lone_pair_virtual_site([atom1, atom2, atom3], distance, out_of_plane_angle, in_plane_angle)
+        vsite1_index = molecule.add_divalent_lone_pair_virtual_site(
+            [atom1, atom2, atom3], distance, out_of_plane_angle, in_plane_angle
+        )
         with pytest.raises(AssertionError) as excinfo:
-            vsite1_index = molecule.add_divalent_lone_pair_virtual_site([atom1, atom2], distance, out_of_plane_angle, in_plane_angle)
+            vsite1_index = molecule.add_divalent_lone_pair_virtual_site(
+                [atom1, atom2], distance, out_of_plane_angle, in_plane_angle
+            )
         molecule_dict = molecule.to_dict()
         molecule2 = Molecule.from_dict(molecule_dict)
         assert molecule_dict == molecule2.to_dict()
 
-    @pytest.mark.parametrize('molecule', mini_drug_bank())
+    @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_add_trivalent_lone_pair_virtual_site(self, molecule):
         """Test addition of a TrivalentLonePairVirtualSite to the Molecule"""
         # Do not modify the original molecule.
@@ -1921,10 +2490,14 @@ class TestMolecule:
         distance = 0.3 * unit.angstrom
         out_of_plane_angle = 30 * unit.degree
         in_plane_angle = 0.2 * unit.radian
-        vsite1_index = molecule.add_trivalent_lone_pair_virtual_site([atom1, atom2, atom3, atom4], distance, out_of_plane_angle, in_plane_angle)
+        vsite1_index = molecule.add_trivalent_lone_pair_virtual_site(
+            [atom1, atom2, atom3, atom4], distance, out_of_plane_angle, in_plane_angle
+        )
         # Test for assertion when giving too few atoms
         with pytest.raises(AssertionError) as excinfo:
-            vsite1_index = molecule.add_trivalent_lone_pair_virtual_site([atom1, atom2, atom3], distance, out_of_plane_angle, in_plane_angle)
+            vsite1_index = molecule.add_trivalent_lone_pair_virtual_site(
+                [atom1, atom2, atom3], distance, out_of_plane_angle, in_plane_angle
+            )
         molecule_dict = molecule.to_dict()
         molecule2 = Molecule.from_dict(molecule_dict)
         assert molecule.to_dict() == molecule2.to_dict()
@@ -1935,34 +2508,51 @@ class TestMolecule:
         # TODO: Move this to test_toolkits, test all available toolkits
         # Create chiral molecule
         from simtk.openmm.app import element
+
         toolkit_wrapper = OpenEyeToolkitWrapper()
         molecule = Molecule()
-        atom_C = molecule.add_atom(element.carbon.atomic_number, 0, False, stereochemistry='R', name='C')
-        atom_H = molecule.add_atom(element.hydrogen.atomic_number, 0, False, name='H')
-        atom_Cl = molecule.add_atom(element.chlorine.atomic_number, 0, False, name='Cl')
-        atom_Br = molecule.add_atom(element.bromine.atomic_number, 0, False, name='Br')
-        atom_F = molecule.add_atom(element.fluorine.atomic_number, 0, False, name='F')
+        atom_C = molecule.add_atom(
+            element.carbon.atomic_number, 0, False, stereochemistry="R", name="C"
+        )
+        atom_H = molecule.add_atom(element.hydrogen.atomic_number, 0, False, name="H")
+        atom_Cl = molecule.add_atom(element.chlorine.atomic_number, 0, False, name="Cl")
+        atom_Br = molecule.add_atom(element.bromine.atomic_number, 0, False, name="Br")
+        atom_F = molecule.add_atom(element.fluorine.atomic_number, 0, False, name="F")
         molecule.add_bond(atom_C, atom_H, 1, False)
         molecule.add_bond(atom_C, atom_Cl, 1, False)
         molecule.add_bond(atom_C, atom_Br, 1, False)
         molecule.add_bond(atom_C, atom_F, 1, False)
         # Test known cases
-        matches = molecule.chemical_environment_matches('[#6:1]', toolkit_registry=toolkit_wrapper)
-        assert len(matches) == 1 # there should be a unique match, so one atom tuple is returned
-        assert len(matches[0]) == 1 # it should have one tagged atom
+        matches = molecule.chemical_environment_matches(
+            "[#6:1]", toolkit_registry=toolkit_wrapper
+        )
+        assert (
+            len(matches) == 1
+        )  # there should be a unique match, so one atom tuple is returned
+        assert len(matches[0]) == 1  # it should have one tagged atom
         assert set(matches[0]) == set([atom_C])
-        matches = molecule.chemical_environment_matches('[#6:1]~[#1:2]', toolkit_registry=toolkit_wrapper)
-        assert len(matches) == 1 # there should be a unique match, so one atom tuple is returned
-        assert len(matches[0]) == 2 # it should have two tagged atoms
+        matches = molecule.chemical_environment_matches(
+            "[#6:1]~[#1:2]", toolkit_registry=toolkit_wrapper
+        )
+        assert (
+            len(matches) == 1
+        )  # there should be a unique match, so one atom tuple is returned
+        assert len(matches[0]) == 2  # it should have two tagged atoms
         assert set(matches[0]) == set([atom_C, atom_H])
-        matches = molecule.chemical_environment_matches('[Cl:1]-[C:2]-[H:3]', toolkit_registry=toolkit_wrapper)
-        assert len(matches) == 1 # there should be a unique match, so one atom tuple is returned
-        assert len(matches[0]) == 3 # it should have three tagged atoms
+        matches = molecule.chemical_environment_matches(
+            "[Cl:1]-[C:2]-[H:3]", toolkit_registry=toolkit_wrapper
+        )
+        assert (
+            len(matches) == 1
+        )  # there should be a unique match, so one atom tuple is returned
+        assert len(matches[0]) == 3  # it should have three tagged atoms
         assert set(matches[0]) == set([atom_Cl, atom_C, atom_H])
-        matches = molecule.chemical_environment_matches('[#6:1]~[*:2]', toolkit_registry=toolkit_wrapper)
-        assert len(matches) == 4 # there should be four matches
+        matches = molecule.chemical_environment_matches(
+            "[#6:1]~[*:2]", toolkit_registry=toolkit_wrapper
+        )
+        assert len(matches) == 4  # there should be four matches
         for match in matches:
-            assert len(match) == 2 # each match should have two tagged atoms
+            assert len(match) == 2  # each match should have two tagged atoms
 
     # TODO: Test forgive undef amide enol stereo
     # TODO: test forgive undef phospho linker stereo
@@ -1976,34 +2566,51 @@ class TestMolecule:
         """Test chemical environment matches"""
         # Create chiral molecule
         from simtk.openmm.app import element
+
         toolkit_wrapper = RDKitToolkitWrapper()
         molecule = Molecule()
-        atom_C = molecule.add_atom(element.carbon.atomic_number, 0, False, stereochemistry='R', name='C')
-        atom_H = molecule.add_atom(element.hydrogen.atomic_number, 0, False, name='H')
-        atom_Cl = molecule.add_atom(element.chlorine.atomic_number, 0, False, name='Cl')
-        atom_Br = molecule.add_atom(element.bromine.atomic_number, 0, False, name='Br')
-        atom_F = molecule.add_atom(element.fluorine.atomic_number, 0, False, name='F')
+        atom_C = molecule.add_atom(
+            element.carbon.atomic_number, 0, False, stereochemistry="R", name="C"
+        )
+        atom_H = molecule.add_atom(element.hydrogen.atomic_number, 0, False, name="H")
+        atom_Cl = molecule.add_atom(element.chlorine.atomic_number, 0, False, name="Cl")
+        atom_Br = molecule.add_atom(element.bromine.atomic_number, 0, False, name="Br")
+        atom_F = molecule.add_atom(element.fluorine.atomic_number, 0, False, name="F")
         molecule.add_bond(atom_C, atom_H, 1, False)
         molecule.add_bond(atom_C, atom_Cl, 1, False)
         molecule.add_bond(atom_C, atom_Br, 1, False)
         molecule.add_bond(atom_C, atom_F, 1, False)
         # Test known cases
-        matches = molecule.chemical_environment_matches('[#6:1]', toolkit_registry=toolkit_wrapper)
-        assert len(matches) == 1 # there should be a unique match, so one atom tuple is returned
-        assert len(matches[0]) == 1 # it should have one tagged atom
+        matches = molecule.chemical_environment_matches(
+            "[#6:1]", toolkit_registry=toolkit_wrapper
+        )
+        assert (
+            len(matches) == 1
+        )  # there should be a unique match, so one atom tuple is returned
+        assert len(matches[0]) == 1  # it should have one tagged atom
         assert set(matches[0]) == set([atom_C])
-        matches = molecule.chemical_environment_matches('[#6:1]~[#1:2]', toolkit_registry=toolkit_wrapper)
-        assert len(matches) == 1 # there should be a unique match, so one atom tuple is returned
-        assert len(matches[0]) == 2 # it should have two tagged atoms
+        matches = molecule.chemical_environment_matches(
+            "[#6:1]~[#1:2]", toolkit_registry=toolkit_wrapper
+        )
+        assert (
+            len(matches) == 1
+        )  # there should be a unique match, so one atom tuple is returned
+        assert len(matches[0]) == 2  # it should have two tagged atoms
         assert set(matches[0]) == set([atom_C, atom_H])
-        matches = molecule.chemical_environment_matches('[Cl:1]-[C:2]-[H:3]', toolkit_registry=toolkit_wrapper)
-        assert len(matches) == 1 # there should be a unique match, so one atom tuple is returned
-        assert len(matches[0]) == 3 # it should have three tagged atoms
+        matches = molecule.chemical_environment_matches(
+            "[Cl:1]-[C:2]-[H:3]", toolkit_registry=toolkit_wrapper
+        )
+        assert (
+            len(matches) == 1
+        )  # there should be a unique match, so one atom tuple is returned
+        assert len(matches[0]) == 3  # it should have three tagged atoms
         assert set(matches[0]) == set([atom_Cl, atom_C, atom_H])
-        matches = molecule.chemical_environment_matches('[#6:1]~[*:2]', toolkit_registry=toolkit_wrapper)
-        assert len(matches) == 4 # there should be four matches
+        matches = molecule.chemical_environment_matches(
+            "[#6:1]~[*:2]", toolkit_registry=toolkit_wrapper
+        )
+        assert len(matches) == 4  # there should be four matches
         for match in matches:
-            assert len(match) == 2 # each match should have two tagged atoms
+            assert len(match) == 2  # each match should have two tagged atoms
 
     @pytest.mark.slow
     def test_compute_partial_charges(self):
@@ -2018,29 +2625,43 @@ class TestMolecule:
 
         # Test a single toolkit at a time
         # Removed  ['amber', 'amberff94'] from OE list, as those won't find the residue types they're expecting
-        toolkit_to_charge_method = {OpenEyeToolkitWrapper:['mmff', 'mmff94', 'am1bcc', 'am1bccnosymspt', 'am1bccelf10'],
-                                   AmberToolsToolkitWrapper:['bcc', 'gas', 'mul']}
+        toolkit_to_charge_method = {
+            OpenEyeToolkitWrapper: [
+                "mmff",
+                "mmff94",
+                "am1bcc",
+                "am1bccnosymspt",
+                "am1bccelf10",
+            ],
+            AmberToolsToolkitWrapper: ["bcc", "gas", "mul"],
+        }
 
         manual_skips = []
 
-        manual_skips.append('ZINC1564378') # Warning: OEMMFF94Charges: assigning OEMMFFAtomTypes failed on mol .
-        manual_skips.append('ZINC00265517') # Warning: OEMMFF94Charges: assigning OEMMFFAtomTypes failed on mol .
+        manual_skips.append(
+            "ZINC1564378"
+        )  # Warning: OEMMFF94Charges: assigning OEMMFFAtomTypes failed on mol .
+        manual_skips.append(
+            "ZINC00265517"
+        )  # Warning: OEMMFF94Charges: assigning OEMMFFAtomTypes failed on mol .
 
         for toolkit in list(toolkit_to_charge_method.keys()):
             toolkit_registry = ToolkitRegistry(toolkit_precedence=[toolkit])
             for charge_model in toolkit_to_charge_method[toolkit]:
                 c = 0
-                for molecule in molecules[:1]: # Just test first molecule to save time
+                for molecule in molecules[:1]:  # Just test first molecule to save time
                     c += 1
                     if molecule.name in manual_skips:  # Manual skips, hopefully rare
                         continue
-                    molecule.compute_partial_charges(charge_model=charge_model, toolkit_registry=toolkit_registry)
+                    molecule.compute_partial_charges(
+                        charge_model=charge_model, toolkit_registry=toolkit_registry
+                    )
                     charges1 = molecule._partial_charges
                     # Make sure everything isn't 0s
                     assert (abs(charges1 / unit.elementary_charge) > 0.01).any()
                     # Check total charge
                     charges_sum_unitless = charges1.sum() / unit.elementary_charge
-                    #if abs(charges_sum_unitless - float(molecule.total_charge)) > 0.0001:
+                    # if abs(charges_sum_unitless - float(molecule.total_charge)) > 0.0001:
                     #    print('c {}  molecule {}    charge_sum {}     molecule.total_charge {}'.format(c, molecule.name,
                     #                                                                                   charges_sum_unitless,
                     #                                                                                   molecule.total_charge))
@@ -2048,9 +2669,11 @@ class TestMolecule:
 
                     # Call should be faster second time due to caching
                     # TODO: Implement caching
-                    molecule.compute_partial_charges(charge_model=charge_model, toolkit_registry=toolkit_registry)
+                    molecule.compute_partial_charges(
+                        charge_model=charge_model, toolkit_registry=toolkit_registry
+                    )
                     charges2 = molecule._partial_charges
-                    assert (np.allclose(charges1, charges2, atol=0.002))
+                    assert np.allclose(charges1, charges2, atol=0.002)
 
     @requires_openeye
     def test_assign_fractional_bond_orders(self):
@@ -2062,17 +2685,23 @@ class TestMolecule:
         # Do not modify the original molecules.
         molecules = copy.deepcopy(mini_drug_bank())
 
-        toolkits_to_bondorder_method = {(OpenEyeToolkitWrapper,):['am1-wiberg','pm3-wiberg']}
+        toolkits_to_bondorder_method = {
+            (OpenEyeToolkitWrapper,): ["am1-wiberg", "pm3-wiberg"]
+        }
         # Don't test AmberTools here since it takes too long
-                                       #(AmberToolsToolkitWrapper, RDKitToolkitWrapper):['am1-wiberg']}
+        # (AmberToolsToolkitWrapper, RDKitToolkitWrapper):['am1-wiberg']}
         for toolkits in list(toolkits_to_bondorder_method.keys()):
             toolkit_registry = ToolkitRegistry(toolkit_precedence=toolkits)
             for bond_order_model in toolkits_to_bondorder_method[toolkits]:
-                for molecule in molecules[:5]: # Just test first five molecules for speed
+                for molecule in molecules[
+                    :5
+                ]:  # Just test first five molecules for speed
                     molecule.generate_conformers(toolkit_registry=toolkit_registry)
-                    molecule.assign_fractional_bond_orders(bond_order_model=bond_order_model,
-                                                           toolkit_registry=toolkit_registry,
-                                                           use_conformers=molecule.conformers)
+                    molecule.assign_fractional_bond_orders(
+                        bond_order_model=bond_order_model,
+                        toolkit_registry=toolkit_registry,
+                        use_conformers=molecule.conformers,
+                    )
                     fbo1 = [bond.fractional_bond_order for bond in molecule.bonds]
                     # TODO: Now that the assign_fractional_bond_orders function takes more kwargs,
                     #       how can we meaningfully cache its results?
@@ -2087,17 +2716,19 @@ class TestMolecule:
         """Test that the visualize method returns an expected object when using RDKit to generate a 2-D representation"""
         import rdkit
 
-        mol = Molecule().from_smiles('CCO')
+        mol = Molecule().from_smiles("CCO")
 
-        assert isinstance(mol.visualize(backend='rdkit'), rdkit.Chem.rdchem.Mol)
+        assert isinstance(mol.visualize(backend="rdkit"), rdkit.Chem.rdchem.Mol)
 
-    @pytest.mark.skipif(RDKitToolkitWrapper.is_available(),
-        reason='Test requires that RDKit is NOT installed')
+    @pytest.mark.skipif(
+        RDKitToolkitWrapper.is_available(),
+        reason="Test requires that RDKit is NOT installed",
+    )
     def test_visualize_fallback(self):
         """Test falling back from RDKit to OpenEye if RDKit is specified but not installed"""
-        mol = Molecule().from_smiles('CCO')
+        mol = Molecule().from_smiles("CCO")
         with pytest.warns(UserWarning):
-            mol.visualize(backend='rdkit')
+            mol.visualize(backend="rdkit")
 
     def test_visualize_nglview(self):
         """Test that the visualize method returns an NGLview widget"""
@@ -2107,22 +2738,22 @@ class TestMolecule:
             pass
 
         # Start with a molecule without conformers
-        mol = Molecule().from_smiles('CCO')
+        mol = Molecule().from_smiles("CCO")
 
         with pytest.raises(ValueError):
-            mol.visualize(backend='nglview')
+            mol.visualize(backend="nglview")
 
         # Add conformers
         mol.generate_conformers()
 
         # Ensure an NGLView widget is returned
-        assert isinstance(mol.visualize(backend='nglview'), nglview.NGLWidget)
+        assert isinstance(mol.visualize(backend="nglview"), nglview.NGLWidget)
 
     @requires_openeye
     def test_visualize_openeye(self):
         """Test that the visualize method returns an expected object when using OpenEye to generate a 2-D representation"""
         import IPython
 
-        mol = Molecule().from_smiles('CCO')
+        mol = Molecule().from_smiles("CCO")
 
-        assert isinstance(mol.visualize(backend='openeye'), IPython.core.display.Image)
+        assert isinstance(mol.visualize(backend="openeye"), IPython.core.display.Image)

--- a/openforcefield/tests/test_parameter_plugins.py
+++ b/openforcefield/tests/test_parameter_plugins.py
@@ -29,19 +29,18 @@ def mock_entry_point_plugins():
     # Create the fake entry point definitions. These include a parameter handler
     # which is supported, and an io parameter handler which should be skipped.
     handler_entry_point = pkg_resources.EntryPoint.parse(
-        "CustomHandler = openforcefield.tests.plugins:CustomHandler",
-        dist=distribution
+        "CustomHandler = openforcefield.tests.plugins:CustomHandler", dist=distribution
     )
     io_handler_entry_point = pkg_resources.EntryPoint.parse(
         "CustomIOHandler = openforcefield.tests.plugins:CustomIOHandler",
-        dist=distribution
+        dist=distribution,
     )
 
     # Add the mapping to the fake EntryPoint
     distribution._ep_map = {
         "openff.toolkit.plugins.handlers": {
             "CustomHandler": handler_entry_point,
-            "CustomIOHandler": io_handler_entry_point
+            "CustomIOHandler": io_handler_entry_point,
         }
     }
 
@@ -67,7 +66,7 @@ def test_force_field_custom_handler(mock_entry_point_plugins):
             "<?xml version='1.0' encoding='ASCII'?>",
             "<SMIRNOFF version='0.3' aromaticity_model='OEAroModel_MDL'>",
             "  <CustomHandler version='0.3'></CustomHandler>",
-            "</SMIRNOFF>"
+            "</SMIRNOFF>",
         ]
     )
 
@@ -76,7 +75,8 @@ def test_force_field_custom_handler(mock_entry_point_plugins):
         ForceField(force_field_contents)
 
     assert (
-        "Cannot find a registered parameter handler class for tag 'CustomHandler'" in error_info.value.args[0]
+        "Cannot find a registered parameter handler class for tag 'CustomHandler'"
+        in error_info.value.args[0]
     )
 
     # Otherwise the FF should be created as expected.

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#======================================================================
+# ======================================================================
 # MODULE DOCSTRING
-#======================================================================
+# ======================================================================
 
 """
 Test classes and function in module openforcefield.typing.engines.smirnoff.parameters.
@@ -10,9 +10,9 @@ Test classes and function in module openforcefield.typing.engines.smirnoff.param
 """
 
 
-#======================================================================
+# ======================================================================
 # GLOBAL IMPORTS
-#======================================================================
+# ======================================================================
 
 import pytest
 from numpy.testing import assert_almost_equal
@@ -20,85 +20,110 @@ from simtk import unit
 
 from openforcefield.typing.engines.smirnoff import SMIRNOFFVersionError
 from openforcefield.typing.engines.smirnoff.parameters import (
-    ParameterAttribute, IndexedParameterAttribute, ParameterList,
-    ParameterType, BondHandler, ParameterHandler, ProperTorsionHandler,
-    ImproperTorsionHandler, LibraryChargeHandler, GBSAHandler, SMIRNOFFSpecError,
-    _ParameterAttributeHandler, ChargeIncrementModelHandler, IncompatibleParameterError,
+    ParameterAttribute,
+    IndexedParameterAttribute,
+    ParameterList,
+    ParameterType,
+    BondHandler,
+    ParameterHandler,
+    ProperTorsionHandler,
+    ImproperTorsionHandler,
+    LibraryChargeHandler,
+    GBSAHandler,
+    SMIRNOFFSpecError,
+    _ParameterAttributeHandler,
+    ChargeIncrementModelHandler,
+    IncompatibleParameterError,
     DuplicateParameterError,
-    )
+)
 from openforcefield.utils import detach_units, IncompatibleUnitError
 from openforcefield.utils.collections import ValidatedList
 
 
-#======================================================================
+# ======================================================================
 # Test ParameterAttribute descriptor
-#======================================================================
+# ======================================================================
+
 
 class TestParameterAttribute:
     """Test cases for the descriptor ParameterAttribute."""
 
     def test_default_value(self):
         """Default values are assigned correctly on initialization."""
+
         class MyParameter:
             attr_optional = ParameterAttribute(default=2)
+
         my_par = MyParameter()
         assert my_par.attr_optional == 2
 
     def test_none_default_value(self):
         """None is a valid default value for ParameterAttribute."""
+
         class MyParameter:
             attr_optional = ParameterAttribute(default=None)
+
         my_par = MyParameter()
         assert my_par.attr_optional is None
 
     def test_required_value(self):
         """AttributeError is raised if a required attribute is accessed before being initialized."""
+
         class MyParameter:
             attr_required = ParameterAttribute()
+
         my_par = MyParameter()
         with pytest.raises(AttributeError):
             my_par.attr_required
 
     def test_unit_validation(self):
         """ParameterAttributes attached to a unit are validated correctly."""
+
         class MyParameter:
-            attr_unit = ParameterAttribute(unit=unit.kilocalories_per_mole/unit.angstrom**2)
+            attr_unit = ParameterAttribute(
+                unit=unit.kilocalories_per_mole / unit.angstrom ** 2
+            )
+
         my_par = MyParameter()
 
         # TypeError is raised when setting a unit-less value.
-        with pytest.raises(IncompatibleUnitError, match='should have units of'):
+        with pytest.raises(IncompatibleUnitError, match="should have units of"):
             my_par.attr_unit = 3.0
         # TypeError is raised when setting a value with incorrect units.
-        with pytest.raises(IncompatibleUnitError, match='should have units of'):
+        with pytest.raises(IncompatibleUnitError, match="should have units of"):
             my_par.attr_unit = 3.0 * unit.kilocalories_per_mole
 
         # Otherwise the attribute is assigned correctly.
-        value = 3.0 * unit.kilocalories_per_mole/unit.angstrom**2
+        value = 3.0 * unit.kilocalories_per_mole / unit.angstrom ** 2
         my_par.attr_unit = value
         assert my_par.attr_unit == value
         assert my_par.attr_unit.unit == value.unit
 
     def test_quantity_string_parsing(self):
         """ParameterAttributes attached to units convert strings into Quantity objects."""
+
         class MyParameter:
-            attr_unit = ParameterAttribute(unit=unit.meter/unit.second**2)
+            attr_unit = ParameterAttribute(unit=unit.meter / unit.second ** 2)
+
         my_par = MyParameter()
 
-        my_par.attr_unit = '3.0*meter/second**2'
-        assert my_par.attr_unit == 3.0 * unit.meter/unit.second**2
-        assert my_par.attr_unit.unit == unit.meter/unit.second**2
+        my_par.attr_unit = "3.0*meter/second**2"
+        assert my_par.attr_unit == 3.0 * unit.meter / unit.second ** 2
+        assert my_par.attr_unit.unit == unit.meter / unit.second ** 2
 
         # Assigning incorrect units still raises an error.
-        with pytest.raises(IncompatibleUnitError, match='should have units of'):
-            my_par.attr_unit = '3.0'
-        with pytest.raises(IncompatibleUnitError, match='should have units of'):
-            my_par.attr_unit = '3.0*meter/second'
+        with pytest.raises(IncompatibleUnitError, match="should have units of"):
+            my_par.attr_unit = "3.0"
+        with pytest.raises(IncompatibleUnitError, match="should have units of"):
+            my_par.attr_unit = "3.0*meter/second"
 
     def test_custom_converter(self):
         """Custom converters of ParameterAttributes are executed correctly."""
+
         class MyParameter:
             attr_all_to_float = ParameterAttribute(converter=float)
             attr_int_to_float = ParameterAttribute()
+
             @attr_int_to_float.converter
             def attr_int_to_float(self, attr, value):
                 """Convert only integers to float"""
@@ -111,21 +136,34 @@ class TestParameterAttribute:
         my_par = MyParameter()
 
         # Both strings and integers are converted to floats when casted with float().
-        my_par.attr_all_to_float = '1.0'
-        assert isinstance(my_par.attr_all_to_float, float) and my_par.attr_all_to_float == 1.0
+        my_par.attr_all_to_float = "1.0"
+        assert (
+            isinstance(my_par.attr_all_to_float, float)
+            and my_par.attr_all_to_float == 1.0
+        )
         my_par.attr_all_to_float = 2
-        assert isinstance(my_par.attr_all_to_float, float) and my_par.attr_all_to_float == 2.0
+        assert (
+            isinstance(my_par.attr_all_to_float, float)
+            and my_par.attr_all_to_float == 2.0
+        )
 
         # Only integers are converted with the custom converter function.
         with pytest.raises(TypeError):
-            my_par.attr_int_to_float = '1.0'
+            my_par.attr_int_to_float = "1.0"
         my_par.attr_int_to_float = 2
-        assert isinstance(my_par.attr_int_to_float, float) and my_par.attr_int_to_float == 2.0
+        assert (
+            isinstance(my_par.attr_int_to_float, float)
+            and my_par.attr_int_to_float == 2.0
+        )
 
     def test_default_pass_validation(self):
         """The default value of ParameterAttribute is always allowed regardless of the validator/converter."""
+
         class MyParameter:
-            attr = ParameterAttribute(default=None, unit=unit.angstrom, converter=unit.Quantity)
+            attr = ParameterAttribute(
+                default=None, unit=unit.angstrom, converter=unit.Quantity
+            )
+
         my_par = MyParameter()
         my_par.attr = 3.0 * unit.nanometer
         my_par.attr = None
@@ -133,8 +171,10 @@ class TestParameterAttribute:
 
     def test_get_descriptor_object(self):
         """When the descriptor is called from the class, the ParameterAttribute descriptor is returned."""
+
         class MyParameter:
             attr = ParameterAttribute()
+
         assert isinstance(MyParameter.attr, ParameterAttribute)
 
 
@@ -143,16 +183,20 @@ class TestIndexedParameterAttribute:
 
     def test_tuple_conversion(self):
         """IndexedParameterAttribute converts internally sequences to ValidatedList."""
+
         class MyParameter:
             attr_indexed = IndexedParameterAttribute()
+
         my_par = MyParameter()
         my_par.attr_indexed = [1, 2, 3]
         assert isinstance(my_par.attr_indexed, ValidatedList)
 
     def test_indexed_default(self):
         """IndexedParameterAttribute handles default values correctly."""
+
         class MyParameter:
             attr_indexed_optional = IndexedParameterAttribute(default=None)
+
         my_par = MyParameter()
         assert my_par.attr_indexed_optional is None
 
@@ -162,54 +206,60 @@ class TestIndexedParameterAttribute:
 
     def test_units_on_all_elements(self):
         """IndexedParameterAttribute validates every single element of the sequence."""
+
         class MyParameter:
             attr_indexed_unit = IndexedParameterAttribute(unit=unit.gram)
+
         my_par = MyParameter()
 
         # Strings are correctly converted.
-        my_par.attr_indexed_unit = ['1.0*gram', 2*unit.gram]
-        assert my_par.attr_indexed_unit == [1.0*unit.gram, 2*unit.gram]
+        my_par.attr_indexed_unit = ["1.0*gram", 2 * unit.gram]
+        assert my_par.attr_indexed_unit == [1.0 * unit.gram, 2 * unit.gram]
 
         # Incompatible units on a single elements are correctly caught.
-        with pytest.raises(IncompatibleUnitError, match='should have units of'):
-            my_par.attr_indexed_unit = [3.0, 2*unit.gram]
-        with pytest.raises(IncompatibleUnitError, match='should have units of'):
-            my_par.attr_indexed_unit = [2*unit.gram, 4.0*unit.meter]
+        with pytest.raises(IncompatibleUnitError, match="should have units of"):
+            my_par.attr_indexed_unit = [3.0, 2 * unit.gram]
+        with pytest.raises(IncompatibleUnitError, match="should have units of"):
+            my_par.attr_indexed_unit = [2 * unit.gram, 4.0 * unit.meter]
 
     def test_converter_on_all_elements(self):
         """IndexedParameterAttribute calls custom converters on every single element of the sequence."""
+
         class MyParameter:
             attr_indexed_converter = IndexedParameterAttribute(converter=float)
+
         my_par = MyParameter()
 
-        my_par.attr_indexed_converter = [1, '2.0', '1e-3', 4.0]
+        my_par.attr_indexed_converter = [1, "2.0", "1e-3", 4.0]
         assert my_par.attr_indexed_converter == [1.0, 2.0, 1e-3, 4.0]
 
     def test_validate_new_elements(self):
         """New elements set in the list are correctly validated."""
+
         class MyParameter:
             attr_indexed = IndexedParameterAttribute(converter=int)
+
         my_par = MyParameter()
         my_par.attr_indexed = (1, 2, 3)
 
         # Modifying one or more elements of the list should validate them.
-        my_par.attr_indexed[2] = '4'
+        my_par.attr_indexed[2] = "4"
         assert my_par.attr_indexed[2] == 4
-        my_par.attr_indexed[0:3] = ['2', '3', 4]
+        my_par.attr_indexed[0:3] = ["2", "3", 4]
         assert my_par.attr_indexed == [2, 3, 4]
 
         # Same for append().
-        my_par.attr_indexed.append('5')
+        my_par.attr_indexed.append("5")
         assert my_par.attr_indexed[3] == 5
 
         # And extend.
-        my_par.attr_indexed.extend([6, '7'])
+        my_par.attr_indexed.extend([6, "7"])
         assert my_par.attr_indexed[5] == 7
-        my_par.attr_indexed += ['8', 9]
+        my_par.attr_indexed += ["8", 9]
         assert my_par.attr_indexed[6] == 8
 
         # And insert.
-        my_par.attr_indexed.insert(5, '10')
+        my_par.attr_indexed.insert(5, "10")
         assert my_par.attr_indexed[5] == 10
 
 
@@ -218,8 +268,10 @@ class TestParameterAttributeHandler:
 
     def test_access_get_set_single_indexed_attribute(self):
         """Single indexed attributes such as k1 can be accessed through normal attribute syntax."""
+
         class MyParameterType(_ParameterAttributeHandler):
             k = IndexedParameterAttribute()
+
         my_parameter = MyParameterType(k=[1, 2, 3])
 
         # Getting the attribute works.
@@ -233,9 +285,13 @@ class TestParameterAttributeHandler:
         assert my_parameter.k == [1, 5, 3]
 
         # Accessing k4 raises an index error.
-        with pytest.raises(IndexError, match="'k4' is out of bound for indexed attribute 'k'"):
+        with pytest.raises(
+            IndexError, match="'k4' is out of bound for indexed attribute 'k'"
+        ):
             my_parameter.k4
-        with pytest.raises(IndexError, match="'k4' is out of bound for indexed attribute 'k'"):
+        with pytest.raises(
+            IndexError, match="'k4' is out of bound for indexed attribute 'k'"
+        ):
             my_parameter.k4 = 2
 
         # For other attributes, the behavior is normal.
@@ -246,6 +302,7 @@ class TestParameterAttributeHandler:
 
     def test_mro_access_get_set_single_indexed_attribute(self):
         """Attribute access is forwarded correctly to the next MRO classes."""
+
         class MixIn:
             """Utility class to keep track of whether __get/setattr__ are called."""
 
@@ -260,7 +317,7 @@ class TestParameterAttributeHandler:
 
             def __setattr__(self, key, value):
                 self.data[key] = value
-                super().__setattr__('setattr_flag', True)
+                super().__setattr__("setattr_flag", True)
 
             def assert_getattr(self):
                 assert self.getattr_flag is True
@@ -268,7 +325,7 @@ class TestParameterAttributeHandler:
 
             def assert_setattr(self):
                 assert self.setattr_flag is True
-                super().__setattr__('setattr_flag', False)
+                super().__setattr__("setattr_flag", False)
 
         class MyParameterType(_ParameterAttributeHandler, MixIn):
             k = IndexedParameterAttribute()
@@ -287,15 +344,17 @@ class TestParameterAttributeHandler:
         my_parameter.assert_getattr()
 
 
-#======================================================================
+# ======================================================================
 # Test ParameterHandler
-#======================================================================
+# ======================================================================
+
 
 class TestParameterHandler:
 
     from simtk import unit
-    length = 1*unit.angstrom
-    k = 10*unit.kilocalorie_per_mole/unit.angstrom**2
+
+    length = 1 * unit.angstrom
+    k = 10 * unit.kilocalorie_per_mole / unit.angstrom ** 2
 
     def test_tagname(self):
         """Test the TAGNAME getter and default behavior"""
@@ -303,43 +362,81 @@ class TestParameterHandler:
         assert ph.TAGNAME is None
 
         bh = BondHandler(skip_version_check=True)
-        assert bh.TAGNAME == 'Bonds'
+        assert bh.TAGNAME == "Bonds"
 
     def test_add_parameter(self):
         """Test the behavior of add_parameter"""
         bh = BondHandler(skip_version_check=True)
-        param1 = {'smirks': '[*:1]-[*:2]', 'length': self.length, 'k': self.k, 'id': 'b1'}
-        param2 = {'smirks': '[*:1]=[*:2]', 'length': self.length, 'k': self.k, 'id': 'b2'}
-        param3 = {'smirks': '[*:1]#[*:2]', 'length': self.length, 'k': self.k, 'id': 'b3'}
+        param1 = {
+            "smirks": "[*:1]-[*:2]",
+            "length": self.length,
+            "k": self.k,
+            "id": "b1",
+        }
+        param2 = {
+            "smirks": "[*:1]=[*:2]",
+            "length": self.length,
+            "k": self.k,
+            "id": "b2",
+        }
+        param3 = {
+            "smirks": "[*:1]#[*:2]",
+            "length": self.length,
+            "k": self.k,
+            "id": "b3",
+        }
 
         bh.add_parameter(param1)
         bh.add_parameter(param2)
         bh.add_parameter(param3)
 
-        assert [p.id for p in bh._parameters] == ['b1', 'b2', 'b3']
+        assert [p.id for p in bh._parameters] == ["b1", "b2", "b3"]
 
-        param_duplicate_smirks = {'smirks': param2['smirks'], 'length': 2*self.length, 'k': 2*self.k}
+        param_duplicate_smirks = {
+            "smirks": param2["smirks"],
+            "length": 2 * self.length,
+            "k": 2 * self.k,
+        }
 
         # Ensure a duplicate parameter cannot be added
         with pytest.raises(DuplicateParameterError):
             bh.add_parameter(param_duplicate_smirks)
 
         dict_to_add_by_smirks = {
-            'smirks': '[#1:1]-[#6:2]', 'length': self.length, 'k': self.k, 'id': 'd1',
+            "smirks": "[#1:1]-[#6:2]",
+            "length": self.length,
+            "k": self.k,
+            "id": "d1",
         }
         dict_to_add_by_index = {
-            'smirks': '[#1:1]-[#8:2]', 'length': self.length, 'k': self.k, 'id': 'd2',
+            "smirks": "[#1:1]-[#8:2]",
+            "length": self.length,
+            "k": self.k,
+            "id": "d2",
         }
 
         param_to_add_by_smirks = BondHandler.BondType(
-            **{'smirks': '[#6:1]-[#6:2]', 'length': self.length, 'k': self.k, 'id': 'p1'}
+            **{
+                "smirks": "[#6:1]-[#6:2]",
+                "length": self.length,
+                "k": self.k,
+                "id": "p1",
+            }
         )
         param_to_add_by_index = BondHandler.BondType(
-            **{'smirks': '[#6:1]=[#8:2]', 'length': self.length, 'k': self.k, 'id': 'p2'}
+            **{
+                "smirks": "[#6:1]=[#8:2]",
+                "length": self.length,
+                "k": self.k,
+                "id": "p2",
+            }
         )
 
         param_several_apart = {
-            'smirks': '[#1:1]-[#7:2]', 'length': self.length, 'k': self.k, 'id': 's0',
+            "smirks": "[#1:1]-[#7:2]",
+            "length": self.length,
+            "k": self.k,
+            "id": "s0",
         }
 
         # The `before` parameter should come after the `after` parameter
@@ -347,36 +444,55 @@ class TestParameterHandler:
         # impossible to add a new parameter after '=' *and* before '-'
         with pytest.raises(ValueError):
             # Test invalid parameter order by SMIRKS
-            bh.add_parameter(dict_to_add_by_smirks, after='[*:1]=[*:2]', before='[*:1]-[*:2]')
+            bh.add_parameter(
+                dict_to_add_by_smirks, after="[*:1]=[*:2]", before="[*:1]-[*:2]"
+            )
 
         with pytest.raises(ValueError):
             # Test invalid parameter order by index
             bh.add_parameter(dict_to_add_by_index, after=1, before=0)
 
         # Add d1 before param b2
-        bh.add_parameter(dict_to_add_by_smirks, before='[*:1]=[*:2]')
+        bh.add_parameter(dict_to_add_by_smirks, before="[*:1]=[*:2]")
 
-        assert [p.id for p in bh._parameters] == ['b1', 'd1', 'b2', 'b3']
+        assert [p.id for p in bh._parameters] == ["b1", "d1", "b2", "b3"]
 
         # Add d2 after index 2 (which is also param b2)
         bh.add_parameter(dict_to_add_by_index, after=2)
 
-        assert [p.id for p in bh._parameters] == ['b1', 'd1', 'b2', 'd2', 'b3']
+        assert [p.id for p in bh._parameters] == ["b1", "d1", "b2", "d2", "b3"]
 
         # Add p1 before param b3
-        bh.add_parameter(parameter=param_to_add_by_smirks, before='[*:1]=[*:2]')
+        bh.add_parameter(parameter=param_to_add_by_smirks, before="[*:1]=[*:2]")
 
-        assert [p.id for p in bh._parameters] == ['b1', 'd1', 'p1', 'b2', 'd2', 'b3']
+        assert [p.id for p in bh._parameters] == ["b1", "d1", "p1", "b2", "d2", "b3"]
 
         # Add p2 after index 2 (which is param p1)
         bh.add_parameter(parameter=param_to_add_by_index, after=2)
 
-        assert [p.id for p in bh._parameters] == ['b1', 'd1', 'p1', 'p2', 'b2', 'd2', 'b3']
+        assert [p.id for p in bh._parameters] == [
+            "b1",
+            "d1",
+            "p1",
+            "p2",
+            "b2",
+            "d2",
+            "b3",
+        ]
 
         # Add s0 between params that are several positions apart
         bh.add_parameter(param_several_apart, after=1, before=6)
 
-        assert [p.id for p in bh._parameters] == ['b1', 'd1', 's0', 'p1', 'p2', 'b2', 'd2', 'b3']
+        assert [p.id for p in bh._parameters] == [
+            "b1",
+            "d1",
+            "s0",
+            "p1",
+            "p2",
+            "b2",
+            "d2",
+            "b3",
+        ]
 
     def test_different_units_to_dict(self):
         """Test ParameterHandler.to_dict() function when some parameters are in
@@ -384,39 +500,62 @@ class TestParameterHandler:
         read unit)
         """
         from simtk import unit
+
         bh = BondHandler(skip_version_check=True)
-        bh.add_parameter({'smirks': '[*:1]-[*:2]',
-                          'length': 1*unit.angstrom,
-                          'k': 10*unit.kilocalorie_per_mole/unit.angstrom**2})
-        bh.add_parameter({'smirks': '[*:1]=[*:2]',
-                          'length': 0.2*unit.nanometer,
-                          'k': 0.4*unit.kilojoule_per_mole/unit.nanometer**2})
+        bh.add_parameter(
+            {
+                "smirks": "[*:1]-[*:2]",
+                "length": 1 * unit.angstrom,
+                "k": 10 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+            }
+        )
+        bh.add_parameter(
+            {
+                "smirks": "[*:1]=[*:2]",
+                "length": 0.2 * unit.nanometer,
+                "k": 0.4 * unit.kilojoule_per_mole / unit.nanometer ** 2,
+            }
+        )
         bh_dict = bh.to_dict()
-        assert bh_dict['Bond'][0]['length'] == unit.Quantity(value=1, unit=unit.angstrom)
-        assert bh_dict['Bond'][1]['length'] == unit.Quantity(value=2, unit=unit.angstrom)
+        assert bh_dict["Bond"][0]["length"] == unit.Quantity(
+            value=1, unit=unit.angstrom
+        )
+        assert bh_dict["Bond"][1]["length"] == unit.Quantity(
+            value=2, unit=unit.angstrom
+        )
 
     def test_to_dict_maintain_units(self):
         """Test ParameterHandler.to_dict() function when parameters were provided in different units
         """
         from simtk import unit
-        bh = BondHandler(skip_version_check=True)
-        bh.add_parameter({'smirks': '[*:1]-[*:2]',
-                          'length': 1*unit.angstrom,
-                          'k': 10*unit.kilocalorie_per_mole/unit.angstrom**2})
-        bh.add_parameter({'smirks': '[*:1]=[*:2]',
-                          'length': 0.2*unit.nanometer,
-                          'k': 0.4*unit.kilojoule_per_mole/unit.nanometer**2})
-        bh_dict = bh.to_dict()
-        assert bh_dict['Bond'][0]['length'] == unit.Quantity(1., unit.angstrom)
-        assert bh_dict['Bond'][0]['length'].unit == unit.angstrom
-        assert bh_dict['Bond'][1]['length'] == unit.Quantity(0.2, unit.nanometer)
-        assert bh_dict['Bond'][1]['length'].unit == unit.nanometer
 
+        bh = BondHandler(skip_version_check=True)
+        bh.add_parameter(
+            {
+                "smirks": "[*:1]-[*:2]",
+                "length": 1 * unit.angstrom,
+                "k": 10 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+            }
+        )
+        bh.add_parameter(
+            {
+                "smirks": "[*:1]=[*:2]",
+                "length": 0.2 * unit.nanometer,
+                "k": 0.4 * unit.kilojoule_per_mole / unit.nanometer ** 2,
+            }
+        )
+        bh_dict = bh.to_dict()
+        assert bh_dict["Bond"][0]["length"] == unit.Quantity(1.0, unit.angstrom)
+        assert bh_dict["Bond"][0]["length"].unit == unit.angstrom
+        assert bh_dict["Bond"][1]["length"] == unit.Quantity(0.2, unit.nanometer)
+        assert bh_dict["Bond"][1]["length"].unit == unit.nanometer
 
     def test_missing_section_version(self):
         """Test that exceptions are raised if invalid or improper section versions are provided during intialization"""
         # Generate a SMIRNOFFSpecError by not providing a section version
-        with pytest.raises(SMIRNOFFSpecError, match='Missing version while trying to construct') as excinfo:
+        with pytest.raises(
+            SMIRNOFFSpecError, match="Missing version while trying to construct"
+        ) as excinfo:
             ph = ParameterHandler()
         # Successfully create ParameterHandler by skipping version check
         ph = ParameterHandler(skip_version_check=True)
@@ -428,15 +567,20 @@ class TestParameterHandler:
         ph = ParameterHandler(version=ParameterHandler._MIN_SUPPORTED_SECTION_VERSION)
 
         # Generate a SMIRNOFFSpecError by providing a value higher than the max supported
-        with pytest.raises(SMIRNOFFVersionError, match='SMIRNOFF offxml file was written with version 1000.0, '
-                                                    'but this version of ForceField only supports version') as excinfo:
-            ph = ParameterHandler(version='1000.0')
-
+        with pytest.raises(
+            SMIRNOFFVersionError,
+            match="SMIRNOFF offxml file was written with version 1000.0, "
+            "but this version of ForceField only supports version",
+        ) as excinfo:
+            ph = ParameterHandler(version="1000.0")
 
         # Generate a SMIRNOFFSpecError by providing a value lower than the min supported
-        with pytest.raises(SMIRNOFFVersionError, match='SMIRNOFF offxml file was written with version 0.1, '
-                                                    'but this version of ForceField only supports version') as excinfo:
-            ph = ParameterHandler(version='0.1')
+        with pytest.raises(
+            SMIRNOFFVersionError,
+            match="SMIRNOFF offxml file was written with version 0.1, "
+            "but this version of ForceField only supports version",
+        ) as excinfo:
+            ph = ParameterHandler(version="0.1")
 
     def test_add_delete_cosmetic_attributes(self):
         """Test ParameterHandler.to_dict() function when some parameters are in
@@ -444,77 +588,96 @@ class TestParameterHandler:
         read unit)
         """
         from simtk import unit
-        bh = BondHandler(skip_version_check=True)
-        bh.add_parameter({'smirks': '[*:1]-[*:2]',
-                          'length': 1*unit.angstrom,
-                          'k': 10*unit.kilocalorie_per_mole/unit.angstrom**2})
-        bh.add_parameter({'smirks': '[*:1]=[*:2]',
-                          'length': 0.2*unit.nanometer,
-                          'k': 0.4*unit.kilojoule_per_mole/unit.nanometer**2})
 
-        assert not(bh.attribute_is_cosmetic('pilot'))
+        bh = BondHandler(skip_version_check=True)
+        bh.add_parameter(
+            {
+                "smirks": "[*:1]-[*:2]",
+                "length": 1 * unit.angstrom,
+                "k": 10 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+            }
+        )
+        bh.add_parameter(
+            {
+                "smirks": "[*:1]=[*:2]",
+                "length": 0.2 * unit.nanometer,
+                "k": 0.4 * unit.kilojoule_per_mole / unit.nanometer ** 2,
+            }
+        )
+
+        assert not (bh.attribute_is_cosmetic("pilot"))
 
         # Ensure the cosmetic attribute is present by default during output
-        bh.add_cosmetic_attribute('pilot', 'alice')
+        bh.add_cosmetic_attribute("pilot", "alice")
         param_dict = bh.to_dict()
-        assert ('pilot', 'alice') in param_dict.items()
-        assert bh.attribute_is_cosmetic('pilot')
+        assert ("pilot", "alice") in param_dict.items()
+        assert bh.attribute_is_cosmetic("pilot")
 
         # Ensure the cosmetic attribute isn't present if we request that it be discarded
         param_dict = bh.to_dict(discard_cosmetic_attributes=True)
-        assert 'pilot' not in param_dict
+        assert "pilot" not in param_dict
 
         # Manually delete the cosmetic attribute and ensure it doesn't get written out
-        bh.delete_cosmetic_attribute('pilot')
+        bh.delete_cosmetic_attribute("pilot")
         param_dict = bh.to_dict()
-        assert 'pilot' not in param_dict
-        assert not(bh.attribute_is_cosmetic('pilot'))
-
+        assert "pilot" not in param_dict
+        assert not (bh.attribute_is_cosmetic("pilot"))
 
     def test_get_parameter(self):
         """Test that ParameterHandler.get_parameter can lookup function
         """
         from simtk import unit
+
         bh = BondHandler(skip_version_check=True, allow_cosmetic_attributes=True)
 
-        bh.add_parameter({'smirks': '[*:1]-[*:2]',
-                          'length': 1*unit.angstrom,
-                          'k': 10*unit.kilocalorie_per_mole/unit.angstrom**2,
-                          'id': 'b0'})
-        bh.parameters[0].add_cosmetic_attribute('foo', 'bar')
+        bh.add_parameter(
+            {
+                "smirks": "[*:1]-[*:2]",
+                "length": 1 * unit.angstrom,
+                "k": 10 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+                "id": "b0",
+            }
+        )
+        bh.parameters[0].add_cosmetic_attribute("foo", "bar")
 
         # Check base behavior
-        params = bh.get_parameter({'smirks': '[*:1]-[*:2]'})
+        params = bh.get_parameter({"smirks": "[*:1]-[*:2]"})
 
         assert params[0].length == unit.Quantity(1.0, unit.angstrom)
-        assert params[0].k == unit.Quantity(10.0, unit.kilocalorie_per_mole/unit.angstrom**2)
+        assert params[0].k == unit.Quantity(
+            10.0, unit.kilocalorie_per_mole / unit.angstrom ** 2
+        )
 
         # Ensure a query with no matches returns an empty list
-        assert not bh.get_parameter({'smirks': 'xyz'})
+        assert not bh.get_parameter({"smirks": "xyz"})
 
         # Ensure searching for a nonexistent attr does not raise an exception
-        assert not bh.get_parameter({'bAdAttR': '0'})
+        assert not bh.get_parameter({"bAdAttR": "0"})
 
         # Check for optional and cosmetic attrs
-        optional_params = bh.get_parameter({'id': 'b0'})
-        cosmetic_params = bh.get_parameter({'foo': 'bar'})
+        optional_params = bh.get_parameter({"id": "b0"})
+        cosmetic_params = bh.get_parameter({"foo": "bar"})
 
-        assert optional_params[0].id == 'b0'
-        assert cosmetic_params[0]._foo == 'bar'
+        assert optional_params[0].id == "b0"
+        assert cosmetic_params[0]._foo == "bar"
 
         # Ensure selection behaves a "OR" not "AND"
-        bh.add_parameter({'smirks': '[#1:1]-[#6:2]',
-                          'length': 1*unit.angstrom,
-                          'k': 10*unit.kilocalorie_per_mole/unit.angstrom**2,
-                          'id': 'b1'})
+        bh.add_parameter(
+            {
+                "smirks": "[#1:1]-[#6:2]",
+                "length": 1 * unit.angstrom,
+                "k": 10 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+                "id": "b1",
+            }
+        )
 
-        params = bh.get_parameter({'id': 'b0', 'smirks': '[#1:1]-[#6:2]'})
+        params = bh.get_parameter({"id": "b0", "smirks": "[#1:1]-[#6:2]"})
 
-        assert 'b0' in [param.id for param in params]
-        assert '[*:1]-[*:2]' in [param.smirks for param in params]
+        assert "b0" in [param.id for param in params]
+        assert "[*:1]-[*:2]" in [param.smirks for param in params]
 
         # Ensure selection does not return duplicates if multiple matches
-        params = bh.get_parameter({'id': 'b1', 'smirks': '[#1:1]-[#6:2]'})
+        params = bh.get_parameter({"id": "b1", "smirks": "[#1:1]-[#6:2]"})
 
         assert len(params) == 1
 
@@ -526,17 +689,19 @@ class TestParameterList:
     def test_create(self):
         """Test creation of a parameter list.
         """
-        p1 = ParameterType(smirks='[*:1]')
-        p2 = ParameterType(smirks='[#1:1]')
+        p1 = ParameterType(smirks="[*:1]")
+        p2 = ParameterType(smirks="[#1:1]")
         parameters = ParameterList([p1, p2])
 
-    @pytest.mark.wip(reason="Until ChemicalEnvironment won't be refactored to use the ToolkitRegistry "
-                            "API, the smirks assignment will fail with RDKit.")
+    @pytest.mark.wip(
+        reason="Until ChemicalEnvironment won't be refactored to use the ToolkitRegistry "
+        "API, the smirks assignment will fail with RDKit."
+    )
     def test_getitem(self):
         """Test ParameterList __getitem__ overloading.
         """
-        p1 = ParameterType(smirks='[*:1]')
-        p2 = ParameterType(smirks='[#1:1]')
+        p1 = ParameterType(smirks="[*:1]")
+        p2 = ParameterType(smirks="[#1:1]")
         parameters = ParameterList([p1, p2])
         assert parameters[0] == p1
         assert parameters[1] == p2
@@ -544,38 +709,40 @@ class TestParameterList:
         assert parameters[p2.smirks] == p2
 
         # Note that this call access __getitem__, not __setitem__.
-        parameters['[*:1]'].smirks = '[*X4:1]'
-        assert parameters[0].smirks == '[*X4:1]'
-        assert p1.smirks == '[*X4:1]'
+        parameters["[*:1]"].smirks = "[*X4:1]"
+        assert parameters[0].smirks == "[*X4:1]"
+        assert p1.smirks == "[*X4:1]"
 
     def test_index(self):
         """
         Tests the ParameterList.index() function by attempting lookups by SMIRKS and by ParameterType equivalence.
 
         """
-        p1 = ParameterType(smirks='[*:1]')
-        p2 = ParameterType(smirks='[#1:1]')
-        p3 = ParameterType(smirks='[#7:1]')
+        p1 = ParameterType(smirks="[*:1]")
+        p2 = ParameterType(smirks="[#1:1]")
+        p3 = ParameterType(smirks="[#7:1]")
         parameters = ParameterList([p1, p2, p3])
         assert parameters.index(p1) == 0
         assert parameters.index(p2) == 1
         assert parameters.index(p3) == 2
-        assert parameters.index('[*:1]') == 0
-        assert parameters.index('[#1:1]') == 1
-        assert parameters.index('[#7:1]') == 2
-        with pytest.raises(IndexError, match=r'SMIRKS \[#2:1\] not found in ParameterList') as excinfo:
-            parameters.index('[#2:1]')
+        assert parameters.index("[*:1]") == 0
+        assert parameters.index("[#1:1]") == 1
+        assert parameters.index("[#7:1]") == 2
+        with pytest.raises(
+            IndexError, match=r"SMIRKS \[#2:1\] not found in ParameterList"
+        ) as excinfo:
+            parameters.index("[#2:1]")
 
-        p4 = ParameterType(smirks='[#2:1]')
-        with pytest.raises(ValueError, match='is not in list') as excinfo:
+        p4 = ParameterType(smirks="[#2:1]")
+        with pytest.raises(ValueError, match="is not in list") as excinfo:
             parameters.index(p4)
 
     def test_contains(self):
         """Test ParameterList __contains__ overloading.
         """
-        p1 = ParameterType(smirks='[*:1]')
-        p2 = ParameterType(smirks='[#1:1]')
-        p3 = ParameterType(smirks='[#7:1]')
+        p1 = ParameterType(smirks="[*:1]")
+        p2 = ParameterType(smirks="[#1:1]")
+        p3 = ParameterType(smirks="[#7:1]")
         parameters = ParameterList([p1, p2])
         assert p1 in parameters
         assert p2 in parameters
@@ -588,15 +755,17 @@ class TestParameterList:
         """
         Test ParameterList __del__ overloading.
         """
-        p1 = ParameterType(smirks='[*:1]')
-        p2 = ParameterType(smirks='[#1:1]')
-        p3 = ParameterType(smirks='[#7:1]')
+        p1 = ParameterType(smirks="[*:1]")
+        p2 = ParameterType(smirks="[#1:1]")
+        p3 = ParameterType(smirks="[#7:1]")
         parameters = ParameterList([p1, p2, p3])
 
-        with pytest.raises(IndexError, match='list assignment index out of range'):
+        with pytest.raises(IndexError, match="list assignment index out of range"):
             del parameters[4]
-        with pytest.raises(IndexError, match=r'SMIRKS \[#6:1\] not found in ParameterList'):
-            del parameters['[#6:1]']
+        with pytest.raises(
+            IndexError, match=r"SMIRKS \[#6:1\] not found in ParameterList"
+        ):
+            del parameters["[#6:1]"]
 
         # Test that original list deletion behavior is preserved.
         del parameters[2]
@@ -606,26 +775,25 @@ class TestParameterList:
         assert p3 not in parameters
 
         # Test that we can delete elements by their smirks.
-        del parameters['[#1:1]']
+        del parameters["[#1:1]"]
         assert len(parameters) == 1
         assert p1 in parameters
         assert p2 not in parameters
-
 
     def test_append(self):
         """
         Test ParameterList.append, ensuring that the new parameter was added to the bottom of the list
         and that it is properly recorded as the most recently-added.
         """
-        p1 = ParameterType(smirks='[*:1]-[*:2]')
-        p2 = ParameterType(smirks='[*:1]=[*:2]')
+        p1 = ParameterType(smirks="[*:1]-[*:2]")
+        p2 = ParameterType(smirks="[*:1]=[*:2]")
         param_list = ParameterList()
         param_list.append(p1)
         assert len(param_list) == 1
-        assert '[*:1]-[*:2]' in param_list
+        assert "[*:1]-[*:2]" in param_list
         param_list.append(p2)
         assert len(param_list) == 2
-        assert '[*:1]=[*:2]' in param_list
+        assert "[*:1]=[*:2]" in param_list
         assert param_list[-1] == p2
 
     def test_insert(self):
@@ -633,9 +801,9 @@ class TestParameterList:
         Test ParameterList.insert, ensuring that the new parameter was added to the proper spot in
         the list and that it is propertly recorded as the most recently added.
         """
-        p1 = ParameterType(smirks='[*:1]-[*:2]')
-        p2 = ParameterType(smirks='[*:1]=[*:2]')
-        p3 = ParameterType(smirks='[*:1]#[*:2]')
+        p1 = ParameterType(smirks="[*:1]-[*:2]")
+        p2 = ParameterType(smirks="[*:1]=[*:2]")
+        p3 = ParameterType(smirks="[*:1]#[*:2]")
         param_list = ParameterList([p1, p2])
         param_list.insert(1, p3)
         assert param_list[1] == p3
@@ -645,52 +813,60 @@ class TestParameterList:
         Test ParameterList.extend, ensuring that the new parameter was added to the proper spot in
         the list and that it is propertly recorded as the most recently added.
         """
-        p1 = ParameterType(smirks='[*:1]-[*:2]')
-        p2 = ParameterType(smirks='[*:1]=[*:2]')
+        p1 = ParameterType(smirks="[*:1]-[*:2]")
+        p2 = ParameterType(smirks="[*:1]=[*:2]")
         param_list1 = ParameterList()
         param_list2 = ParameterList([p1, p2])
 
         param_list1.extend(param_list2)
         assert len(param_list1) == 2
-        assert '[*:1]-[*:2]' in param_list1
-        assert '[*:1]=[*:2]' in param_list1
+        assert "[*:1]-[*:2]" in param_list1
+        assert "[*:1]=[*:2]" in param_list1
         assert param_list1[-1] == p2
 
     def test_to_list(self):
         """Test basic ParameterList.to_list() function, ensuring units are preserved"""
         from simtk import unit
-        p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
-                                  length=1.01 * unit.angstrom,
-                                  k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2
-                                  )
-        p2 = BondHandler.BondType(smirks='[*:1]=[*:2]',
-                                  length=1.02 * unit.angstrom,
-                                  k=6 * unit.kilocalorie_per_mole / unit.angstrom ** 2
-                                  )
-        p3 = BondHandler.BondType(smirks='[*:1]#[*:3]',
-                                  length=1.03 * unit.angstrom,
-                                  k=7 * unit.kilocalorie_per_mole / unit.angstrom ** 2
-                                  )
+
+        p1 = BondHandler.BondType(
+            smirks="[*:1]-[*:2]",
+            length=1.01 * unit.angstrom,
+            k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+        )
+        p2 = BondHandler.BondType(
+            smirks="[*:1]=[*:2]",
+            length=1.02 * unit.angstrom,
+            k=6 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+        )
+        p3 = BondHandler.BondType(
+            smirks="[*:1]#[*:3]",
+            length=1.03 * unit.angstrom,
+            k=7 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+        )
         parameter_list = ParameterList([p1, p2, p3])
         ser_param_list = parameter_list.to_list()
         assert len(ser_param_list) == 3
-        assert ser_param_list[0]['length'] == 1.01 * unit.angstrom
+        assert ser_param_list[0]["length"] == 1.01 * unit.angstrom
 
     def test_round_trip(self):
         """Test basic ParameterList.to_list() function and constructor"""
         from simtk import unit
-        p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
-                                  length=1.01 * unit.angstrom,
-                                  k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2
-                                  )
-        p2 = BondHandler.BondType(smirks='[*:1]=[*:2]',
-                                  length=1.02 * unit.angstrom,
-                                  k=6 * unit.kilocalorie_per_mole / unit.angstrom ** 2
-                                  )
-        p3 = BondHandler.BondType(smirks='[*:1]#[*:3]',
-                                  length=1.03 * unit.angstrom,
-                                  k=7 * unit.kilocalorie_per_mole / unit.angstrom ** 2
-                                  )
+
+        p1 = BondHandler.BondType(
+            smirks="[*:1]-[*:2]",
+            length=1.01 * unit.angstrom,
+            k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+        )
+        p2 = BondHandler.BondType(
+            smirks="[*:1]=[*:2]",
+            length=1.02 * unit.angstrom,
+            k=6 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+        )
+        p3 = BondHandler.BondType(
+            smirks="[*:1]#[*:3]",
+            length=1.03 * unit.angstrom,
+            k=7 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+        )
         parameter_list = ParameterList([p1, p2, p3])
         param_dict_list = parameter_list.to_list()
         parameter_list_2 = ParameterList()
@@ -701,9 +877,9 @@ class TestParameterList:
 
 
 class TestParameterType:
-
     def test_find_all_parameter_attrs(self):
         """ParameterType find all ParameterAttributes in the declared order."""
+
         class MyParameter(ParameterType):
             attr = ParameterAttribute()
             indexed = IndexedParameterAttribute()
@@ -711,111 +887,133 @@ class TestParameterType:
         parameter_attributes = MyParameter._get_parameter_attributes()
 
         # The function should find also the parent's attributes and in the correct order.
-        expected_attributes = ['smirks', 'id', 'parent_id', 'attr', 'indexed']
+        expected_attributes = ["smirks", "id", "parent_id", "attr", "indexed"]
         assert list(parameter_attributes.keys()) == expected_attributes
 
         # The keys map to the descriptor instances.
-        assert type(parameter_attributes['attr']) is ParameterAttribute
-        assert type(parameter_attributes['indexed']) is IndexedParameterAttribute
+        assert type(parameter_attributes["attr"]) is ParameterAttribute
+        assert type(parameter_attributes["indexed"]) is IndexedParameterAttribute
 
     def test_find_all_indexed_parameter_attrs(self):
         """ParameterType find all IndexedParameterAttributes."""
+
         class MyParameter(ParameterType):
             attr = ParameterAttribute()
             indexed = IndexedParameterAttribute()
             attr2 = ParameterAttribute()
             indexed2 = IndexedParameterAttribute(default=None)
 
-        expected_names = ['indexed', 'indexed2']
+        expected_names = ["indexed", "indexed2"]
         parameter_attributes = MyParameter._get_indexed_parameter_attributes()
         assert list(parameter_attributes.keys()) == expected_names
-        assert all(isinstance(parameter_attributes[name], IndexedParameterAttribute)
-                   for name in expected_names)
+        assert all(
+            isinstance(parameter_attributes[name], IndexedParameterAttribute)
+            for name in expected_names
+        )
 
     def test_find_all_required_and_optional_parameter_attrs(self):
         """ParameterType distinguish between required and optional ParameterAttributes."""
+
         class MyParameter(ParameterType):
             required = ParameterAttribute()
             optional = ParameterAttribute(default=1)
             required_indexed = IndexedParameterAttribute()
             optional_indexed2 = IndexedParameterAttribute(default=None)
 
-        expected_names = ['smirks', 'required', 'required_indexed']
+        expected_names = ["smirks", "required", "required_indexed"]
         parameter_attributes = MyParameter._get_required_parameter_attributes()
         assert list(parameter_attributes.keys()) == expected_names
 
-        expected_names = ['id', 'parent_id', 'optional', 'optional_indexed2']
+        expected_names = ["id", "parent_id", "optional", "optional_indexed2"]
         parameter_attributes = MyParameter._get_optional_parameter_attributes()
         assert list(parameter_attributes.keys()) == expected_names
 
     def test_required_attribute_on_init(self):
         """ParameterType raises TypeError if a required attribute is not specified on construction."""
+
         class MyParameter(ParameterType):
             required = ParameterAttribute()
             optional = ParameterAttribute(default=None)
-        with pytest.raises(SMIRNOFFSpecError, match="require the following missing parameters"):
-            MyParameter(smirks='[*:1]', optional=1)
+
+        with pytest.raises(
+            SMIRNOFFSpecError, match="require the following missing parameters"
+        ):
+            MyParameter(smirks="[*:1]", optional=1)
 
     def test_add_delete_cosmetic_attributes(self):
         """
         Test ParameterType.add_cosmetic_attribute, delete_cosmetic_attribute,
         attribute_is_cosmetic, and to_dict() functions for proper behavior
         """
+
         class MyParameter(ParameterType):
             required = ParameterAttribute()
-        my_par = MyParameter(smirks='[*:1]', required='aaa')
-        assert not(my_par.attribute_is_cosmetic('pilot'))
+
+        my_par = MyParameter(smirks="[*:1]", required="aaa")
+        assert not (my_par.attribute_is_cosmetic("pilot"))
 
         # Ensure the cosmetic attribute is present by default during output
-        my_par.add_cosmetic_attribute('pilot', 'alice')
+        my_par.add_cosmetic_attribute("pilot", "alice")
         param_dict = my_par.to_dict()
-        assert ('pilot', 'alice') in param_dict.items()
-        assert my_par.attribute_is_cosmetic('pilot')
+        assert ("pilot", "alice") in param_dict.items()
+        assert my_par.attribute_is_cosmetic("pilot")
 
         # Ensure the cosmetic attribute isn't present if we request that it be discarded
         param_dict = my_par.to_dict(discard_cosmetic_attributes=True)
-        assert 'pilot' not in param_dict
-
+        assert "pilot" not in param_dict
 
         # Manually delete the cosmetic attribute and ensure it doesn't get written out
-        my_par.delete_cosmetic_attribute('pilot')
+        my_par.delete_cosmetic_attribute("pilot")
         param_dict = my_par.to_dict()
-        assert 'pilot' not in param_dict
-        assert not(my_par.attribute_is_cosmetic('pilot'))
+        assert "pilot" not in param_dict
+        assert not (my_par.attribute_is_cosmetic("pilot"))
 
     def test_indexed_attrs(self):
         """ParameterType handles indexed attributes correctly."""
+
         class MyParameter(ParameterType):
             a = IndexedParameterAttribute()
             b = IndexedParameterAttribute()
-        my_par = MyParameter(smirks='[*:1]', a1=1, a3=3, a2=2, b1=4, b2=5, b3=6)
+
+        my_par = MyParameter(smirks="[*:1]", a1=1, a3=3, a2=2, b1=4, b2=5, b3=6)
         assert my_par.a == [1, 2, 3]
         assert my_par.b == [4, 5, 6]
 
     def test_sequence_init_indexed_attr(self):
         """ParameterType handle indexed attributes initialized with sequences correctly."""
+
         class MyParameter(ParameterType):
             a = IndexedParameterAttribute()
-        my_par = MyParameter(smirks='[*:1]', a=(1, 2))
+
+        my_par = MyParameter(smirks="[*:1]", a=(1, 2))
         assert my_par.a == [1, 2]
 
     def test_same_length_indexed_attrs(self):
         """ParameterType raises TypeError if indexed attributes of different lengths are given."""
+
         class MyParameter(ParameterType):
             a = IndexedParameterAttribute()
             b = IndexedParameterAttribute()
-        with pytest.raises(TypeError, match="indexed attributes have different lengths"):
-            MyParameter(smirks='[*:1]', a1=1, a2=2, a3=3, b1=1, b2=2)
+
+        with pytest.raises(
+            TypeError, match="indexed attributes have different lengths"
+        ):
+            MyParameter(smirks="[*:1]", a1=1, a2=2, a3=3, b1=1, b2=2)
 
     def test_error_single_value_plus_index(self):
         """ParameterType raises an error if an indexed attribute is specified with and without index."""
+
         class MyParameter(ParameterType):
             a = IndexedParameterAttribute()
-        with pytest.raises(TypeError, match="'a' has been specified with and without index"):
-            MyParameter(smirks='[*:1]', a=[1], a1=2)
+
+        with pytest.raises(
+            TypeError, match="'a' has been specified with and without index"
+        ):
+            MyParameter(smirks="[*:1]", a=[1], a1=2)
 
     def test_find_all_defined_parameter_attrs(self):
         """ParameterType._get_defined_attributes() discards None default-value attributes."""
+
         class MyParameter(ParameterType):
             required1 = ParameterAttribute()
             optional1 = ParameterAttribute(default=None)
@@ -823,11 +1021,19 @@ class TestParameterType:
             optional3 = ParameterAttribute(default=5)
             required2 = IndexedParameterAttribute()
             optional4 = ParameterAttribute(default=2)
-        my_par = MyParameter(smirks='[*:1]', required1=0, optional1=10, required2=[0])
+
+        my_par = MyParameter(smirks="[*:1]", required1=0, optional1=10, required2=[0])
 
         # _get_defined_parameter_attributes discards only the attribute
         # that are set to None as a default value.
-        expected_names = ['smirks', 'required1', 'required2', 'optional1', 'optional3', 'optional4']
+        expected_names = [
+            "smirks",
+            "required1",
+            "required2",
+            "optional1",
+            "optional3",
+            "optional4",
+        ]
         parameter_attributes = my_par._get_defined_parameter_attributes()
         assert list(parameter_attributes.keys()) == expected_names
 
@@ -835,9 +1041,9 @@ class TestParameterType:
         """
         Test ParameterType to_dict.
         """
-        p1 = ParameterType(smirks='[*:1]')
+        p1 = ParameterType(smirks="[*:1]")
         param_dict = p1.to_dict()
-        assert param_dict['smirks'] == '[*:1]'
+        assert param_dict["smirks"] == "[*:1]"
         assert len(param_dict.keys()) == 1
 
 
@@ -850,50 +1056,62 @@ class TestBondType:
         """
         from simtk import unit
 
-        p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
-                                  length=1.02 * unit.angstrom,
-                                  k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2
-                                  )
+        p1 = BondHandler.BondType(
+            smirks="[*:1]-[*:2]",
+            length=1.02 * unit.angstrom,
+            k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+        )
         param_dict = p1.to_dict()
         param_dict_unitless, attached_units = detach_units(param_dict)
-        assert param_dict_unitless == {'smirks': '[*:1]-[*:2]',
-                                       'length': 1.02,
-                                       'k': 5,}
-        assert attached_units == {'length_unit': unit.angstrom,
-                                  'k_unit': (unit.angstrom ** -2) * (unit.mole ** -1) * (unit.kilocalorie ** 1)
-                                  }
+        assert param_dict_unitless == {
+            "smirks": "[*:1]-[*:2]",
+            "length": 1.02,
+            "k": 5,
+        }
+        assert attached_units == {
+            "length_unit": unit.angstrom,
+            "k_unit": (unit.angstrom ** -2)
+            * (unit.mole ** -1)
+            * (unit.kilocalorie ** 1),
+        }
 
     def test_bondtype_to_dict_custom_output_units(self):
         """
         Test BondType to_dict with custom output units.
         """
         from simtk import unit
-        p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
-                                  length=1.02*unit.angstrom,
-                                  k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2
-                                  )
+
+        p1 = BondHandler.BondType(
+            smirks="[*:1]-[*:2]",
+            length=1.02 * unit.angstrom,
+            k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+        )
         param_dict = p1.to_dict()
-        param_dict_unitless, attached_units=detach_units(param_dict, output_units={'length_unit':
-                                                                                       unit.nanometer})
-        assert attached_units['length_unit'] == unit.nanometer
-        assert abs(param_dict_unitless['length'] - 0.102) < 1e-10
+        param_dict_unitless, attached_units = detach_units(
+            param_dict, output_units={"length_unit": unit.nanometer}
+        )
+        assert attached_units["length_unit"] == unit.nanometer
+        assert abs(param_dict_unitless["length"] - 0.102) < 1e-10
 
     def test_bondtype_to_dict_invalid_output_units(self):
         """
         Test ParameterType to_dict with invalid output units.
         """
         from simtk import unit
-        p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
-                                  length=1.02*unit.angstrom,
-                                  k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2
-                                  )
-        param_dict = p1.to_dict()
-        with pytest.raises(ValueError,
-                           match='Requested output unit calorie is not compatible with quantity unit angstrom .'
-                           ) as context:
-            param_dict_unitless, attached_units = detach_units(param_dict, output_units = {'length_unit':
-                                                                                               unit.calorie})
 
+        p1 = BondHandler.BondType(
+            smirks="[*:1]-[*:2]",
+            length=1.02 * unit.angstrom,
+            k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+        )
+        param_dict = p1.to_dict()
+        with pytest.raises(
+            ValueError,
+            match="Requested output unit calorie is not compatible with quantity unit angstrom .",
+        ) as context:
+            param_dict_unitless, attached_units = detach_units(
+                param_dict, output_units={"length_unit": unit.calorie}
+            )
 
     def test_read_write_optional_parameter_attribute(self):
         """
@@ -901,13 +1119,14 @@ class TestBondType:
         """
         from simtk import unit
 
-        p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
-                                  length=1.02*unit.angstrom,
-                                  k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
-                                  id='b1'
-                                  )
-        param_dict= p1.to_dict()
-        assert ('id', 'b1') in param_dict.items()
+        p1 = BondHandler.BondType(
+            smirks="[*:1]-[*:2]",
+            length=1.02 * unit.angstrom,
+            k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+            id="b1",
+        )
+        param_dict = p1.to_dict()
+        assert ("id", "b1") in param_dict.items()
 
     def test_read_write_cosmetic_parameter_attribute(self):
         """
@@ -915,14 +1134,15 @@ class TestBondType:
         """
         from simtk import unit
 
-        p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
-                                  length=1.02*unit.angstrom,
-                                  k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
-                                  pilot='alice',
-                                  allow_cosmetic_attributes=True
-                                  )
-        param_dict= p1.to_dict(discard_cosmetic_attributes=False)
-        assert ('pilot', 'alice') in param_dict.items()
+        p1 = BondHandler.BondType(
+            smirks="[*:1]-[*:2]",
+            length=1.02 * unit.angstrom,
+            k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+            pilot="alice",
+            allow_cosmetic_attributes=True,
+        )
+        param_dict = p1.to_dict(discard_cosmetic_attributes=False)
+        assert ("pilot", "alice") in param_dict.items()
 
     def test_read_but_dont_write_cosmetic_parameter_attribute(self):
         """
@@ -930,14 +1150,15 @@ class TestBondType:
         """
         from simtk import unit
 
-        p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
-                                  length=1.02*unit.angstrom,
-                                  k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
-                                  pilot='alice',
-                                  allow_cosmetic_attributes=True
-                                  )
+        p1 = BondHandler.BondType(
+            smirks="[*:1]-[*:2]",
+            length=1.02 * unit.angstrom,
+            k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+            pilot="alice",
+            allow_cosmetic_attributes=True,
+        )
         param_dict = p1.to_dict(discard_cosmetic_attributes=True)
-        assert ('pilot', 'alice') not in param_dict.items()
+        assert ("pilot", "alice") not in param_dict.items()
 
     def test_error_cosmetic_parameter_attribute(self):
         """
@@ -945,14 +1166,16 @@ class TestBondType:
         """
         from simtk import unit
 
-        with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg (pilot: alice)*") as context:
-            p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
-                                      length=1.02*unit.angstrom,
-                                      k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
-                                      pilot='alice',
-                                      allow_cosmetic_attributes=False
-                                      )
-
+        with pytest.raises(
+            SMIRNOFFSpecError, match="Unexpected kwarg (pilot: alice)*"
+        ) as context:
+            p1 = BondHandler.BondType(
+                smirks="[*:1]-[*:2]",
+                length=1.02 * unit.angstrom,
+                k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+                pilot="alice",
+                allow_cosmetic_attributes=False,
+            )
 
     def test_add_delete_cosmetic_attrib(self):
         """
@@ -960,23 +1183,24 @@ class TestBondType:
         """
         from simtk import unit
 
-        p1 = BondHandler.BondType(smirks='[*:1]-[*:2]',
-                                  length=1.02*unit.angstrom,
-                                  k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
-                                  )
+        p1 = BondHandler.BondType(
+            smirks="[*:1]-[*:2]",
+            length=1.02 * unit.angstrom,
+            k=5 * unit.kilocalorie_per_mole / unit.angstrom ** 2,
+        )
         # Ensure the cosmetic attribute is present by default during output
-        p1.add_cosmetic_attribute('pilot', 'alice')
+        p1.add_cosmetic_attribute("pilot", "alice")
         param_dict = p1.to_dict()
-        assert ('pilot', 'alice') in param_dict.items()
+        assert ("pilot", "alice") in param_dict.items()
 
         # Ensure the cosmetic attribute isn't present if we request that it be discarded
         param_dict = p1.to_dict(discard_cosmetic_attributes=True)
-        assert ('pilot', 'alice') not in param_dict.items()
+        assert ("pilot", "alice") not in param_dict.items()
 
         # Manually delete the cosmetic attribute and ensure it doesn't get written out
-        p1.delete_cosmetic_attribute('pilot')
+        p1.delete_cosmetic_attribute("pilot")
         param_dict = p1.to_dict()
-        assert ('pilot', 'alice') not in param_dict.items()
+        assert ("pilot", "alice") not in param_dict.items()
 
 
 class TestProperTorsionType:
@@ -988,16 +1212,17 @@ class TestProperTorsionType:
         """
         from simtk import unit
 
-        p1 = ProperTorsionHandler.ProperTorsionType(smirks='[*:1]-[*:2]-[*:3]-[*:4]',
-                                                    phase1=30 * unit.degree,
-                                                    periodicity1=2,
-                                                    k1=5 * unit.kilocalorie_per_mole
-                                                    )
+        p1 = ProperTorsionHandler.ProperTorsionType(
+            smirks="[*:1]-[*:2]-[*:3]-[*:4]",
+            phase1=30 * unit.degree,
+            periodicity1=2,
+            k1=5 * unit.kilocalorie_per_mole,
+        )
         param_dict = p1.to_dict()
-        assert ('k1', 5 * unit.kilocalorie_per_mole) in param_dict.items()
-        assert ('phase1', 30 * unit.degree) in param_dict.items()
-        assert ('periodicity1', 2) in param_dict.items()
-        assert 'idivf' not in param_dict
+        assert ("k1", 5 * unit.kilocalorie_per_mole) in param_dict.items()
+        assert ("phase1", 30 * unit.degree) in param_dict.items()
+        assert ("periodicity1", 2) in param_dict.items()
+        assert "idivf" not in param_dict
 
     def test_single_term_proper_torsion_w_idivf(self):
         """
@@ -1005,18 +1230,19 @@ class TestProperTorsionType:
         """
         from simtk import unit
 
-        p1 = ProperTorsionHandler.ProperTorsionType(smirks='[*:1]-[*:2]-[*:3]-[*:4]',
-                                                    phase1=30 * unit.degree,
-                                                    periodicity1=2,
-                                                    k1=5 * unit.kilocalorie_per_mole,
-                                                    idivf1=4
-                                                    )
+        p1 = ProperTorsionHandler.ProperTorsionType(
+            smirks="[*:1]-[*:2]-[*:3]-[*:4]",
+            phase1=30 * unit.degree,
+            periodicity1=2,
+            k1=5 * unit.kilocalorie_per_mole,
+            idivf1=4,
+        )
 
         param_dict = p1.to_dict()
-        assert ('k1', 5 * unit.kilocalorie_per_mole) in param_dict.items()
-        assert ('phase1', 30 * unit.degree) in param_dict.items()
-        assert ('periodicity1', 2) in param_dict.items()
-        assert ('idivf1', 4) in param_dict.items()
+        assert ("k1", 5 * unit.kilocalorie_per_mole) in param_dict.items()
+        assert ("phase1", 30 * unit.degree) in param_dict.items()
+        assert ("periodicity1", 2) in param_dict.items()
+        assert ("idivf1", 4) in param_dict.items()
 
     def test_multi_term_proper_torsion(self):
         """
@@ -1024,21 +1250,22 @@ class TestProperTorsionType:
         """
         from simtk import unit
 
-        p1 = ProperTorsionHandler.ProperTorsionType(smirks='[*:1]-[*:2]-[*:3]-[*:4]',
-                                                    phase1=30 * unit.degree,
-                                                    periodicity1=2,
-                                                    k1=5 * unit.kilocalorie_per_mole,
-                                                    phase2=31 * unit.degree,
-                                                    periodicity2=3,
-                                                    k2=6 * unit.kilocalorie_per_mole,
-                                                    )
+        p1 = ProperTorsionHandler.ProperTorsionType(
+            smirks="[*:1]-[*:2]-[*:3]-[*:4]",
+            phase1=30 * unit.degree,
+            periodicity1=2,
+            k1=5 * unit.kilocalorie_per_mole,
+            phase2=31 * unit.degree,
+            periodicity2=3,
+            k2=6 * unit.kilocalorie_per_mole,
+        )
         param_dict = p1.to_dict()
-        assert param_dict['k1'] == 5 * unit.kilocalorie_per_mole
-        assert param_dict['phase1'] == 30 * unit.degree
-        assert param_dict['periodicity1'] == 2
-        assert param_dict['k2'] == 6 * unit.kilocalorie_per_mole
-        assert param_dict['phase2'] == 31 * unit.degree
-        assert param_dict['periodicity2'] == 3
+        assert param_dict["k1"] == 5 * unit.kilocalorie_per_mole
+        assert param_dict["phase1"] == 30 * unit.degree
+        assert param_dict["periodicity1"] == 2
+        assert param_dict["k2"] == 6 * unit.kilocalorie_per_mole
+        assert param_dict["phase2"] == 31 * unit.degree
+        assert param_dict["periodicity2"] == 3
 
     def test_multi_term_proper_torsion_skip_index(self):
         """
@@ -1047,15 +1274,18 @@ class TestProperTorsionType:
         """
         from simtk import unit
 
-        with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg \(phase3: 31 deg\)*.") as context:
-            p1 = ProperTorsionHandler.ProperTorsionType(smirks='[*:1]-[*:2]-[*:3]-[*:4]',
-                                                        phase1=30 * unit.degree,
-                                                        periodicity1=2,
-                                                        k1=5 * unit.kilocalorie_per_mole,
-                                                        phase3=31 * unit.degree,
-                                                        periodicity3=3,
-                                                        k3=6 * unit.kilocalorie_per_mole,
-                                                        )
+        with pytest.raises(
+            SMIRNOFFSpecError, match="Unexpected kwarg \(phase3: 31 deg\)*."
+        ) as context:
+            p1 = ProperTorsionHandler.ProperTorsionType(
+                smirks="[*:1]-[*:2]-[*:3]-[*:4]",
+                phase1=30 * unit.degree,
+                periodicity1=2,
+                k1=5 * unit.kilocalorie_per_mole,
+                phase3=31 * unit.degree,
+                periodicity3=3,
+                k3=6 * unit.kilocalorie_per_mole,
+            )
 
     def test_multi_term_proper_torsion_bad_units(self):
         """
@@ -1064,16 +1294,18 @@ class TestProperTorsionType:
         """
         from simtk import unit
 
-        with pytest.raises(IncompatibleUnitError, match="should have units of")\
-                as context:
-            p1 = ProperTorsionHandler.ProperTorsionType(smirks='[*:1]-[*:2]-[*:3]-[*:4]',
-                                                        phase1=30 * unit.degree,
-                                                        periodicity1=2,
-                                                        k1=5 * unit.kilocalorie_per_mole,
-                                                        phase2=31 * unit.angstrom, # This should be caught
-                                                        periodicity2=3,
-                                                        k2=6 * unit.kilocalorie_per_mole,
-                                                        )
+        with pytest.raises(
+            IncompatibleUnitError, match="should have units of"
+        ) as context:
+            p1 = ProperTorsionHandler.ProperTorsionType(
+                smirks="[*:1]-[*:2]-[*:3]-[*:4]",
+                phase1=30 * unit.degree,
+                periodicity1=2,
+                k1=5 * unit.kilocalorie_per_mole,
+                phase2=31 * unit.angstrom,  # This should be caught
+                periodicity2=3,
+                k2=6 * unit.kilocalorie_per_mole,
+            )
 
     def test_single_term_proper_torsion_bo(self):
         """
@@ -1081,18 +1313,19 @@ class TestProperTorsionType:
         """
         from simtk import unit
 
-        p1 = ProperTorsionHandler.ProperTorsionType(smirks='[*:1]-[*:2]~[*:3]-[*:4]',
-                                                    phase1=30 * unit.degree,
-                                                    periodicity1=2,
-                                                    k1_bondorder1=1 * unit.kilocalorie_per_mole,
-                                                    k1_bondorder2=1.8 * unit.kilocalorie_per_mole,
-                                                    )
+        p1 = ProperTorsionHandler.ProperTorsionType(
+            smirks="[*:1]-[*:2]~[*:3]-[*:4]",
+            phase1=30 * unit.degree,
+            periodicity1=2,
+            k1_bondorder1=1 * unit.kilocalorie_per_mole,
+            k1_bondorder2=1.8 * unit.kilocalorie_per_mole,
+        )
         param_dict = p1.to_dict()
-        assert ('k1_bondorder1', 1 * unit.kilocalorie_per_mole) in param_dict.items()
-        assert ('k1_bondorder2', 1.8 * unit.kilocalorie_per_mole) in param_dict.items()
-        assert ('phase1', 30 * unit.degree) in param_dict.items()
-        assert ('periodicity1', 2) in param_dict.items()
-        assert 'idivf' not in param_dict
+        assert ("k1_bondorder1", 1 * unit.kilocalorie_per_mole) in param_dict.items()
+        assert ("k1_bondorder2", 1.8 * unit.kilocalorie_per_mole) in param_dict.items()
+        assert ("phase1", 30 * unit.degree) in param_dict.items()
+        assert ("periodicity1", 2) in param_dict.items()
+        assert "idivf" not in param_dict
 
         assert len(p1.k_bondorder) == 1
         assert len(p1.k_bondorder[0]) == 2
@@ -1107,20 +1340,21 @@ class TestProperTorsionType:
         """
         from simtk import unit
 
-        p1 = ProperTorsionHandler.ProperTorsionType(smirks='[*:1]-[*:2]-[*:3]-[*:4]',
-                                                    phase1=30 * unit.degree,
-                                                    periodicity1=2,
-                                                    k1_bondorder1=1 * unit.kilocalorie_per_mole,
-                                                    k1_bondorder2=1.8 * unit.kilocalorie_per_mole,
-                                                    idivf1=4
-                                                    )
+        p1 = ProperTorsionHandler.ProperTorsionType(
+            smirks="[*:1]-[*:2]-[*:3]-[*:4]",
+            phase1=30 * unit.degree,
+            periodicity1=2,
+            k1_bondorder1=1 * unit.kilocalorie_per_mole,
+            k1_bondorder2=1.8 * unit.kilocalorie_per_mole,
+            idivf1=4,
+        )
 
         param_dict = p1.to_dict()
-        assert ('k1_bondorder1', 1 * unit.kilocalorie_per_mole) in param_dict.items()
-        assert ('k1_bondorder2', 1.8 * unit.kilocalorie_per_mole) in param_dict.items()
-        assert ('phase1', 30 * unit.degree) in param_dict.items()
-        assert ('periodicity1', 2) in param_dict.items()
-        assert ('idivf1', 4) in param_dict.items()
+        assert ("k1_bondorder1", 1 * unit.kilocalorie_per_mole) in param_dict.items()
+        assert ("k1_bondorder2", 1.8 * unit.kilocalorie_per_mole) in param_dict.items()
+        assert ("phase1", 30 * unit.degree) in param_dict.items()
+        assert ("periodicity1", 2) in param_dict.items()
+        assert ("idivf1", 4) in param_dict.items()
 
     def test_multi_term_proper_torsion_bo(self):
         """
@@ -1128,26 +1362,26 @@ class TestProperTorsionType:
         """
         from simtk import unit
 
-        p1 = ProperTorsionHandler.ProperTorsionType(smirks='[*:1]-[*:2]-[*:3]-[*:4]',
-                                                    phase1=30 * unit.degree,
-                                                    periodicity1=2,
-                                                    k1_bondorder1=1 * unit.kilocalorie_per_mole,
-                                                    k1_bondorder2=1.8 * unit.kilocalorie_per_mole,
-                                                    phase2=31 * unit.degree,
-                                                    periodicity2=3,
-                                                    k2_bondorder1=1.2 * unit.kilocalorie_per_mole,
-                                                    k2_bondorder2=1.9 * unit.kilocalorie_per_mole,
-                                                    )
+        p1 = ProperTorsionHandler.ProperTorsionType(
+            smirks="[*:1]-[*:2]-[*:3]-[*:4]",
+            phase1=30 * unit.degree,
+            periodicity1=2,
+            k1_bondorder1=1 * unit.kilocalorie_per_mole,
+            k1_bondorder2=1.8 * unit.kilocalorie_per_mole,
+            phase2=31 * unit.degree,
+            periodicity2=3,
+            k2_bondorder1=1.2 * unit.kilocalorie_per_mole,
+            k2_bondorder2=1.9 * unit.kilocalorie_per_mole,
+        )
         param_dict = p1.to_dict()
-        assert param_dict['k1_bondorder1'] == 1 * unit.kilocalorie_per_mole
-        assert param_dict['k1_bondorder2'] == 1.8 * unit.kilocalorie_per_mole
-        assert param_dict['phase1'] == 30 * unit.degree
-        assert param_dict['periodicity1'] == 2
-        assert param_dict['k2_bondorder1'] == 1.2 * unit.kilocalorie_per_mole
-        assert param_dict['k2_bondorder2'] == 1.9 * unit.kilocalorie_per_mole
-        assert param_dict['phase2'] == 31 * unit.degree
-        assert param_dict['periodicity2'] == 3
-
+        assert param_dict["k1_bondorder1"] == 1 * unit.kilocalorie_per_mole
+        assert param_dict["k1_bondorder2"] == 1.8 * unit.kilocalorie_per_mole
+        assert param_dict["phase1"] == 30 * unit.degree
+        assert param_dict["periodicity1"] == 2
+        assert param_dict["k2_bondorder1"] == 1.2 * unit.kilocalorie_per_mole
+        assert param_dict["k2_bondorder2"] == 1.9 * unit.kilocalorie_per_mole
+        assert param_dict["phase2"] == 31 * unit.degree
+        assert param_dict["periodicity2"] == 3
 
     def test_multi_term_proper_torsion_bo_getters_setters(self):
         """
@@ -1155,25 +1389,25 @@ class TestProperTorsionType:
         """
         from simtk import unit
 
-        p1 = ProperTorsionHandler.ProperTorsionType(smirks='[*:1]-[*:2]-[*:3]-[*:4]',
-                                                    phase1=30 * unit.degree,
-                                                    periodicity1=2,
-                                                    k1_bondorder1=1 * unit.kilocalorie_per_mole,
-                                                    k1_bondorder2=1.8 * unit.kilocalorie_per_mole,
-                                                    phase2=31 * unit.degree,
-                                                    periodicity2=3,
-                                                    k2_bondorder1=1.2 * unit.kilocalorie_per_mole,
-                                                    k2_bondorder2=1.9 * unit.kilocalorie_per_mole,
-                                                    )
+        p1 = ProperTorsionHandler.ProperTorsionType(
+            smirks="[*:1]-[*:2]-[*:3]-[*:4]",
+            phase1=30 * unit.degree,
+            periodicity1=2,
+            k1_bondorder1=1 * unit.kilocalorie_per_mole,
+            k1_bondorder2=1.8 * unit.kilocalorie_per_mole,
+            phase2=31 * unit.degree,
+            periodicity2=3,
+            k2_bondorder1=1.2 * unit.kilocalorie_per_mole,
+            k2_bondorder2=1.9 * unit.kilocalorie_per_mole,
+        )
 
-        assert p1.k1_bondorder1 == 1. * unit.kilocalorie_per_mole
-        p1.k1_bondorder1 = 2. * unit.kilocalorie_per_mole
-        assert p1.k1_bondorder1 == 2. * unit.kilocalorie_per_mole
+        assert p1.k1_bondorder1 == 1.0 * unit.kilocalorie_per_mole
+        p1.k1_bondorder1 = 2.0 * unit.kilocalorie_per_mole
+        assert p1.k1_bondorder1 == 2.0 * unit.kilocalorie_per_mole
 
         assert p1.k2_bondorder2 == 1.9 * unit.kilocalorie_per_mole
         p1.k2_bondorder2 = 2.9 * unit.kilocalorie_per_mole
         assert p1.k2_bondorder2 == 2.9 * unit.kilocalorie_per_mole
-
 
     def test_multi_term_proper_torsion_bo_skip_index(self):
         """
@@ -1183,17 +1417,20 @@ class TestProperTorsionType:
         """
         from simtk import unit
 
-        with pytest.raises(SMIRNOFFSpecError, match="Unexpected kwarg \(k3_bondorder1*.") as context:
-            p1 = ProperTorsionHandler.ProperTorsionType(smirks='[*:1]-[*:2]-[*:3]-[*:4]',
-                                                        phase1=30 * unit.degree,
-                                                        periodicity1=2,
-                                                        k1_bondorder1=1 * unit.kilocalorie_per_mole,
-                                                        k1_bondorder2=1.8 * unit.kilocalorie_per_mole,
-                                                        phase3=31 * unit.degree,
-                                                        periodicity3=3,
-                                                        k3_bondorder1=1.2 * unit.kilocalorie_per_mole,
-                                                        k3_bondorder2=1.9 * unit.kilocalorie_per_mole,
-                                                        )
+        with pytest.raises(
+            SMIRNOFFSpecError, match="Unexpected kwarg \(k3_bondorder1*."
+        ) as context:
+            p1 = ProperTorsionHandler.ProperTorsionType(
+                smirks="[*:1]-[*:2]-[*:3]-[*:4]",
+                phase1=30 * unit.degree,
+                periodicity1=2,
+                k1_bondorder1=1 * unit.kilocalorie_per_mole,
+                k1_bondorder2=1.8 * unit.kilocalorie_per_mole,
+                phase3=31 * unit.degree,
+                periodicity3=3,
+                k3_bondorder1=1.2 * unit.kilocalorie_per_mole,
+                k3_bondorder2=1.9 * unit.kilocalorie_per_mole,
+            )
 
     def test_single_term_single_bo_exception(self):
         """Test behavior where a single bond order term is specified for a single k"""
@@ -1201,12 +1438,12 @@ class TestProperTorsionType:
 
         # raises no error, as checks are handled at parameterization
         # we may add a `validate` method later that is called manually by user when they want it
-        p1 = ProperTorsionHandler.ProperTorsionType(smirks='[*:1]-[*:2]~[*:3]-[*:4]',
-                                                    phase1=30 * unit.degree,
-                                                    periodicity1=2,
-                                                    k1_bondorder1=1 * unit.kilocalorie_per_mole,
-                                                    )
-
+        p1 = ProperTorsionHandler.ProperTorsionType(
+            smirks="[*:1]-[*:2]~[*:3]-[*:4]",
+            phase1=30 * unit.degree,
+            periodicity1=2,
+            k1_bondorder1=1 * unit.kilocalorie_per_mole,
+        )
 
     def test_multi_term_single_bo_exception(self):
         """Test behavior where a single bond order term is specified for each of multiple k"""
@@ -1215,15 +1452,15 @@ class TestProperTorsionType:
         # TODO : currently raises no error, as checks are handled at parameterization
         # is this a spec thing that we should be checking?
         # if so, it will be painful to implement
-        p1 = ProperTorsionHandler.ProperTorsionType(smirks='[*:1]-[*:2]-[*:3]-[*:4]',
-                                                    phase1=30 * unit.degree,
-                                                    periodicity1=2,
-                                                    k1_bondorder1=1 * unit.kilocalorie_per_mole,
-                                                    phase2=31 * unit.degree,
-                                                    periodicity2=3,
-                                                    k2_bondorder1=1.2 * unit.kilocalorie_per_mole,
-                                                    )
-
+        p1 = ProperTorsionHandler.ProperTorsionType(
+            smirks="[*:1]-[*:2]-[*:3]-[*:4]",
+            phase1=30 * unit.degree,
+            periodicity1=2,
+            k1_bondorder1=1 * unit.kilocalorie_per_mole,
+            phase2=31 * unit.degree,
+            periodicity2=3,
+            k2_bondorder1=1.2 * unit.kilocalorie_per_mole,
+        )
 
 
 class TestProperTorsionHandler:
@@ -1235,57 +1472,79 @@ class TestProperTorsionHandler:
         import re
 
         # Test creating ProperTorsionHandlers
-        err_msg = re.escape("Attempted to set ProperTorsionHandler.potential to charmm. Currently, "
-                            "only the following values are supported: ['k*(1+cos(periodicity*theta-phase))'].")
+        err_msg = re.escape(
+            "Attempted to set ProperTorsionHandler.potential to charmm. Currently, "
+            "only the following values are supported: ['k*(1+cos(periodicity*theta-phase))']."
+        )
         with pytest.raises(SMIRNOFFSpecError, match=err_msg):
-            ph1 = ProperTorsionHandler(potential='charmm', skip_version_check=True)
-        ph1 = ProperTorsionHandler(potential='k*(1+cos(periodicity*theta-phase))', skip_version_check=True)
+            ph1 = ProperTorsionHandler(potential="charmm", skip_version_check=True)
+        ph1 = ProperTorsionHandler(
+            potential="k*(1+cos(periodicity*theta-phase))", skip_version_check=True
+        )
 
         # Same test, but with ImproperTorsionHandler
-        err_msg = re.escape("Attempted to set ImproperTorsionHandler.potential to charmm. Currently, "
-                            "only the following values are supported: ['k*(1+cos(periodicity*theta-phase))'].")
+        err_msg = re.escape(
+            "Attempted to set ImproperTorsionHandler.potential to charmm. Currently, "
+            "only the following values are supported: ['k*(1+cos(periodicity*theta-phase))']."
+        )
         with pytest.raises(SMIRNOFFSpecError, match=err_msg):
-            ph1 = ImproperTorsionHandler(potential='charmm', skip_version_check=True)
-        ph1 = ImproperTorsionHandler(potential='k*(1+cos(periodicity*theta-phase))', skip_version_check=True)
+            ph1 = ImproperTorsionHandler(potential="charmm", skip_version_check=True)
+        ph1 = ImproperTorsionHandler(
+            potential="k*(1+cos(periodicity*theta-phase))", skip_version_check=True
+        )
 
     @pytest.mark.parametrize(
-            ('fractional_bond_order', 'k_interpolated'),
-            [(1.6, 1.48), (.7, .76), (2.3, 2.04)])
+        ("fractional_bond_order", "k_interpolated"),
+        [(1.6, 1.48), (0.7, 0.76), (2.3, 2.04)],
+    )
     def test_linear_interpolate_k(self, fractional_bond_order, k_interpolated):
         """Test that linear interpolation works as expected"""
         from simtk import unit
 
-        k_bondorder = {1: 1 * unit.kilocalorie_per_mole,
-                       2: 1.8 * unit.kilocalorie_per_mole}
+        k_bondorder = {
+            1: 1 * unit.kilocalorie_per_mole,
+            2: 1.8 * unit.kilocalorie_per_mole,
+        }
 
-        k = ProperTorsionHandler._linear_interpolate_k(k_bondorder, fractional_bond_order)
-        assert_almost_equal(k/k.unit, k_interpolated)
+        k = ProperTorsionHandler._linear_interpolate_k(
+            k_bondorder, fractional_bond_order
+        )
+        assert_almost_equal(k / k.unit, k_interpolated)
 
     @pytest.mark.parametrize(
-            ('fractional_bond_order', 'k_interpolated'),
-            [(1.6, 1.48), (.7, .76), (2.3, 2.01), (3.1, 2.57)])
+        ("fractional_bond_order", "k_interpolated"),
+        [(1.6, 1.48), (0.7, 0.76), (2.3, 2.01), (3.1, 2.57)],
+    )
     def test_linear_interpolate_k_3_terms(self, fractional_bond_order, k_interpolated):
         """Test that linear interpolation works as expected for three terms"""
         from simtk import unit
 
-        k_bondorder = {1: 1 * unit.kilocalorie_per_mole,
-                       2: 1.8 * unit.kilocalorie_per_mole,
-                       3: 2.5 * unit.kilocalorie_per_mole}
+        k_bondorder = {
+            1: 1 * unit.kilocalorie_per_mole,
+            2: 1.8 * unit.kilocalorie_per_mole,
+            3: 2.5 * unit.kilocalorie_per_mole,
+        }
 
-        k = ProperTorsionHandler._linear_interpolate_k(k_bondorder, fractional_bond_order)
-        assert_almost_equal(k/k.unit, k_interpolated)
+        k = ProperTorsionHandler._linear_interpolate_k(
+            k_bondorder, fractional_bond_order
+        )
+        assert_almost_equal(k / k.unit, k_interpolated)
 
     def test_linear_interpolate_k_below_zero(self):
         """Test that linear interpolation does not error if resulting k less than 0"""
         from simtk import unit
 
-        k_bondorder = {1: 1 * unit.kilocalorie_per_mole,
-                       2: 2.3 * unit.kilocalorie_per_mole}
+        k_bondorder = {
+            1: 1 * unit.kilocalorie_per_mole,
+            2: 2.3 * unit.kilocalorie_per_mole,
+        }
 
-        fractional_bond_order = .2
-        k = ProperTorsionHandler._linear_interpolate_k(k_bondorder, fractional_bond_order)
+        fractional_bond_order = 0.2
+        k = ProperTorsionHandler._linear_interpolate_k(
+            k_bondorder, fractional_bond_order
+        )
 
-        assert k/k.unit < 0
+        assert k / k.unit < 0
 
 
 class TestLibraryChargeHandler:
@@ -1296,54 +1555,93 @@ class TestLibraryChargeHandler:
     def test_library_charge_type_wrong_num_charges(self):
         """Ensure that an error is raised if a LibraryChargeType is initialized with a different number of
         tagged atoms and charges"""
-        lc_type = LibraryChargeHandler.LibraryChargeType(smirks='[#6:1]-[#7:2]',
-                                                         charge1=0.1 * unit.elementary_charge,
-                                                         charge2=-0.1 * unit.elementary_charge)
+        lc_type = LibraryChargeHandler.LibraryChargeType(
+            smirks="[#6:1]-[#7:2]",
+            charge1=0.1 * unit.elementary_charge,
+            charge2=-0.1 * unit.elementary_charge,
+        )
 
-        lc_type = LibraryChargeHandler.LibraryChargeType(smirks='[#6:1]-[#7:2]-[#6]',
-                                                         charge1=0.1 * unit.elementary_charge,
-                                                         charge2=-0.1 * unit.elementary_charge)
+        lc_type = LibraryChargeHandler.LibraryChargeType(
+            smirks="[#6:1]-[#7:2]-[#6]",
+            charge1=0.1 * unit.elementary_charge,
+            charge2=-0.1 * unit.elementary_charge,
+        )
 
-        with pytest.raises(SMIRNOFFSpecError, match="initialized with unequal number of tagged atoms and charges") as excinfo:
-            lc_type = LibraryChargeHandler.LibraryChargeType(smirks='[#6:1]-[#7:2]',
-                                                             charge1=0.05 * unit.elementary_charge,
-                                                             charge2=0.05 * unit.elementary_charge,
-                                                             charge3=-0.1 * unit.elementary_charge)
+        with pytest.raises(
+            SMIRNOFFSpecError,
+            match="initialized with unequal number of tagged atoms and charges",
+        ) as excinfo:
+            lc_type = LibraryChargeHandler.LibraryChargeType(
+                smirks="[#6:1]-[#7:2]",
+                charge1=0.05 * unit.elementary_charge,
+                charge2=0.05 * unit.elementary_charge,
+                charge3=-0.1 * unit.elementary_charge,
+            )
 
-        with pytest.raises(SMIRNOFFSpecError, match="initialized with unequal number of tagged atoms and charges") as excinfo:
-            lc_type = LibraryChargeHandler.LibraryChargeType(smirks='[#6:1]-[#7:2]-[#6]',
-                                                             charge1=0.05 * unit.elementary_charge,
-                                                             charge2=0.05 * unit.elementary_charge,
-                                                             charge3=-0.1 * unit.elementary_charge)
+        with pytest.raises(
+            SMIRNOFFSpecError,
+            match="initialized with unequal number of tagged atoms and charges",
+        ) as excinfo:
+            lc_type = LibraryChargeHandler.LibraryChargeType(
+                smirks="[#6:1]-[#7:2]-[#6]",
+                charge1=0.05 * unit.elementary_charge,
+                charge2=0.05 * unit.elementary_charge,
+                charge3=-0.1 * unit.elementary_charge,
+            )
 
-        with pytest.raises(SMIRNOFFSpecError, match="initialized with unequal number of tagged atoms and charges") as excinfo:
-            lc_type = LibraryChargeHandler.LibraryChargeType(smirks='[#6:1]-[#7:2]-[#6]',
-                                                             charge1=0.05 * unit.elementary_charge)
+        with pytest.raises(
+            SMIRNOFFSpecError,
+            match="initialized with unequal number of tagged atoms and charges",
+        ) as excinfo:
+            lc_type = LibraryChargeHandler.LibraryChargeType(
+                smirks="[#6:1]-[#7:2]-[#6]", charge1=0.05 * unit.elementary_charge
+            )
+
 
 class TestChargeIncrementModelHandler:
     def test_create_charge_increment_model_handler(self):
         """Test creation of ChargeIncrementModelHandlers"""
         handler = ChargeIncrementModelHandler(skip_version_check=True)
         assert handler.number_of_conformers == 1
-        assert handler.partial_charge_method == 'AM1-Mulliken'
-        handler = ChargeIncrementModelHandler(skip_version_check=True, number_of_conformers=10)
-        handler = ChargeIncrementModelHandler(skip_version_check=True, number_of_conformers=1)
-        handler = ChargeIncrementModelHandler(skip_version_check=True, number_of_conformers="10")
-        handler = ChargeIncrementModelHandler(skip_version_check=True, number_of_conformers=0)
-        handler = ChargeIncrementModelHandler(skip_version_check=True, number_of_conformers="0")
+        assert handler.partial_charge_method == "AM1-Mulliken"
+        handler = ChargeIncrementModelHandler(
+            skip_version_check=True, number_of_conformers=10
+        )
+        handler = ChargeIncrementModelHandler(
+            skip_version_check=True, number_of_conformers=1
+        )
+        handler = ChargeIncrementModelHandler(
+            skip_version_check=True, number_of_conformers="10"
+        )
+        handler = ChargeIncrementModelHandler(
+            skip_version_check=True, number_of_conformers=0
+        )
+        handler = ChargeIncrementModelHandler(
+            skip_version_check=True, number_of_conformers="0"
+        )
         with pytest.raises(TypeError) as excinfo:
-            handler = ChargeIncrementModelHandler(skip_version_check=True, number_of_conformers=None)
+            handler = ChargeIncrementModelHandler(
+                skip_version_check=True, number_of_conformers=None
+            )
         with pytest.raises(SMIRNOFFSpecError) as excinfo:
-            handler = ChargeIncrementModelHandler(skip_version_check=True, n_conformers=[10])
-        handler = ChargeIncrementModelHandler(skip_version_check=True, partial_charge_method="AM1-Mulliken")
-        handler = ChargeIncrementModelHandler(skip_version_check=True, partial_charge_method="Gasteiger")
-        handler = ChargeIncrementModelHandler(skip_version_check=True, partial_charge_method=None)
+            handler = ChargeIncrementModelHandler(
+                skip_version_check=True, n_conformers=[10]
+            )
+        handler = ChargeIncrementModelHandler(
+            skip_version_check=True, partial_charge_method="AM1-Mulliken"
+        )
+        handler = ChargeIncrementModelHandler(
+            skip_version_check=True, partial_charge_method="Gasteiger"
+        )
+        handler = ChargeIncrementModelHandler(
+            skip_version_check=True, partial_charge_method=None
+        )
 
     def test_charge_increment_model_handler_getters_setters(self):
         """Test ChargeIncrementModelHandler getters and setters"""
         handler = ChargeIncrementModelHandler(skip_version_check=True)
         assert handler.number_of_conformers == 1
-        assert handler.partial_charge_method == 'AM1-Mulliken'
+        assert handler.partial_charge_method == "AM1-Mulliken"
         handler.number_of_conformers = 2
         assert handler.number_of_conformers == 2
         handler.number_of_conformers = "3"
@@ -1357,84 +1655,113 @@ class TestChargeIncrementModelHandler:
         handler2 = ChargeIncrementModelHandler(skip_version_check=True)
         handler1.check_handler_compatibility(handler2)
 
-        handler3 = ChargeIncrementModelHandler(skip_version_check=True, number_of_conformers='9')
+        handler3 = ChargeIncrementModelHandler(
+            skip_version_check=True, number_of_conformers="9"
+        )
         with pytest.raises(IncompatibleParameterError) as excinfo:
             handler1.check_handler_compatibility(handler3)
 
     def test_charge_increment_type_wrong_num_increments(self):
         """Ensure that an error is raised if a ChargeIncrementType is initialized with a different number of
         tagged atoms and chargeincrements"""
-        ci_type = ChargeIncrementModelHandler.ChargeIncrementType(smirks='[#6:1]-[#7:2]',
-                                                                  charge_increment1=0.1 * unit.elementary_charge,
-                                                                  charge_increment2=-0.1 * unit.elementary_charge)
+        ci_type = ChargeIncrementModelHandler.ChargeIncrementType(
+            smirks="[#6:1]-[#7:2]",
+            charge_increment1=0.1 * unit.elementary_charge,
+            charge_increment2=-0.1 * unit.elementary_charge,
+        )
 
-        ci_type = ChargeIncrementModelHandler.ChargeIncrementType(smirks='[#6:1]-[#7:2]-[#6]',
-                                                                  charge_increment1=0.1 * unit.elementary_charge,
-                                                                  charge_increment2=-0.1 * unit.elementary_charge)
+        ci_type = ChargeIncrementModelHandler.ChargeIncrementType(
+            smirks="[#6:1]-[#7:2]-[#6]",
+            charge_increment1=0.1 * unit.elementary_charge,
+            charge_increment2=-0.1 * unit.elementary_charge,
+        )
 
-        with pytest.raises(SMIRNOFFSpecError, match="initialized with unequal number of tagged atoms and charge increments") as excinfo:
-            ci_type = ChargeIncrementModelHandler.ChargeIncrementType(smirks='[#6:1]-[#7:2]',
-                                                                      charge_increment1=0.05 * unit.elementary_charge,
-                                                                      charge_increment2=0.05 * unit.elementary_charge,
-                                                                      charge_increment3=-0.1 * unit.elementary_charge)
+        with pytest.raises(
+            SMIRNOFFSpecError,
+            match="initialized with unequal number of tagged atoms and charge increments",
+        ) as excinfo:
+            ci_type = ChargeIncrementModelHandler.ChargeIncrementType(
+                smirks="[#6:1]-[#7:2]",
+                charge_increment1=0.05 * unit.elementary_charge,
+                charge_increment2=0.05 * unit.elementary_charge,
+                charge_increment3=-0.1 * unit.elementary_charge,
+            )
 
-        with pytest.raises(SMIRNOFFSpecError, match="initialized with unequal number of tagged atoms and charge increments") as excinfo:
-            ci_type = ChargeIncrementModelHandler.ChargeIncrementType(smirks='[#6:1]-[#7:2]-[#6]',
-                                                                      charge_increment1=0.05 * unit.elementary_charge,
-                                                                      charge_increment2=0.05 * unit.elementary_charge,
-                                                                      charge_increment3=-0.1 * unit.elementary_charge)
+        with pytest.raises(
+            SMIRNOFFSpecError,
+            match="initialized with unequal number of tagged atoms and charge increments",
+        ) as excinfo:
+            ci_type = ChargeIncrementModelHandler.ChargeIncrementType(
+                smirks="[#6:1]-[#7:2]-[#6]",
+                charge_increment1=0.05 * unit.elementary_charge,
+                charge_increment2=0.05 * unit.elementary_charge,
+                charge_increment3=-0.1 * unit.elementary_charge,
+            )
 
-        with pytest.raises(SMIRNOFFSpecError, match="initialized with unequal number of tagged atoms and charge increments") as excinfo:
-            ci_type = ChargeIncrementModelHandler.ChargeIncrementType(smirks='[#6:1]-[#7:2]-[#6]',
-                                                                      charge_increment1=0.05 * unit.elementary_charge)
+        with pytest.raises(
+            SMIRNOFFSpecError,
+            match="initialized with unequal number of tagged atoms and charge increments",
+        ) as excinfo:
+            ci_type = ChargeIncrementModelHandler.ChargeIncrementType(
+                smirks="[#6:1]-[#7:2]-[#6]",
+                charge_increment1=0.05 * unit.elementary_charge,
+            )
 
 
 class TestGBSAHandler:
     def test_create_default_gbsahandler(self):
         """Test creation of an empty GBSAHandler, with all default attributes"""
         from simtk import unit
+
         gbsa_handler = GBSAHandler(skip_version_check=True)
-        assert gbsa_handler.gb_model == 'OBC1'
+        assert gbsa_handler.gb_model == "OBC1"
         assert gbsa_handler.solvent_dielectric == 78.5
         assert gbsa_handler.solute_dielectric == 1
-        assert gbsa_handler.sa_model == 'ACE'
-        assert gbsa_handler.surface_area_penalty == 5.4 * unit.calorie / unit.mole / unit.angstrom**2
+        assert gbsa_handler.sa_model == "ACE"
+        assert (
+            gbsa_handler.surface_area_penalty
+            == 5.4 * unit.calorie / unit.mole / unit.angstrom ** 2
+        )
         assert gbsa_handler.solvent_radius == 1.4 * unit.angstrom
-
 
     def test_gbsahandler_setters(self):
         """Test creation of an empty GBSAHandler, with all default attributes"""
         from simtk import unit
+
         gbsa_handler = GBSAHandler(skip_version_check=True)
 
-        gbsa_handler.gb_model = 'OBC2'
-        gbsa_handler.gb_model = 'HCT'
-        gbsa_handler.gb_model = 'OBC1'
+        gbsa_handler.gb_model = "OBC2"
+        gbsa_handler.gb_model = "HCT"
+        gbsa_handler.gb_model = "OBC1"
         with pytest.raises(SMIRNOFFSpecError) as excinfo:
-            gbsa_handler.gb_model = 'Something invalid'
+            gbsa_handler.gb_model = "Something invalid"
 
         gbsa_handler.solvent_dielectric = 50.0
         gbsa_handler.solvent_dielectric = "50.0"
         with pytest.raises(ValueError) as excinfo:
-            gbsa_handler.solvent_dielectric = 'string that can not be cast to float'
+            gbsa_handler.solvent_dielectric = "string that can not be cast to float"
 
         gbsa_handler.solute_dielectric = 2.5
         gbsa_handler.solute_dielectric = "3.5"
         with pytest.raises(ValueError) as excinfo:
-            gbsa_handler.solute_dielectric = 'string that can not be cast to float'
+            gbsa_handler.solute_dielectric = "string that can not be cast to float"
 
-        gbsa_handler.sa_model = 'ACE'
+        gbsa_handler.sa_model = "ACE"
 
         # NOTE -- Right now, the SMIRNOFF spec will implicitly assume these are the same.
         gbsa_handler.sa_model = None
-        gbsa_handler.sa_model = 'None'
+        gbsa_handler.sa_model = "None"
 
         with pytest.raises(TypeError) as excinfo:
-            gbsa_handler.sa_model = 'Invalid SA option'
+            gbsa_handler.sa_model = "Invalid SA option"
 
-        gbsa_handler.surface_area_penalty = 1.23 * unit.kilocalorie / unit.mole / unit.nanometer**2
+        gbsa_handler.surface_area_penalty = (
+            1.23 * unit.kilocalorie / unit.mole / unit.nanometer ** 2
+        )
         with pytest.raises(IncompatibleUnitError) as excinfo:
-            gbsa_handler.surface_area_penalty = 1.23 * unit.degree / unit.mole / unit.nanometer**2
+            gbsa_handler.surface_area_penalty = (
+                1.23 * unit.degree / unit.mole / unit.nanometer ** 2
+            )
 
         gbsa_handler.solvent_radius = 300 * unit.femtometer
         with pytest.raises(IncompatibleUnitError) as excinfo:
@@ -1445,6 +1772,7 @@ class TestGBSAHandler:
         Test the check_handler_compatibility function of GBSAHandler
         """
         from simtk import unit
+
         gbsa_handler_1 = GBSAHandler(skip_version_check=True)
         gbsa_handler_2 = GBSAHandler(skip_version_check=True)
 
@@ -1452,8 +1780,12 @@ class TestGBSAHandler:
         gbsa_handler_1.check_handler_compatibility(gbsa_handler_2)
 
         # Perform a check which should fail
-        gbsa_handler_3 = GBSAHandler(skip_version_check=True, solvent_radius=1.3 * unit.angstrom)
-        with pytest.raises(IncompatibleParameterError, match="Difference between 'solvent_radius' ") as excinfo:
+        gbsa_handler_3 = GBSAHandler(
+            skip_version_check=True, solvent_radius=1.3 * unit.angstrom
+        )
+        with pytest.raises(
+            IncompatibleParameterError, match="Difference between 'solvent_radius' "
+        ) as excinfo:
             gbsa_handler_1.check_handler_compatibility(gbsa_handler_3)
 
 

--- a/openforcefield/tests/test_toolkits.py
+++ b/openforcefield/tests/test_toolkits.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python
 
-#=============================================================================================
+# =============================================================================================
 # MODULE DOCSTRING
-#=============================================================================================
+# =============================================================================================
 
 """
 Tests for cheminformatics toolkit wrappers
 
 """
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 from simtk import unit
 import numpy as np
@@ -20,22 +20,36 @@ from tempfile import NamedTemporaryFile
 
 import pytest
 
-from openforcefield.utils.toolkits import (OpenEyeToolkitWrapper, RDKitToolkitWrapper,
-                                           AmberToolsToolkitWrapper, BuiltInToolkitWrapper,
-                                           ToolkitRegistry, ToolkitWrapper,
-                                           GAFFAtomTypeWarning, UndefinedStereochemistryError,
-                                           ChargeMethodUnavailableError, IncorrectNumConformersError,
-                                           IncorrectNumConformersWarning, InvalidToolkitError,
-                                           ToolkitUnavailableException, GLOBAL_TOOLKIT_REGISTRY)
+from openforcefield.utils.toolkits import (
+    OpenEyeToolkitWrapper,
+    RDKitToolkitWrapper,
+    AmberToolsToolkitWrapper,
+    BuiltInToolkitWrapper,
+    ToolkitRegistry,
+    ToolkitWrapper,
+    GAFFAtomTypeWarning,
+    UndefinedStereochemistryError,
+    ChargeMethodUnavailableError,
+    IncorrectNumConformersError,
+    IncorrectNumConformersWarning,
+    InvalidToolkitError,
+    ToolkitUnavailableException,
+    GLOBAL_TOOLKIT_REGISTRY,
+)
 
 from openforcefield.utils import get_data_file_path
 from openforcefield.topology.molecule import Molecule
-from openforcefield.tests.test_forcefield import create_ethanol, create_cyclohexane, create_acetaldehyde, \
-    create_reversed_ethanol, create_acetate
+from openforcefield.tests.test_forcefield import (
+    create_ethanol,
+    create_cyclohexane,
+    create_acetaldehyde,
+    create_reversed_ethanol,
+    create_acetate,
+)
 
-#=============================================================================================
+# =============================================================================================
 # FIXTURES
-#=============================================================================================
+# =============================================================================================
 
 
 def get_mini_drug_bank(toolkit_class):
@@ -45,73 +59,173 @@ def get_mini_drug_bank(toolkit_class):
     #  we still try and read the file with the toolkit
     if toolkit_class.is_available():
         toolkit = toolkit_class()
-        molecules = Molecule.from_file(get_data_file_path('molecules/MiniDrugBank.sdf'), 'sdf', toolkit_registry=toolkit,
-                                       allow_undefined_stereo=True)
+        molecules = Molecule.from_file(
+            get_data_file_path("molecules/MiniDrugBank.sdf"),
+            "sdf",
+            toolkit_registry=toolkit,
+            allow_undefined_stereo=True,
+        )
     else:
         molecules = []
 
     return molecules
 
 
-openeye_inchi_stereochemistry_lost = ['DrugBank_2799', 'DrugBank_5414', 'DrugBank_5415', 'DrugBank_5418',
-                                      'DrugBank_2955', 'DrugBank_2987', 'DrugBank_5555', 'DrugBank_472',
-                                      'DrugBank_5737', 'DrugBank_3332', 'DrugBank_3461', 'DrugBank_794',
-                                      'DrugBank_3502', 'DrugBank_6026', 'DrugBank_3622', 'DrugBank_977',
-                                      'DrugBank_3693', 'DrugBank_3726', 'DrugBank_3739', 'DrugBank_6222',
-                                      'DrugBank_6232', 'DrugBank_3844', 'DrugBank_6295', 'DrugBank_6304',
-                                      'DrugBank_6305', 'DrugBank_3930', 'DrugBank_6329', 'DrugBank_6353',
-                                      'DrugBank_6355', 'DrugBank_6401', 'DrugBank_4161', 'DrugBank_4162',
-                                      'DrugBank_6509', 'DrugBank_6531', 'DrugBank_1570', 'DrugBank_4249',
-                                      'DrugBank_1634', 'DrugBank_1659', 'DrugBank_6647', 'DrugBank_1700',
-                                      'DrugBank_1721', 'DrugBank_1742', 'DrugBank_1802', 'DrugBank_6775',
-                                      'DrugBank_1849', 'DrugBank_1864', 'DrugBank_6875', 'DrugBank_1897',
-                                      'DrugBank_4593', 'DrugBank_1962', 'DrugBank_4662', 'DrugBank_7049',
-                                      'DrugBank_4702', 'DrugBank_2095', 'DrugBank_4778', 'DrugBank_2141',
-                                      'DrugBank_2148', 'DrugBank_2178', 'DrugBank_4865', 'DrugBank_2208',
-                                      'DrugBank_2210', 'DrugBank_2276', 'DrugBank_4959', 'DrugBank_4964',
-                                      'DrugBank_5043', 'DrugBank_2429', 'DrugBank_5076', 'DrugBank_2465',
-                                      'DrugBank_2519', 'DrugBank_2538', 'DrugBank_5158', 'DrugBank_5176',
-                                      'DrugBank_2592']
+openeye_inchi_stereochemistry_lost = [
+    "DrugBank_2799",
+    "DrugBank_5414",
+    "DrugBank_5415",
+    "DrugBank_5418",
+    "DrugBank_2955",
+    "DrugBank_2987",
+    "DrugBank_5555",
+    "DrugBank_472",
+    "DrugBank_5737",
+    "DrugBank_3332",
+    "DrugBank_3461",
+    "DrugBank_794",
+    "DrugBank_3502",
+    "DrugBank_6026",
+    "DrugBank_3622",
+    "DrugBank_977",
+    "DrugBank_3693",
+    "DrugBank_3726",
+    "DrugBank_3739",
+    "DrugBank_6222",
+    "DrugBank_6232",
+    "DrugBank_3844",
+    "DrugBank_6295",
+    "DrugBank_6304",
+    "DrugBank_6305",
+    "DrugBank_3930",
+    "DrugBank_6329",
+    "DrugBank_6353",
+    "DrugBank_6355",
+    "DrugBank_6401",
+    "DrugBank_4161",
+    "DrugBank_4162",
+    "DrugBank_6509",
+    "DrugBank_6531",
+    "DrugBank_1570",
+    "DrugBank_4249",
+    "DrugBank_1634",
+    "DrugBank_1659",
+    "DrugBank_6647",
+    "DrugBank_1700",
+    "DrugBank_1721",
+    "DrugBank_1742",
+    "DrugBank_1802",
+    "DrugBank_6775",
+    "DrugBank_1849",
+    "DrugBank_1864",
+    "DrugBank_6875",
+    "DrugBank_1897",
+    "DrugBank_4593",
+    "DrugBank_1962",
+    "DrugBank_4662",
+    "DrugBank_7049",
+    "DrugBank_4702",
+    "DrugBank_2095",
+    "DrugBank_4778",
+    "DrugBank_2141",
+    "DrugBank_2148",
+    "DrugBank_2178",
+    "DrugBank_4865",
+    "DrugBank_2208",
+    "DrugBank_2210",
+    "DrugBank_2276",
+    "DrugBank_4959",
+    "DrugBank_4964",
+    "DrugBank_5043",
+    "DrugBank_2429",
+    "DrugBank_5076",
+    "DrugBank_2465",
+    "DrugBank_2519",
+    "DrugBank_2538",
+    "DrugBank_5158",
+    "DrugBank_5176",
+    "DrugBank_2592",
+]
 
-openeye_inchi_isomorphic_fails = ['DrugBank_1661', 'DrugBank_4346', 'DrugBank_2467']
+openeye_inchi_isomorphic_fails = ["DrugBank_1661", "DrugBank_4346", "DrugBank_2467"]
 
-rdkit_inchi_stereochemistry_lost = ['DrugBank_5414', 'DrugBank_2955', 'DrugBank_5737', 'DrugBank_3332', 'DrugBank_3461',
-                                    'DrugBank_6026', 'DrugBank_3622', 'DrugBank_3726', 'DrugBank_6222', 'DrugBank_3844',
-                                    'DrugBank_6304', 'DrugBank_6305', 'DrugBank_6329', 'DrugBank_6509', 'DrugBank_6647',
-                                    'DrugBank_1897', 'DrugBank_4778', 'DrugBank_2148', 'DrugBank_2178', 'DrugBank_2538',
-                                    'DrugBank_2592', 'DrugBank_4249', 'DrugBank_5076', 'DrugBank_5418', 'DrugBank_3930',
-                                    'DrugBank_1634', 'DrugBank_1962', 'DrugBank_5043', 'DrugBank_2519']
+rdkit_inchi_stereochemistry_lost = [
+    "DrugBank_5414",
+    "DrugBank_2955",
+    "DrugBank_5737",
+    "DrugBank_3332",
+    "DrugBank_3461",
+    "DrugBank_6026",
+    "DrugBank_3622",
+    "DrugBank_3726",
+    "DrugBank_6222",
+    "DrugBank_3844",
+    "DrugBank_6304",
+    "DrugBank_6305",
+    "DrugBank_6329",
+    "DrugBank_6509",
+    "DrugBank_6647",
+    "DrugBank_1897",
+    "DrugBank_4778",
+    "DrugBank_2148",
+    "DrugBank_2178",
+    "DrugBank_2538",
+    "DrugBank_2592",
+    "DrugBank_4249",
+    "DrugBank_5076",
+    "DrugBank_5418",
+    "DrugBank_3930",
+    "DrugBank_1634",
+    "DrugBank_1962",
+    "DrugBank_5043",
+    "DrugBank_2519",
+]
 
-rdkit_inchi_isomorphic_fails = ['DrugBank_178', 'DrugBank_246', 'DrugBank_5847', 'DrugBank_700', 'DrugBank_1564',
-                                'DrugBank_1700', 'DrugBank_4662', 'DrugBank_2052', 'DrugBank_2077', 'DrugBank_2082',
-                                'DrugBank_2210', 'DrugBank_2642']
-rdkit_inchi_roundtrip_mangled = ['DrugBank_2684']
+rdkit_inchi_isomorphic_fails = [
+    "DrugBank_178",
+    "DrugBank_246",
+    "DrugBank_5847",
+    "DrugBank_700",
+    "DrugBank_1564",
+    "DrugBank_1700",
+    "DrugBank_4662",
+    "DrugBank_2052",
+    "DrugBank_2077",
+    "DrugBank_2082",
+    "DrugBank_2210",
+    "DrugBank_2642",
+]
+rdkit_inchi_roundtrip_mangled = ["DrugBank_2684"]
 
-#=============================================================================================
+# =============================================================================================
 # TESTS
-#=============================================================================================
+# =============================================================================================
+
 
 class TestOpenEyeToolkitWrapper:
     """Test the OpenEyeToolkitWrapper"""
 
     # TODO: Make separate smiles_add_H and smiles_explicit_H tests
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_smiles(self):
         """Test OpenEyeToolkitWrapper to_smiles() and from_smiles()"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
 
         # This differs from RDKit's SMILES due to different canonicalization schemes
 
-        smiles = '[H]C([H])([H])C([H])([H])[H]'
-        molecule = Molecule.from_smiles(smiles,
-                                        toolkit_registry=toolkit_wrapper)
+        smiles = "[H]C([H])([H])C([H])([H])[H]"
+        molecule = Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
         # When creating an OFFMol from SMILES, partial charges should be initialized to None
         assert molecule.partial_charges is None
         smiles2 = molecule.to_smiles(toolkit_registry=toolkit_wrapper)
         assert smiles == smiles2
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_smiles_missing_stereochemistry(self):
         """Test OpenEyeToolkitWrapper to_smiles() and from_smiles()"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
@@ -121,81 +235,124 @@ class TestOpenEyeToolkitWrapper:
         unspec_db_smiles = r"CC(F)=C(F)C[C@@](C)(Cl)Br"
         spec_db_smiles = r"C\C(F)=C(/F)C[C@@](C)(Cl)Br"
 
-        for title, smiles, raises_exception in [("unspec_chiral_smiles", unspec_chiral_smiles, True),
-                                                ("spec_chiral_smiles", spec_chiral_smiles, False),
-                                                ("unspec_db_smiles", unspec_db_smiles, True),
-                                                ("spec_db_smiles", spec_db_smiles, False),
-                                                ]:
+        for title, smiles, raises_exception in [
+            ("unspec_chiral_smiles", unspec_chiral_smiles, True),
+            ("spec_chiral_smiles", spec_chiral_smiles, False),
+            ("unspec_db_smiles", unspec_db_smiles, True),
+            ("spec_db_smiles", spec_db_smiles, False),
+        ]:
             if raises_exception:
                 with pytest.raises(UndefinedStereochemistryError) as context:
                     Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
-                Molecule.from_smiles(smiles,
-                                     toolkit_registry=toolkit_wrapper,
-                                     allow_undefined_stereo=True)
+                Molecule.from_smiles(
+                    smiles,
+                    toolkit_registry=toolkit_wrapper,
+                    allow_undefined_stereo=True,
+                )
             else:
                 Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
 
     # TODO: test_smiles_round_trip
 
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_smiles_add_H(self):
         """Test OpenEyeToolkitWrapper for adding explicit hydrogens"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
         # This differs from RDKit's SMILES due to different canonicalization schemes
-        input_smiles = 'CC'
-        expected_output_smiles = '[H]C([H])([H])C([H])([H])[H]'
-        molecule = Molecule.from_smiles(input_smiles,
-                                        toolkit_registry=toolkit_wrapper)
+        input_smiles = "CC"
+        expected_output_smiles = "[H]C([H])([H])C([H])([H])[H]"
+        molecule = Molecule.from_smiles(input_smiles, toolkit_registry=toolkit_wrapper)
         smiles2 = molecule.to_smiles(toolkit_registry=toolkit_wrapper)
         assert expected_output_smiles == smiles2
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_smiles_charged(self):
         """Test OpenEyeToolkitWrapper functions for reading/writing charged SMILES"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
         # This differs from RDKit's expected output due to different canonicalization schemes
-        smiles = '[H]C([H])([H])[N+]([H])([H])[H]'
-        molecule = Molecule.from_smiles(smiles,
-                                        toolkit_registry=toolkit_wrapper)
+        smiles = "[H]C([H])([H])[N+]([H])([H])[H]"
+        molecule = Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
         smiles2 = molecule.to_smiles(toolkit_registry=toolkit_wrapper)
         assert smiles == smiles2
 
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_to_from_openeye_core_props_filled(self):
         """Test OpenEyeToolkitWrapper to_openeye() and from_openeye()"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
 
         # Replacing with a simple molecule with stereochemistry
-        input_smiles = r'C\C(F)=C(/F)C[C@@](C)(Cl)Br'
-        expected_output_smiles = r'[H]C([H])([H])/C(=C(/C([H])([H])[C@@](C([H])([H])[H])(Cl)Br)\F)/F'
+        input_smiles = r"C\C(F)=C(/F)C[C@@](C)(Cl)Br"
+        expected_output_smiles = (
+            r"[H]C([H])([H])/C(=C(/C([H])([H])[C@@](C([H])([H])[H])(Cl)Br)\F)/F"
+        )
         molecule = Molecule.from_smiles(input_smiles, toolkit_registry=toolkit_wrapper)
-        assert molecule.to_smiles(toolkit_registry=toolkit_wrapper) == expected_output_smiles
+        assert (
+            molecule.to_smiles(toolkit_registry=toolkit_wrapper)
+            == expected_output_smiles
+        )
 
         # Populate core molecule property fields
-        molecule.name = 'Alice'
-        partial_charges = unit.Quantity(np.array([-.9, -.8, -.7, -.6,
-                                                  -.5, -.4, -.3, -.2,
-                                                  -.1, 0., .1, .2,
-                                                  .3, .4, .5, .6,
-                                                  .7, .8]), unit.elementary_charge)
+        molecule.name = "Alice"
+        partial_charges = unit.Quantity(
+            np.array(
+                [
+                    -0.9,
+                    -0.8,
+                    -0.7,
+                    -0.6,
+                    -0.5,
+                    -0.4,
+                    -0.3,
+                    -0.2,
+                    -0.1,
+                    0.0,
+                    0.1,
+                    0.2,
+                    0.3,
+                    0.4,
+                    0.5,
+                    0.6,
+                    0.7,
+                    0.8,
+                ]
+            ),
+            unit.elementary_charge,
+        )
         molecule.partial_charges = partial_charges
-        coords = unit.Quantity(np.array([['0.0', '1.0', '2.0'], ['3.0', '4.0', '5.0'], ['6.0', '7.0', '8.0'],
-                                         ['9.0', '10.0', '11.0'], ['12.0', '13.0', '14.0'],
-                                         ['15.0', '16.0', '17.0'],
-                                         ['18.0', '19.0', '20.0'], ['21.0', '22.0', '23.0'],
-                                         ['24.0', '25.0', '26.0'],
-                                         ['27.0', '28.0', '29.0'], ['30.0', '31.0', '32.0'],
-                                         ['33.0', '34.0', '35.0'],
-                                         ['36.0', '37.0', '38.0'], ['39.0', '40.0', '41.0'],
-                                         ['42.0', '43.0', '44.0'],
-                                         ['45.0', '46.0', '47.0'], ['48.0', '49.0', '50.0'],
-                                         ['51.0', '52.0', '53.0']]),
-                               unit.angstrom)
+        coords = unit.Quantity(
+            np.array(
+                [
+                    ["0.0", "1.0", "2.0"],
+                    ["3.0", "4.0", "5.0"],
+                    ["6.0", "7.0", "8.0"],
+                    ["9.0", "10.0", "11.0"],
+                    ["12.0", "13.0", "14.0"],
+                    ["15.0", "16.0", "17.0"],
+                    ["18.0", "19.0", "20.0"],
+                    ["21.0", "22.0", "23.0"],
+                    ["24.0", "25.0", "26.0"],
+                    ["27.0", "28.0", "29.0"],
+                    ["30.0", "31.0", "32.0"],
+                    ["33.0", "34.0", "35.0"],
+                    ["36.0", "37.0", "38.0"],
+                    ["39.0", "40.0", "41.0"],
+                    ["42.0", "43.0", "44.0"],
+                    ["45.0", "46.0", "47.0"],
+                    ["48.0", "49.0", "50.0"],
+                    ["51.0", "52.0", "53.0"],
+                ]
+            ),
+            unit.angstrom,
+        )
         molecule.add_conformer(coords)
         # Populate core atom property fields
-        molecule.atoms[2].name = 'Bob'
+        molecule.atoms[2].name = "Bob"
         # Ensure one atom has its stereochemistry specified
         central_carbon_stereo_specified = False
         for atom in molecule.atoms:
@@ -231,20 +388,29 @@ class TestOpenEyeToolkitWrapper:
             pc1_ul = pc1 / unit.elementary_charge
             pc2_ul = pc2 / unit.elementary_charge
             assert_almost_equal(pc1_ul, pc2_ul, decimal=6)
-        assert molecule2.to_smiles(toolkit_registry=toolkit_wrapper) == expected_output_smiles
+        assert (
+            molecule2.to_smiles(toolkit_registry=toolkit_wrapper)
+            == expected_output_smiles
+        )
 
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_to_from_openeye_core_props_unset(self):
         """Test OpenEyeToolkitWrapper to_openeye() and from_openeye() when given empty core property fields"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
 
         # Using a simple molecule with tetrahedral and bond stereochemistry
-        input_smiles = r'C\C(F)=C(/F)C[C@](C)(Cl)Br'
+        input_smiles = r"C\C(F)=C(/F)C[C@](C)(Cl)Br"
 
-        expected_output_smiles = r'[H]C([H])([H])/C(=C(/C([H])([H])[C@](C([H])([H])[H])(Cl)Br)\F)/F'
+        expected_output_smiles = (
+            r"[H]C([H])([H])/C(=C(/C([H])([H])[C@](C([H])([H])[H])(Cl)Br)\F)/F"
+        )
         molecule = Molecule.from_smiles(input_smiles, toolkit_registry=toolkit_wrapper)
-        assert molecule.to_smiles(toolkit_registry=toolkit_wrapper) == expected_output_smiles
+        assert (
+            molecule.to_smiles(toolkit_registry=toolkit_wrapper)
+            == expected_output_smiles
+        )
 
         # Ensure one atom has its stereochemistry specified
         central_carbon_stereo_specified = False
@@ -277,12 +443,18 @@ class TestOpenEyeToolkitWrapper:
         assert molecule.partial_charges is None
         assert molecule2.partial_charges is None
 
-        assert molecule2.to_smiles(toolkit_registry=toolkit_wrapper) == expected_output_smiles
+        assert (
+            molecule2.to_smiles(toolkit_registry=toolkit_wrapper)
+            == expected_output_smiles
+        )
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_to_from_openeye_none_partial_charges(self):
         """Test to ensure that to_openeye and from_openeye correctly handle None partial charges"""
         import math
+
         # Create ethanol, which has partial charges defined with float values
         ethanol = create_ethanol()
         assert ethanol.partial_charges is not None
@@ -294,7 +466,7 @@ class TestOpenEyeToolkitWrapper:
         # Change the first OEAtom's partial charge to nan, and ensure that it comes
         # back to OFFMol with only the first atom as nan
         for oeatom in oemol.GetAtoms():
-            oeatom.SetPartialCharge(float('nan'))
+            oeatom.SetPartialCharge(float("nan"))
             break
         eth_from_oe = Molecule.from_openeye(oemol)
         assert math.isnan(eth_from_oe.partial_charges[0] / unit.elementary_charge)
@@ -303,7 +475,7 @@ class TestOpenEyeToolkitWrapper:
         # Then, set all the OEMol's partial charges to nan, and ensure that
         # from_openeye produces an OFFMol with partial_charges = None
         for oeatom in oemol.GetAtoms():
-            oeatom.SetPartialCharge(float('nan'))
+            oeatom.SetPartialCharge(float("nan"))
         eth_from_oe = Molecule.from_openeye(oemol)
         assert eth_from_oe.partial_charges is None
 
@@ -313,8 +485,9 @@ class TestOpenEyeToolkitWrapper:
         for oeatom in oemol2.GetAtoms():
             assert math.isnan(oeatom.GetPartialCharge())
 
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_from_openeye_implicit_hydrogen(self):
         """
         Test OpenEyeToolkitWrapper for loading a molecule with implicit
@@ -335,7 +508,9 @@ class TestOpenEyeToolkitWrapper:
         molecule_from_expl = Molecule.from_openeye(oemol_expl)
         assert molecule_from_expl.to_smiles() == molecule_from_impl.to_smiles()
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_openeye_from_smiles_hydrogens_are_explicit(self):
         """
         Test to ensure that OpenEyeToolkitWrapper.from_smiles has the proper behavior with
@@ -343,32 +518,38 @@ class TestOpenEyeToolkitWrapper:
         """
         toolkit_wrapper = OpenEyeToolkitWrapper()
         smiles_impl = "C#C"
-        with pytest.raises(ValueError,
-                           match="but OpenEye Toolkit interpreted SMILES 'C#C' as having implicit hydrogen") as excinfo:
-            offmol = Molecule.from_smiles(smiles_impl,
-                                          toolkit_registry=toolkit_wrapper,
-                                          hydrogens_are_explicit=True)
-        offmol = Molecule.from_smiles(smiles_impl,
-                                      toolkit_registry=toolkit_wrapper,
-                                      hydrogens_are_explicit=False)
+        with pytest.raises(
+            ValueError,
+            match="but OpenEye Toolkit interpreted SMILES 'C#C' as having implicit hydrogen",
+        ) as excinfo:
+            offmol = Molecule.from_smiles(
+                smiles_impl,
+                toolkit_registry=toolkit_wrapper,
+                hydrogens_are_explicit=True,
+            )
+        offmol = Molecule.from_smiles(
+            smiles_impl, toolkit_registry=toolkit_wrapper, hydrogens_are_explicit=False
+        )
         assert offmol.n_atoms == 4
 
         smiles_expl = "HC#CH"
-        offmol = Molecule.from_smiles(smiles_expl,
-                                      toolkit_registry=toolkit_wrapper,
-                                      hydrogens_are_explicit=True)
+        offmol = Molecule.from_smiles(
+            smiles_expl, toolkit_registry=toolkit_wrapper, hydrogens_are_explicit=True
+        )
         assert offmol.n_atoms == 4
         # It's debatable whether this next function should pass. Strictly speaking, the hydrogens in this SMILES
         # _are_ explicit, so allowing "hydrogens_are_explicit=False" through here is allowing a contradiction.
         # We might rethink the name of this kwarg.
 
-        offmol = Molecule.from_smiles(smiles_expl,
-                                      toolkit_registry=toolkit_wrapper,
-                                      hydrogens_are_explicit=False)
+        offmol = Molecule.from_smiles(
+            smiles_expl, toolkit_registry=toolkit_wrapper, hydrogens_are_explicit=False
+        )
         assert offmol.n_atoms == 4
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
-    @pytest.mark.parametrize('molecule', get_mini_drug_bank(OpenEyeToolkitWrapper))
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
+    @pytest.mark.parametrize("molecule", get_mini_drug_bank(OpenEyeToolkitWrapper))
     def test_to_inchi(self, molecule):
         """Test conversion to standard and non-standard InChI"""
 
@@ -376,8 +557,10 @@ class TestOpenEyeToolkitWrapper:
         inchi = molecule.to_inchi(toolkit_registry=toolkit)
         non_standard = molecule.to_inchi(True, toolkit_registry=toolkit)
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
-    @pytest.mark.parametrize('molecule', get_mini_drug_bank(OpenEyeToolkitWrapper))
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
+    @pytest.mark.parametrize("molecule", get_mini_drug_bank(OpenEyeToolkitWrapper))
     def test_to_inchikey(self, molecule):
         """Test the conversion to standard and non-standard InChIKey"""
 
@@ -385,17 +568,21 @@ class TestOpenEyeToolkitWrapper:
         inchikey = molecule.to_inchikey(toolkit_registry=toolkit)
         non_standard_key = molecule.to_inchikey(True, toolkit_registry=toolkit)
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_from_bad_inchi(self):
         """Test building a molecule from a bad InChI string"""
 
         toolkit = OpenEyeToolkitWrapper()
-        inchi = 'InChI=1S/ksbfksfksfksbfks'
+        inchi = "InChI=1S/ksbfksfksfksbfks"
         with pytest.raises(RuntimeError):
             mol = Molecule.from_inchi(inchi, toolkit_registry=toolkit)
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
-    @pytest.mark.parametrize('molecule', get_mini_drug_bank(OpenEyeToolkitWrapper))
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
+    @pytest.mark.parametrize("molecule", get_mini_drug_bank(OpenEyeToolkitWrapper))
     def test_non_standard_inchi_round_trip(self, molecule):
         """Test if a molecule can survive an InChi round trip test in some cases the standard InChI
         will not enough to ensure information is preserved so we test the non-standard inchi here."""
@@ -419,35 +606,45 @@ class TestOpenEyeToolkitWrapper:
                 # Some molecules graphs change during the round trip testing
                 # we test quite strict isomorphism here
                 with pytest.raises(AssertionError):
-                    assert molecule.is_isomorphic_with(mol2, bond_order_matching=False, toolkit_registry=toolkit)
+                    assert molecule.is_isomorphic_with(
+                        mol2, bond_order_matching=False, toolkit_registry=toolkit
+                    )
             else:
-                assert molecule.is_isomorphic_with(mol2, bond_order_matching=False, toolkit_registry=toolkit)
+                assert molecule.is_isomorphic_with(
+                    mol2, bond_order_matching=False, toolkit_registry=toolkit
+                )
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_get_sdf_coordinates(self):
         """Test OpenEyeToolkitWrapper for importing a single set of coordinates from a sdf file"""
 
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        filename = get_data_file_path('molecules/toluene.sdf')
+        filename = get_data_file_path("molecules/toluene.sdf")
         molecule = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule.conformers) == 1
-        assert molecule.conformers[0].shape == (15,3)
+        assert molecule.conformers[0].shape == (15, 3)
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_load_multiconformer_sdf_as_separate_molecules(self):
         """
         Test OpenEyeToolkitWrapper for reading a "multiconformer" SDF, which the OFF
         Toolkit should treat as separate molecules
         """
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        filename = get_data_file_path('molecules/methane_multiconformer.sdf')
+        filename = get_data_file_path("molecules/methane_multiconformer.sdf")
         molecules = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecules) == 2
         assert len(molecules[0].conformers) == 1
         assert len(molecules[1].conformers) == 1
         assert molecules[0].conformers[0].shape == (5, 3)
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_load_multiconformer_sdf_as_separate_molecules_properties(self):
         """
         Test OpenEyeToolkitWrapper for reading a "multiconformer" SDF, which the OFF
@@ -455,109 +652,141 @@ class TestOpenEyeToolkitWrapper:
         and partial charges separately
         """
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        filename = get_data_file_path('molecules/methane_multiconformer_properties.sdf')
+        filename = get_data_file_path("molecules/methane_multiconformer_properties.sdf")
         molecules = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecules) == 2
         assert len(molecules[0].conformers) == 1
         assert len(molecules[1].conformers) == 1
         assert molecules[0].conformers[0].shape == (5, 3)
         # The first molecule in the SDF has the following properties and charges:
-        assert molecules[0].properties['test_property_key'] == 'test_property_value'
-        np.testing.assert_allclose(molecules[0].partial_charges / unit.elementary_charge,
-                                          [-0.108680, 0.027170, 0.027170, 0.027170, 0.027170])
+        assert molecules[0].properties["test_property_key"] == "test_property_value"
+        np.testing.assert_allclose(
+            molecules[0].partial_charges / unit.elementary_charge,
+            [-0.108680, 0.027170, 0.027170, 0.027170, 0.027170],
+        )
         # The second molecule in the SDF has the following properties and charges:
-        assert molecules[1].properties['test_property_key'] == 'test_property_value2'
-        assert molecules[1].properties['another_test_property_key'] == 'another_test_property_value'
-        np.testing.assert_allclose(molecules[1].partial_charges / unit.elementary_charge,
-                                   [0.027170, 0.027170, 0.027170, 0.027170, -0.108680])
+        assert molecules[1].properties["test_property_key"] == "test_property_value2"
+        assert (
+            molecules[1].properties["another_test_property_key"]
+            == "another_test_property_value"
+        )
+        np.testing.assert_allclose(
+            molecules[1].partial_charges / unit.elementary_charge,
+            [0.027170, 0.027170, 0.027170, 0.027170, -0.108680],
+        )
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_file_extension_case(self):
         """
         Test round-trips of some file extensions when called directly from the toolkit wrappers,
         including lower- and uppercase file extensions. Note that this test does not ensure
         accuracy, it only tests that reading/writing without raising an exception.
         """
-        mols_in = OpenEyeToolkitWrapper().from_file(file_path=get_data_file_path('molecules/ethanol.sdf'), file_format='sdf')
+        mols_in = OpenEyeToolkitWrapper().from_file(
+            file_path=get_data_file_path("molecules/ethanol.sdf"), file_format="sdf"
+        )
 
         assert len(mols_in) > 0
 
-        mols_in = OpenEyeToolkitWrapper().from_file(file_path=get_data_file_path('molecules/ethanol.sdf'), file_format='SDF')
+        mols_in = OpenEyeToolkitWrapper().from_file(
+            file_path=get_data_file_path("molecules/ethanol.sdf"), file_format="SDF"
+        )
 
         assert len(mols_in) > 0
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_write_sdf_charges(self):
         """Test OpenEyeToolkitWrapper for writing partial charges to a sdf file"""
         from io import StringIO
+
         toolkit_wrapper = OpenEyeToolkitWrapper()
         ethanol = create_ethanol()
         sio = StringIO()
-        ethanol.to_file(sio, 'SDF', toolkit_registry=toolkit_wrapper)
+        ethanol.to_file(sio, "SDF", toolkit_registry=toolkit_wrapper)
         sdf_text = sio.getvalue()
         # The output lines of interest here will look like
         # > <atom.dprop.PartialCharge>
         # -0.400000 -0.300000 -0.200000 -0.100000 0.000010 0.100000 0.200000 0.300000 0.400000
         # Parse the SDF text, grabbing the numeric line above
-        sdf_split = sdf_text.split('\n')
+        sdf_split = sdf_text.split("\n")
         charge_line_found = False
         for line in sdf_split:
             if charge_line_found:
                 charges = [float(i) for i in line.split()]
                 break
-            if '> <atom.dprop.PartialCharge>' in line:
+            if "> <atom.dprop.PartialCharge>" in line:
                 charge_line_found = True
 
         # Make sure that a charge line was ever found
         assert charge_line_found == True
 
         # Make sure that the charges found were correct
-        assert_almost_equal(charges, [-0.4, -0.3, -0.2, -0.1, 0.00001, 0.1, 0.2, 0.3, 0.4])
+        assert_almost_equal(
+            charges, [-0.4, -0.3, -0.2, -0.1, 0.00001, 0.1, 0.2, 0.3, 0.4]
+        )
 
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_write_sdf_no_charges(self):
         """Test OpenEyeToolkitWrapper for writing an SDF file without charges"""
         from io import StringIO
+
         toolkit_wrapper = OpenEyeToolkitWrapper()
         ethanol = create_ethanol()
         ethanol.partial_charges = None
         sio = StringIO()
-        ethanol.to_file(sio, 'SDF', toolkit_registry=toolkit_wrapper)
+        ethanol.to_file(sio, "SDF", toolkit_registry=toolkit_wrapper)
         sdf_text = sio.getvalue()
         # In our current configuration, if the OFFMol doesn't have partial charges, we DO NOT want a partial charge
         # block to be written. For reference, it's possible to indicate that a partial charge is not known by writing
         # out "n/a" (or another placeholder) in the partial charge block atoms without charges.
-        assert '<atom.dprop.PartialCharge>' not in sdf_text
+        assert "<atom.dprop.PartialCharge>" not in sdf_text
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_sdf_properties_roundtrip(self):
         """Test OpenEyeToolkitWrapper for performing a round trip of a molecule with defined partial charges
         and entries in the properties dict to and from a sdf file"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
         ethanol = create_ethanol()
-        ethanol.properties['test_property'] = 'test_value'
+        ethanol.properties["test_property"] = "test_value"
         # Write ethanol to a temporary file, and then immediately read it.
-        with NamedTemporaryFile(suffix='.sdf') as iofile:
-            ethanol.to_file(iofile.name, file_format='SDF', toolkit_registry=toolkit_wrapper)
-            ethanol2 = Molecule.from_file(iofile.name, file_format='SDF', toolkit_registry=toolkit_wrapper)
-        np.testing.assert_allclose(ethanol.partial_charges / unit.elementary_charge,
-                                   ethanol2.partial_charges / unit.elementary_charge)
-        assert ethanol2.properties['test_property'] == 'test_value'
+        with NamedTemporaryFile(suffix=".sdf") as iofile:
+            ethanol.to_file(
+                iofile.name, file_format="SDF", toolkit_registry=toolkit_wrapper
+            )
+            ethanol2 = Molecule.from_file(
+                iofile.name, file_format="SDF", toolkit_registry=toolkit_wrapper
+            )
+        np.testing.assert_allclose(
+            ethanol.partial_charges / unit.elementary_charge,
+            ethanol2.partial_charges / unit.elementary_charge,
+        )
+        assert ethanol2.properties["test_property"] == "test_value"
 
         # Now test with no properties or charges
         ethanol = create_ethanol()
         ethanol.partial_charges = None
         # Write ethanol to a temporary file, and then immediately read it.
-        with NamedTemporaryFile(suffix='.sdf') as iofile:
-            ethanol.to_file(iofile.name, file_format='SDF', toolkit_registry=toolkit_wrapper)
-            ethanol2 = Molecule.from_file(iofile.name, file_format='SDF', toolkit_registry=toolkit_wrapper)
+        with NamedTemporaryFile(suffix=".sdf") as iofile:
+            ethanol.to_file(
+                iofile.name, file_format="SDF", toolkit_registry=toolkit_wrapper
+            )
+            ethanol2 = Molecule.from_file(
+                iofile.name, file_format="SDF", toolkit_registry=toolkit_wrapper
+            )
         assert ethanol2.partial_charges is None
         assert ethanol2.properties == {}
 
-
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_write_multiconformer_mol_as_sdf(self):
         """
         Test OpenEyeToolkitWrapper for writing a multiconformer molecule to SDF. The OFF toolkit should only
@@ -566,75 +795,113 @@ class TestOpenEyeToolkitWrapper:
         from io import StringIO
 
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        filename = get_data_file_path('molecules/ethanol.sdf')
+        filename = get_data_file_path("molecules/ethanol.sdf")
         ethanol = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
-        ethanol.partial_charges = np.array([-4., -3., -2., -1., 0., 1., 2., 3., 4.]) * unit.elementary_charge
-        ethanol.properties['test_prop'] = 'test_value'
-        new_conf = ethanol.conformers[0] + (np.ones(ethanol.conformers[0].shape) * unit.angstrom)
+        ethanol.partial_charges = (
+            np.array([-4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0])
+            * unit.elementary_charge
+        )
+        ethanol.properties["test_prop"] = "test_value"
+        new_conf = ethanol.conformers[0] + (
+            np.ones(ethanol.conformers[0].shape) * unit.angstrom
+        )
         ethanol.add_conformer(new_conf)
         sio = StringIO()
-        ethanol.to_file(sio, 'sdf', toolkit_registry=toolkit_wrapper)
+        ethanol.to_file(sio, "sdf", toolkit_registry=toolkit_wrapper)
         data = sio.getvalue()
         # In SD format, each molecule ends with "$$$$"
-        assert data.count('$$$$') == 1
+        assert data.count("$$$$") == 1
         # A basic SDF for ethanol would be 27 lines, though the properties add three more
-        assert len(data.split('\n')) == 30
-        assert 'test_prop' in data
-        assert '<atom.dprop.PartialCharge>' in data
+        assert len(data.split("\n")) == 30
+        assert "test_prop" in data
+        assert "<atom.dprop.PartialCharge>" in data
         # Ensure the first conformer's first atom's X coordinate is in the file
         assert str(ethanol.conformers[0][0][0].value_in_unit(unit.angstrom))[:5] in data
         # Ensure the SECOND conformer's first atom's X coordinate is NOT in the file
-        assert str(ethanol.conformers[1][0][0].in_units_of(unit.angstrom))[:5] not in data
+        assert (
+            str(ethanol.conformers[1][0][0].in_units_of(unit.angstrom))[:5] not in data
+        )
 
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_get_mol2_coordinates(self):
         """Test OpenEyeToolkitWrapper for importing a single set of molecule coordinates"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        filename = get_data_file_path('molecules/toluene.mol2')
+        filename = get_data_file_path("molecules/toluene.mol2")
         molecule1 = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule1.conformers) == 1
         assert molecule1.conformers[0].shape == (15, 3)
-        assert_almost_equal(molecule1.conformers[0][5][1] / unit.angstrom, 22.98, decimal=2)
+        assert_almost_equal(
+            molecule1.conformers[0][5][1] / unit.angstrom, 22.98, decimal=2
+        )
 
         # Test loading from file-like object
-        with open(filename, 'r') as infile:
-            molecule2 = Molecule(infile, file_format='MOL2', toolkit_registry=toolkit_wrapper)
+        with open(filename, "r") as infile:
+            molecule2 = Molecule(
+                infile, file_format="MOL2", toolkit_registry=toolkit_wrapper
+            )
         assert molecule1.is_isomorphic_with(molecule2)
         assert len(molecule2.conformers) == 1
         assert molecule2.conformers[0].shape == (15, 3)
-        assert_almost_equal(molecule2.conformers[0][5][1] / unit.angstrom, 22.98, decimal=2)
+        assert_almost_equal(
+            molecule2.conformers[0][5][1] / unit.angstrom, 22.98, decimal=2
+        )
 
         # Test loading from gzipped mol2
         import gzip
-        with gzip.GzipFile(filename + '.gz', 'r') as infile:
-            molecule3 = Molecule(infile, file_format='MOL2', toolkit_registry=toolkit_wrapper)
+
+        with gzip.GzipFile(filename + ".gz", "r") as infile:
+            molecule3 = Molecule(
+                infile, file_format="MOL2", toolkit_registry=toolkit_wrapper
+            )
         assert molecule1.is_isomorphic_with(molecule3)
         assert len(molecule3.conformers) == 1
         assert molecule3.conformers[0].shape == (15, 3)
-        assert_almost_equal(molecule3.conformers[0][5][1] / unit.angstrom, 22.98, decimal=2)
+        assert_almost_equal(
+            molecule3.conformers[0][5][1] / unit.angstrom, 22.98, decimal=2
+        )
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_get_mol2_charges(self):
         """Test OpenEyeToolkitWrapper for importing a mol2 file specifying partial charges"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        filename = get_data_file_path('molecules/toluene_charged.mol2')
+        filename = get_data_file_path("molecules/toluene_charged.mol2")
         molecule = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule.conformers) == 1
-        assert molecule.conformers[0].shape == (15,3)
-        target_charges = unit.Quantity(np.array([-0.1342,-0.1271,-0.1271,-0.1310,
-                                                 -0.1310,-0.0765,-0.0541, 0.1314,
-                                                  0.1286, 0.1286, 0.1303, 0.1303,
-                                                  0.0440, 0.0440, 0.0440]),
-                                                unit.elementary_charge)
+        assert molecule.conformers[0].shape == (15, 3)
+        target_charges = unit.Quantity(
+            np.array(
+                [
+                    -0.1342,
+                    -0.1271,
+                    -0.1271,
+                    -0.1310,
+                    -0.1310,
+                    -0.0765,
+                    -0.0541,
+                    0.1314,
+                    0.1286,
+                    0.1286,
+                    0.1303,
+                    0.1303,
+                    0.0440,
+                    0.0440,
+                    0.0440,
+                ]
+            ),
+            unit.elementary_charge,
+        )
         for pc1, pc2 in zip(molecule._partial_charges, target_charges):
             pc1_ul = pc1 / unit.elementary_charge
             pc2_ul = pc2 / unit.elementary_charge
             assert_almost_equal(pc1_ul, pc2_ul, decimal=4)
 
-
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_mol2_charges_roundtrip(self):
         """Test OpenEyeToolkitWrapper for performing a round trip of a molecule with partial charge to and from
         a mol2 file"""
@@ -644,73 +911,98 @@ class TestOpenEyeToolkitWrapper:
         # written to 4 digits of precision, and the default middle charge for our test ethanol is 1e-5
         ethanol.partial_charges *= 100
         # Write ethanol to a temporary file, and then immediately read it.
-        with NamedTemporaryFile(suffix='.mol2') as iofile:
-            ethanol.to_file(iofile.name, file_format='mol2', toolkit_registry=toolkit_wrapper)
-            ethanol2 = Molecule.from_file(iofile.name, file_format='mol2', toolkit_registry=toolkit_wrapper)
-        np.testing.assert_allclose(ethanol.partial_charges / unit.elementary_charge,
-                                   ethanol2.partial_charges / unit.elementary_charge)
+        with NamedTemporaryFile(suffix=".mol2") as iofile:
+            ethanol.to_file(
+                iofile.name, file_format="mol2", toolkit_registry=toolkit_wrapper
+            )
+            ethanol2 = Molecule.from_file(
+                iofile.name, file_format="mol2", toolkit_registry=toolkit_wrapper
+            )
+        np.testing.assert_allclose(
+            ethanol.partial_charges / unit.elementary_charge,
+            ethanol2.partial_charges / unit.elementary_charge,
+        )
 
         # Now test with no properties or charges
         ethanol = create_ethanol()
         ethanol.partial_charges = None
         # Write ethanol to a temporary file, and then immediately read it.
-        with NamedTemporaryFile(suffix='.mol2') as iofile:
-            ethanol.to_file(iofile.name, file_format='mol2', toolkit_registry=toolkit_wrapper)
-            ethanol2 = Molecule.from_file(iofile.name, file_format='mol2', toolkit_registry=toolkit_wrapper)
+        with NamedTemporaryFile(suffix=".mol2") as iofile:
+            ethanol.to_file(
+                iofile.name, file_format="mol2", toolkit_registry=toolkit_wrapper
+            )
+            ethanol2 = Molecule.from_file(
+                iofile.name, file_format="mol2", toolkit_registry=toolkit_wrapper
+            )
         assert ethanol2.partial_charges is None
         assert ethanol2.properties == {}
 
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_get_mol2_gaff_atom_types(self):
         """Test that a warning is raised OpenEyeToolkitWrapper when it detects GAFF atom types in a mol2 file."""
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        mol2_file_path = get_data_file_path('molecules/AlkEthOH_test_filt1_ff.mol2')
-        with pytest.warns(GAFFAtomTypeWarning, match='SYBYL'):
+        mol2_file_path = get_data_file_path("molecules/AlkEthOH_test_filt1_ff.mol2")
+        with pytest.warns(GAFFAtomTypeWarning, match="SYBYL"):
             Molecule.from_file(mol2_file_path, toolkit_registry=toolkit_wrapper)
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_generate_conformers(self):
         """Test OpenEyeToolkitWrapper generate_conformers()"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        smiles = '[H]C([H])([H])C([H])([H])[H]'
+        smiles = "[H]C([H])([H])C([H])([H])[H]"
         molecule = toolkit_wrapper.from_smiles(smiles)
         molecule.generate_conformers()
         assert molecule.n_conformers != 0
-        assert not(molecule.conformers[0] == (0.*unit.angstrom)).all()
+        assert not (molecule.conformers[0] == (0.0 * unit.angstrom)).all()
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_generate_multiple_conformers(self):
         """Test OpenEyeToolkitWrapper generate_conformers() for generating multiple conformers"""
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        smiles = 'CCCCCCC'
+        smiles = "CCCCCCC"
         molecule = toolkit_wrapper.from_smiles(smiles)
-        molecule.generate_conformers(rms_cutoff=1*unit.angstrom,
-                                     n_conformers=100,
-                                     toolkit_registry=toolkit_wrapper)
+        molecule.generate_conformers(
+            rms_cutoff=1 * unit.angstrom,
+            n_conformers=100,
+            toolkit_registry=toolkit_wrapper,
+        )
         assert molecule.n_conformers > 1
-        assert not(molecule.conformers[0] == (0.*unit.angstrom)).all()
+        assert not (molecule.conformers[0] == (0.0 * unit.angstrom)).all()
 
         # Ensure rms_cutoff kwarg is working
         molecule2 = toolkit_wrapper.from_smiles(smiles)
-        molecule2.generate_conformers(rms_cutoff=0.1*unit.angstrom,
-                                      n_conformers=100,
-                                      toolkit_registry=toolkit_wrapper)
+        molecule2.generate_conformers(
+            rms_cutoff=0.1 * unit.angstrom,
+            n_conformers=100,
+            toolkit_registry=toolkit_wrapper,
+        )
         assert molecule2.n_conformers > molecule.n_conformers
 
         # Ensure n_conformers kwarg is working
         molecule2 = toolkit_wrapper.from_smiles(smiles)
-        molecule2.generate_conformers(rms_cutoff=0.1*unit.angstrom,
-                                      n_conformers=10,
-                                      toolkit_registry=toolkit_wrapper)
+        molecule2.generate_conformers(
+            rms_cutoff=0.1 * unit.angstrom,
+            n_conformers=10,
+            toolkit_registry=toolkit_wrapper,
+        )
         assert molecule2.n_conformers == 10
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_compute_partial_charges_am1bcc(self):
         """Test OpenEyeToolkitWrapper compute_partial_charges_am1bcc()"""
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper])
         molecule = create_ethanol()
-        molecule.compute_partial_charges_am1bcc(toolkit_registry=toolkit_registry)  # , charge_model=charge_model)
+        molecule.compute_partial_charges_am1bcc(
+            toolkit_registry=toolkit_registry
+        )  # , charge_model=charge_model)
         charge_sum = 0 * unit.elementary_charge
         abs_charge_sum = 0 * unit.elementary_charge
         for pc in molecule._partial_charges:
@@ -719,7 +1011,9 @@ class TestOpenEyeToolkitWrapper:
         assert abs(charge_sum) < 0.005 * unit.elementary_charge
         assert abs_charge_sum > 0.25 * unit.elementary_charge
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_compute_partial_charges_am1bcc_net_charge(self):
         """Test OpenEyeToolkitWrapper assign_partial_charges() on a molecule with a net +1 charge"""
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper])
@@ -728,9 +1022,15 @@ class TestOpenEyeToolkitWrapper:
         charge_sum = 0 * unit.elementary_charge
         for pc in molecule._partial_charges:
             charge_sum += pc
-        assert -0.999 * unit.elementary_charge > charge_sum > -1.001 * unit.elementary_charge
+        assert (
+            -0.999 * unit.elementary_charge
+            > charge_sum
+            > -1.001 * unit.elementary_charge
+        )
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_compute_partial_charges_am1bcc_wrong_n_confs(self):
         """
         Test OpenEyeToolkitWrapper compute_partial_charges_am1bcc() when requesting to use an incorrect number of
@@ -738,150 +1038,206 @@ class TestOpenEyeToolkitWrapper:
         ELF10 multiconformer method of AM1BCC, which doesn't have a maximum number of conformers.
         """
         from openforcefield.tests.test_forcefield import create_ethanol
+
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper])
         molecule = create_ethanol()
-        molecule.generate_conformers(n_conformers=2,
-                                     rms_cutoff=0.1*unit.angstrom,
-                                     toolkit_registry=toolkit_registry)
+        molecule.generate_conformers(
+            n_conformers=2,
+            rms_cutoff=0.1 * unit.angstrom,
+            toolkit_registry=toolkit_registry,
+        )
 
         # Try again, with strict_n_confs as true, but not including use_confs, so the
         # recommended number of confs will be generated
-        molecule.compute_partial_charges_am1bcc(toolkit_registry=toolkit_registry,
-                                                strict_n_conformers=True)
+        molecule.compute_partial_charges_am1bcc(
+            toolkit_registry=toolkit_registry, strict_n_conformers=True
+        )
 
-
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
-    @pytest.mark.parametrize("partial_charge_method", ['am1bcc', 'am1elf10', 'am1-mulliken', 'gasteiger'])
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
+    @pytest.mark.parametrize(
+        "partial_charge_method", ["am1bcc", "am1elf10", "am1-mulliken", "gasteiger"]
+    )
     def test_assign_partial_charges_neutral(self, partial_charge_method):
         """Test OpenEyeToolkitWrapper assign_partial_charges()"""
         from openforcefield.tests.test_forcefield import create_ethanol
+
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper])
         molecule = create_ethanol()
-        molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                        partial_charge_method=partial_charge_method)
-        charge_sum = 0. * unit.elementary_charge
+        molecule.assign_partial_charges(
+            toolkit_registry=toolkit_registry,
+            partial_charge_method=partial_charge_method,
+        )
+        charge_sum = 0.0 * unit.elementary_charge
         for pc in molecule.partial_charges:
             charge_sum += pc
-        assert -1.e-5 < charge_sum.value_in_unit(unit.elementary_charge) < 1.e-5
+        assert -1.0e-5 < charge_sum.value_in_unit(unit.elementary_charge) < 1.0e-5
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
-    @pytest.mark.parametrize("partial_charge_method", ['am1bcc', 'am1-mulliken'])
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
+    @pytest.mark.parametrize("partial_charge_method", ["am1bcc", "am1-mulliken"])
     def test_assign_partial_charges_conformer_dependence(self, partial_charge_method):
         """Test OpenEyeToolkitWrapper assign_partial_charges()'s use_conformers kwarg
         to ensure charges are really conformer dependent. Skip Gasteiger because it isn't
         conformer dependent."""
         from openforcefield.tests.test_forcefield import create_ethanol
         import copy
+
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper])
         molecule = create_ethanol()
         molecule.generate_conformers(n_conformers=1)
-        molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                        partial_charge_method=partial_charge_method,
-                                        use_conformers=molecule.conformers)
+        molecule.assign_partial_charges(
+            toolkit_registry=toolkit_registry,
+            partial_charge_method=partial_charge_method,
+            use_conformers=molecule.conformers,
+        )
         pcs1 = copy.deepcopy(molecule.partial_charges)
         molecule._conformers[0][0][0] += 0.2 * unit.angstrom
         molecule._conformers[0][1][1] -= 0.2 * unit.angstrom
         molecule._conformers[0][2][1] += 0.2 * unit.angstrom
-        molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                        partial_charge_method=partial_charge_method,
-                                        use_conformers=molecule.conformers)
+        molecule.assign_partial_charges(
+            toolkit_registry=toolkit_registry,
+            partial_charge_method=partial_charge_method,
+            use_conformers=molecule.conformers,
+        )
         for pc1, pc2 in zip(pcs1, molecule.partial_charges):
-            assert abs(pc1 - pc2) > 1.e-5 * unit.elementary_charge
+            assert abs(pc1 - pc2) > 1.0e-5 * unit.elementary_charge
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
-    @pytest.mark.parametrize("partial_charge_method", ['am1bcc', 'am1elf10', 'am1-mulliken', 'gasteiger'])
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
+    @pytest.mark.parametrize(
+        "partial_charge_method", ["am1bcc", "am1elf10", "am1-mulliken", "gasteiger"]
+    )
     def test_assign_partial_charges_net_charge(self, partial_charge_method):
         """
         Test OpenEyeToolkitWrapper assign_partial_charges() on a molecule with net charge.
         """
         from openforcefield.tests.test_forcefield import create_acetate
+
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper])
         molecule = create_acetate()
-        molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                        partial_charge_method=partial_charge_method)
-        charge_sum = 0. * unit.elementary_charge
+        molecule.assign_partial_charges(
+            toolkit_registry=toolkit_registry,
+            partial_charge_method=partial_charge_method,
+        )
+        charge_sum = 0.0 * unit.elementary_charge
         for pc in molecule.partial_charges:
             charge_sum += pc
-        assert -1.e-5 < charge_sum.value_in_unit(unit.elementary_charge) + 1. < 1.e-5
+        assert -1.0e-5 < charge_sum.value_in_unit(unit.elementary_charge) + 1.0 < 1.0e-5
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_assign_partial_charges_bad_charge_method(self):
         """Test OpenEyeToolkitWrapper assign_partial_charges() for a nonexistent charge method"""
         from openforcefield.tests.test_forcefield import create_ethanol
+
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper])
         molecule = create_ethanol()
 
         # Molecule.assign_partial_charges calls the ToolkitRegistry with raise_exception_types = [],
         # which means it will only ever return ValueError
-        with pytest.raises(ValueError, match="is not available from OpenEyeToolkitWrapper") as excinfo:
-            molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                            partial_charge_method="NotARealChargeMethod")
+        with pytest.raises(
+            ValueError, match="is not available from OpenEyeToolkitWrapper"
+        ) as excinfo:
+            molecule.assign_partial_charges(
+                toolkit_registry=toolkit_registry,
+                partial_charge_method="NotARealChargeMethod",
+            )
 
         # ToolkitWrappers raise a specific exception class, so we test that here
-        with pytest.raises(ChargeMethodUnavailableError, match="is not available from OpenEyeToolkitWrapper") as excinfo:
+        with pytest.raises(
+            ChargeMethodUnavailableError,
+            match="is not available from OpenEyeToolkitWrapper",
+        ) as excinfo:
             OETKW = OpenEyeToolkitWrapper()
-            OETKW.assign_partial_charges(molecule=molecule,
-                                         partial_charge_method="NotARealChargeMethod")
+            OETKW.assign_partial_charges(
+                molecule=molecule, partial_charge_method="NotARealChargeMethod"
+            )
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
-    @pytest.mark.parametrize("partial_charge_method,expected_n_confs", [('am1bcc', 1),
-                                                                        ('am1-mulliken', 1),
-                                                                        ('gasteiger', 0)])
-    def test_assign_partial_charges_wrong_n_confs(self, partial_charge_method, expected_n_confs):
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
+    @pytest.mark.parametrize(
+        "partial_charge_method,expected_n_confs",
+        [("am1bcc", 1), ("am1-mulliken", 1), ("gasteiger", 0)],
+    )
+    def test_assign_partial_charges_wrong_n_confs(
+        self, partial_charge_method, expected_n_confs
+    ):
         """
         Test OpenEyeToolkitWrapper assign_partial_charges() when requesting to use an incorrect number of
         conformers
         """
         from openforcefield.tests.test_forcefield import create_ethanol
+
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper])
         molecule = create_ethanol()
-        molecule.generate_conformers(n_conformers=2, rms_cutoff=0.01*unit.angstrom)
+        molecule.generate_conformers(n_conformers=2, rms_cutoff=0.01 * unit.angstrom)
 
         # Try passing in the incorrect number of confs, but without specifying strict_n_conformers,
         # which should produce a warning
-        with pytest.warns(IncorrectNumConformersWarning,
-                          match=f"has 2 conformers, but charge method '{partial_charge_method}' "
-                                f"expects exactly {expected_n_confs}."):
-            molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                            partial_charge_method=partial_charge_method,
-                                            use_conformers=molecule.conformers,
-                                            strict_n_conformers=False)
+        with pytest.warns(
+            IncorrectNumConformersWarning,
+            match=f"has 2 conformers, but charge method '{partial_charge_method}' "
+            f"expects exactly {expected_n_confs}.",
+        ):
+            molecule.assign_partial_charges(
+                toolkit_registry=toolkit_registry,
+                partial_charge_method=partial_charge_method,
+                use_conformers=molecule.conformers,
+                strict_n_conformers=False,
+            )
 
         # Try again, with strict_n_confs as true, but not including use_confs, so the
         # recommended number of confs will be generated
-        molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                        partial_charge_method=partial_charge_method,
-                                        strict_n_conformers=True)
+        molecule.assign_partial_charges(
+            toolkit_registry=toolkit_registry,
+            partial_charge_method=partial_charge_method,
+            strict_n_conformers=True,
+        )
 
         # Test calling the ToolkitWrapper _indirectly_, though a ToolkitRegistry,
         # which should aggregate any exceptions and bundle all of the messages
         # in a failed task together in a single ValueError.
-        with pytest.raises(ValueError,
-                           match=f"has 2 conformers, but charge method '{partial_charge_method}' "
-                                 f"expects exactly {expected_n_confs}."):
-            molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                            partial_charge_method=partial_charge_method,
-                                            use_conformers=molecule.conformers,
-                                            strict_n_conformers=True)
+        with pytest.raises(
+            ValueError,
+            match=f"has 2 conformers, but charge method '{partial_charge_method}' "
+            f"expects exactly {expected_n_confs}.",
+        ):
+            molecule.assign_partial_charges(
+                toolkit_registry=toolkit_registry,
+                partial_charge_method=partial_charge_method,
+                use_conformers=molecule.conformers,
+                strict_n_conformers=True,
+            )
 
         # Test calling the ToolkitWrapper _directly_, passing in the incorrect number of
         # confs, and specify strict_n_conformers, which should produce an IncorrectNumConformersError
-        with pytest.raises(IncorrectNumConformersError,
-                           match=f"has 2 conformers, but charge method '{partial_charge_method}' "
-                                 f"expects exactly {expected_n_confs}."):
+        with pytest.raises(
+            IncorrectNumConformersError,
+            match=f"has 2 conformers, but charge method '{partial_charge_method}' "
+            f"expects exactly {expected_n_confs}.",
+        ):
             OETKW = OpenEyeToolkitWrapper()
-            OETKW.assign_partial_charges(molecule=molecule,
-                                         partial_charge_method=partial_charge_method,
-                                         use_conformers=molecule.conformers,
-                                         strict_n_conformers=True)
+            OETKW.assign_partial_charges(
+                molecule=molecule,
+                partial_charge_method=partial_charge_method,
+                use_conformers=molecule.conformers,
+                strict_n_conformers=True,
+            )
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_compute_partial_charges_failure(self):
         """Test OpenEyeToolkitWrapper compute_partial_charges() on a molecule it cannot assign charges to"""
 
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        smiles = '[Li+1]'
+        smiles = "[Li+1]"
         molecule = toolkit_wrapper.from_smiles(smiles)
         molecule.generate_conformers(toolkit_registry=toolkit_wrapper)
 
@@ -891,8 +1247,9 @@ class TestOpenEyeToolkitWrapper:
             assert "Unable to assign charges" in str(excinfo)
             assert "OE Error: " in str(excinfo)
 
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_compute_partial_charges_trans_cooh_am1bcc(self):
         """Test OpenEyeToolkitWrapper for computing partial charges for problematic molecules, as exemplified by
         Issue 346 (https://github.com/openforcefield/openforcefield/issues/346)"""
@@ -902,125 +1259,146 @@ class TestOpenEyeToolkitWrapper:
         lysine.generate_conformers(toolkit_registry=toolkit_wrapper)
         lysine.compute_partial_charges_am1bcc(toolkit_registry=toolkit_wrapper)
 
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_assign_fractional_bond_orders(self):
         """Test OpenEyeToolkitWrapper assign_fractional_bond_orders()"""
 
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        smiles = '[H]C([H])([H])C([H])([H])[H]'
+        smiles = "[H]C([H])([H])C([H])([H])[H]"
         molecule = toolkit_wrapper.from_smiles(smiles)
         molecule.generate_conformers(toolkit_registry=toolkit_wrapper)
-        for bond_order_model in ['am1-wiberg', 'pm3-wiberg']:
-            molecule.assign_fractional_bond_orders(toolkit_registry=toolkit_wrapper,
-                                                    bond_order_model=bond_order_model)
+        for bond_order_model in ["am1-wiberg", "pm3-wiberg"]:
+            molecule.assign_fractional_bond_orders(
+                toolkit_registry=toolkit_wrapper, bond_order_model=bond_order_model
+            )
             # TODO: Add test for equivalent Wiberg orders for equivalent bonds
 
-
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_assign_fractional_bond_orders_neutral_charge_mol(self):
         """Test OpenEyeToolkitWrapper assign_fractional_bond_orders() for neutral and charged molecule"""
 
         toolkit_wrapper = OpenEyeToolkitWrapper()
         # Reading neutral molecule from file
-        filename = get_data_file_path('molecules/CID20742535_neutral.sdf')
+        filename = get_data_file_path("molecules/CID20742535_neutral.sdf")
         molecule1 = Molecule.from_file(filename)
         # Reading negative molecule from file
-        filename = get_data_file_path('molecules/CID20742535_anion.sdf')
+        filename = get_data_file_path("molecules/CID20742535_anion.sdf")
         molecule2 = Molecule.from_file(filename)
 
         # Checking that only one additional bond is present in the neutral molecule
-        assert (len(molecule1.bonds) == len(molecule2.bonds)+1)
+        assert len(molecule1.bonds) == len(molecule2.bonds) + 1
 
-        for bond_order_model in ['am1-wiberg']:
-            molecule1.assign_fractional_bond_orders(toolkit_registry=toolkit_wrapper,
-                                                    bond_order_model=bond_order_model,
-                                                    use_conformers=molecule1.conformers)
+        for bond_order_model in ["am1-wiberg"]:
+            molecule1.assign_fractional_bond_orders(
+                toolkit_registry=toolkit_wrapper,
+                bond_order_model=bond_order_model,
+                use_conformers=molecule1.conformers,
+            )
 
             for i in molecule1.bonds:
                 if i.is_aromatic:
                     # Checking aromatic bonds
-                    assert (1.05 < i.fractional_bond_order < 1.65)
-                elif (i.atom1.atomic_number == 1 or i.atom2.atomic_number == 1):
+                    assert 1.05 < i.fractional_bond_order < 1.65
+                elif i.atom1.atomic_number == 1 or i.atom2.atomic_number == 1:
                     # Checking bond order of C-H or O-H bonds are around 1
-                    assert (0.85 < i.fractional_bond_order < 1.05)
-                elif (i.atom1.atomic_number == 8 or i.atom2.atomic_number == 8):
+                    assert 0.85 < i.fractional_bond_order < 1.05
+                elif i.atom1.atomic_number == 8 or i.atom2.atomic_number == 8:
                     # Checking C-O single bond
                     wbo_C_O_neutral = i.fractional_bond_order
-                    assert (1.0 < wbo_C_O_neutral < 1.5)
+                    assert 1.0 < wbo_C_O_neutral < 1.5
                 else:
                     # Should be C-C single bond
-                    assert (i.atom1_index == 4 and i.atom2_index == 6) or (i.atom1_index == 6 and i.atom2_index == 4)
+                    assert (i.atom1_index == 4 and i.atom2_index == 6) or (
+                        i.atom1_index == 6 and i.atom2_index == 4
+                    )
                     wbo_C_C_neutral = i.fractional_bond_order
-                    assert (1.0 < wbo_C_C_neutral < 1.3)
+                    assert 1.0 < wbo_C_C_neutral < 1.3
 
-            molecule2.assign_fractional_bond_orders(toolkit_registry=toolkit_wrapper,
-                                                    bond_order_model=bond_order_model,
-                                                    use_conformers=molecule2.conformers)
+            molecule2.assign_fractional_bond_orders(
+                toolkit_registry=toolkit_wrapper,
+                bond_order_model=bond_order_model,
+                use_conformers=molecule2.conformers,
+            )
             for i in molecule2.bonds:
                 if i.is_aromatic:
                     # Checking aromatic bonds
-                    assert (1.05 < i.fractional_bond_order < 1.65)
-                elif (i.atom1.atomic_number == 1 or i.atom2.atomic_number == 1):
+                    assert 1.05 < i.fractional_bond_order < 1.65
+                elif i.atom1.atomic_number == 1 or i.atom2.atomic_number == 1:
                     # Checking bond order of C-H or O-H bonds are around 1
-                    assert (0.85 < i.fractional_bond_order < 1.05)
-                elif (i.atom1.atomic_number == 8 or i.atom2.atomic_number == 8):
+                    assert 0.85 < i.fractional_bond_order < 1.05
+                elif i.atom1.atomic_number == 8 or i.atom2.atomic_number == 8:
                     # Checking C-O single bond
                     wbo_C_O_anion = i.fractional_bond_order
-                    assert (1.3 < wbo_C_O_anion < 1.8)
+                    assert 1.3 < wbo_C_O_anion < 1.8
                 else:
                     # Should be C-C single bond
-                    assert(i.atom1_index == 4 and i.atom2_index == 6) or (i.atom1_index == 6 and i.atom2_index == 4)
+                    assert (i.atom1_index == 4 and i.atom2_index == 6) or (
+                        i.atom1_index == 6 and i.atom2_index == 4
+                    )
                     wbo_C_C_anion = i.fractional_bond_order
-                    assert (1.0 < wbo_C_C_anion < 1.3)
+                    assert 1.0 < wbo_C_C_anion < 1.3
 
             # Wiberg bond order of C-C single bond is higher in the anion
-            assert (wbo_C_C_anion > wbo_C_C_neutral)
+            assert wbo_C_C_anion > wbo_C_C_neutral
             # Wiberg bond order of C-O bond is higher in the anion
-            assert (wbo_C_O_anion > wbo_C_O_neutral)
+            assert wbo_C_O_anion > wbo_C_O_neutral
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_assign_fractional_bond_orders_charged(self):
         """Test OpenEyeToolkitWrapper assign_fractional_bond_orders() on a molecule with net charge +1"""
 
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        smiles = '[H]C([H])([H])[N+]([H])([H])[H]'
+        smiles = "[H]C([H])([H])[N+]([H])([H])[H]"
         molecule = toolkit_wrapper.from_smiles(smiles)
         molecule.generate_conformers(toolkit_registry=toolkit_wrapper)
-        for bond_order_model in ['am1-wiberg', 'pm3-wiberg']:
-            molecule.assign_fractional_bond_orders(toolkit_registry=toolkit_wrapper,
-                                                   bond_order_model=bond_order_model)
+        for bond_order_model in ["am1-wiberg", "pm3-wiberg"]:
+            molecule.assign_fractional_bond_orders(
+                toolkit_registry=toolkit_wrapper, bond_order_model=bond_order_model
+            )
             # TODO: Add test for equivalent Wiberg orders for equivalent bonds
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_assign_fractional_bond_orders_invalid_method(self):
         """
         Test that OpenEyeToolkitWrapper assign_fractional_bond_orders() raises the
         correct error if an invalid charge model is provided
         """
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        smiles = '[H]C([H])([H])[N+]([H])([H])[H]'
+        smiles = "[H]C([H])([H])[N+]([H])([H])[H]"
         molecule = toolkit_wrapper.from_smiles(smiles)
         molecule.generate_conformers(toolkit_registry=toolkit_wrapper)
-        expected_error = "Bond order model 'not a real bond order model' is not supported by " \
-                         "OpenEyeToolkitWrapper. Supported models are ([[]'am1-wiberg', 'pm3-wiberg'[]])"
+        expected_error = (
+            "Bond order model 'not a real bond order model' is not supported by "
+            "OpenEyeToolkitWrapper. Supported models are ([[]'am1-wiberg', 'pm3-wiberg'[]])"
+        )
         with pytest.raises(ValueError, match=expected_error) as excinfo:
-            molecule.assign_fractional_bond_orders(toolkit_registry=toolkit_wrapper,
-                                                    bond_order_model='not a real bond order model')
+            molecule.assign_fractional_bond_orders(
+                toolkit_registry=toolkit_wrapper,
+                bond_order_model="not a real bond order model",
+            )
 
-
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_assign_fractional_bond_orders_double_bond(self):
         """Test OpenEyeToolkitWrapper assign_fractional_bond_orders() on a molecule with a double bond"""
 
         toolkit_wrapper = OpenEyeToolkitWrapper()
-        smiles = r'C\C(F)=C(/F)C[C@@](C)(Cl)Br'
+        smiles = r"C\C(F)=C(/F)C[C@@](C)(Cl)Br"
         molecule = toolkit_wrapper.from_smiles(smiles)
         molecule.generate_conformers(toolkit_registry=toolkit_wrapper)
-        for bond_order_model in ['am1-wiberg', 'pm3-wiberg']:
-            molecule.assign_fractional_bond_orders(toolkit_registry=toolkit_wrapper,
-                                                   bond_order_model=bond_order_model)
+        for bond_order_model in ["am1-wiberg", "pm3-wiberg"]:
+            molecule.assign_fractional_bond_orders(
+                toolkit_registry=toolkit_wrapper, bond_order_model=bond_order_model
+            )
             # TODO: Add test for equivalent Wiberg orders for equivalent bonds
 
         double_bond_has_wbo_near_2 = False
@@ -1031,12 +1409,14 @@ class TestOpenEyeToolkitWrapper:
         assert double_bond_has_wbo_near_2
 
     @pytest.mark.slow
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_substructure_search_on_large_molecule(self):
         """Test OpenEyeToolkitWrapper substructure search when a large number hits are found"""
 
         tk = OpenEyeToolkitWrapper()
-        smiles = "C"*600
+        smiles = "C" * 600
         molecule = tk.from_smiles(smiles)
         query = "[C:1]~[C:2]"
         ret = molecule.chemical_environment_matches(query, toolkit_registry=tk)
@@ -1055,29 +1435,33 @@ class TestOpenEyeToolkitWrapper:
             assert ethanol.atoms[bond.atom2_index].atomic_number != 1
 
         # now ignore the C-O bond, forwards
-        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups='[#6:1]-[#8:2]')
+        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups="[#6:1]-[#8:2]")
         assert len(bonds) == 1
         assert ethanol.atoms[bonds[0].atom1_index].atomic_number == 6
         assert ethanol.atoms[bonds[0].atom2_index].atomic_number == 6
 
         # now ignore the O-C bond, backwards
-        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups='[#8:1]-[#6:2]')
+        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups="[#8:1]-[#6:2]")
         assert len(bonds) == 1
         assert ethanol.atoms[bonds[0].atom1_index].atomic_number == 6
         assert ethanol.atoms[bonds[0].atom2_index].atomic_number == 6
 
         # now ignore the C-C bond
-        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups='[#6:1]-[#6:2]')
+        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups="[#6:1]-[#6:2]")
         assert len(bonds) == 1
         assert ethanol.atoms[bonds[0].atom1_index].atomic_number == 6
         assert ethanol.atoms[bonds[0].atom2_index].atomic_number == 8
 
         # ignore a list of searches, forward
-        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups=['[#6:1]-[#8:2]', '[#6:1]-[#6:2]'])
+        bonds = ethanol.find_rotatable_bonds(
+            ignore_functional_groups=["[#6:1]-[#8:2]", "[#6:1]-[#6:2]"]
+        )
         assert bonds == []
 
         # ignore a list of searches, backwards
-        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups=['[#6:1]-[#6:2]', '[#8:1]-[#6:2]'])
+        bonds = ethanol.find_rotatable_bonds(
+            ignore_functional_groups=["[#6:1]-[#6:2]", "[#8:1]-[#6:2]"]
+        )
         assert bonds == []
 
         # test  molecules that should have no rotatable bonds
@@ -1085,18 +1469,18 @@ class TestOpenEyeToolkitWrapper:
         bonds = cyclohexane.find_rotatable_bonds()
         assert bonds == []
 
-        methane = Molecule.from_smiles('C')
+        methane = Molecule.from_smiles("C")
         bonds = methane.find_rotatable_bonds()
         assert bonds == []
 
-        ethene = Molecule.from_smiles('C=C')
+        ethene = Molecule.from_smiles("C=C")
         bonds = ethene.find_rotatable_bonds()
         assert bonds == []
 
-        terminal_forwards = '[*]~[*:1]-[X2H1,X3H2,X4H3:2]-[#1]'
-        terminal_backwards = '[#1]-[X2H1,X3H2,X4H3:1]-[*:2]~[*]'
+        terminal_forwards = "[*]~[*:1]-[X2H1,X3H2,X4H3:2]-[#1]"
+        terminal_backwards = "[#1]-[X2H1,X3H2,X4H3:1]-[*:2]~[*]"
         # test removing terminal rotors
-        toluene = Molecule.from_file(get_data_file_path('molecules/toluene.sdf'))
+        toluene = Molecule.from_file(get_data_file_path("molecules/toluene.sdf"))
         bonds = toluene.find_rotatable_bonds()
         assert len(bonds) == 1
         assert toluene.atoms[bonds[0].atom1_index].atomic_number == 6
@@ -1107,40 +1491,46 @@ class TestOpenEyeToolkitWrapper:
         assert bonds == []
 
         # find terminal bonds backwards
-        bonds = toluene.find_rotatable_bonds(ignore_functional_groups=terminal_backwards)
+        bonds = toluene.find_rotatable_bonds(
+            ignore_functional_groups=terminal_backwards
+        )
         assert bonds == []
-        
-        
+
         # TODO: Check partial charge invariants (total charge, charge equivalence)
 
         # TODO: Add test for aromaticity
         # TODO: Add test and molecule functionality for isotopes
 
 
-
 class TestRDKitToolkitWrapper:
     """Test the RDKitToolkitWrapper"""
-    
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_smiles(self):
         """Test RDKitToolkitWrapper to_smiles() and from_smiles()"""
         toolkit_wrapper = RDKitToolkitWrapper()
         # This differs from OE's expected output due to different canonicalization schemes
-        smiles = '[H][C]([H])([H])[C]([H])([H])[H]'
-        molecule = Molecule.from_smiles(smiles,
-                                        toolkit_registry=toolkit_wrapper)
+        smiles = "[H][C]([H])([H])[C]([H])([H])[H]"
+        molecule = Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
         # When making a molecule from SMILES, partial charges should be initialized to None
         assert molecule.partial_charges is None
         smiles2 = molecule.to_smiles(toolkit_registry=toolkit_wrapper)
-        #print(smiles, smiles2)
+        # print(smiles, smiles2)
         assert smiles == smiles2
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
-    @pytest.mark.parametrize("smiles,exception_regex", [
-        (r"C\C(F)=C(/F)CC(C)(Cl)Br", "Undefined chiral centers"),
-        (r"C\C(F)=C(/F)C[C@@](C)(Cl)Br", None),
-        (r"CC(F)=C(F)C[C@@](C)(Cl)Br", "Bonds with undefined stereochemistry")
-    ])
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
+    @pytest.mark.parametrize(
+        "smiles,exception_regex",
+        [
+            (r"C\C(F)=C(/F)CC(C)(Cl)Br", "Undefined chiral centers"),
+            (r"C\C(F)=C(/F)C[C@@](C)(Cl)Br", None),
+            (r"CC(F)=C(F)C[C@@](C)(Cl)Br", "Bonds with undefined stereochemistry"),
+        ],
+    )
     def test_smiles_missing_stereochemistry(self, smiles, exception_regex):
         """Test RDKitToolkitWrapper to_smiles() and from_smiles() when given ambiguous stereochemistry"""
         toolkit_wrapper = RDKitToolkitWrapper()
@@ -1148,27 +1538,30 @@ class TestRDKitToolkitWrapper:
         if exception_regex is not None:
             with pytest.raises(UndefinedStereochemistryError, match=exception_regex):
                 Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
-            Molecule.from_smiles(smiles,
-                                 toolkit_registry=toolkit_wrapper,
-                                 allow_undefined_stereo=True)
+            Molecule.from_smiles(
+                smiles, toolkit_registry=toolkit_wrapper, allow_undefined_stereo=True
+            )
         else:
             Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
 
     # TODO: test_smiles_round_trip
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_smiles_add_H(self):
         """Test RDKitToolkitWrapper to_smiles() and from_smiles()"""
         toolkit_wrapper = RDKitToolkitWrapper()
-        input_smiles = 'CC'
+        input_smiles = "CC"
         # This differs from OE's expected output due to different canonicalization schemes
-        expected_output_smiles = '[H][C]([H])([H])[C]([H])([H])[H]'
-        molecule = Molecule.from_smiles(input_smiles,
-                                        toolkit_registry=toolkit_wrapper)
+        expected_output_smiles = "[H][C]([H])([H])[C]([H])([H])[H]"
+        molecule = Molecule.from_smiles(input_smiles, toolkit_registry=toolkit_wrapper)
         smiles2 = molecule.to_smiles(toolkit_registry=toolkit_wrapper)
         assert smiles2 == expected_output_smiles
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_rdkit_from_smiles_hydrogens_are_explicit(self):
         """
         Test to ensure that RDKitToolkitWrapper.from_smiles has the proper behavior with
@@ -1176,78 +1569,107 @@ class TestRDKitToolkitWrapper:
         """
         toolkit_wrapper = RDKitToolkitWrapper()
         smiles_impl = "C#C"
-        with pytest.raises(ValueError,
-                           match="but RDKit toolkit interpreted SMILES 'C#C' as having implicit hydrogen") as excinfo:
-            offmol = Molecule.from_smiles(smiles_impl,
-                                          toolkit_registry=toolkit_wrapper,
-                                          hydrogens_are_explicit=True)
-        offmol = Molecule.from_smiles(smiles_impl,
-                                      toolkit_registry=toolkit_wrapper,
-                                      hydrogens_are_explicit=False)
+        with pytest.raises(
+            ValueError,
+            match="but RDKit toolkit interpreted SMILES 'C#C' as having implicit hydrogen",
+        ) as excinfo:
+            offmol = Molecule.from_smiles(
+                smiles_impl,
+                toolkit_registry=toolkit_wrapper,
+                hydrogens_are_explicit=True,
+            )
+        offmol = Molecule.from_smiles(
+            smiles_impl, toolkit_registry=toolkit_wrapper, hydrogens_are_explicit=False
+        )
         assert offmol.n_atoms == 4
 
         smiles_expl = "[H][C]#[C][H]"
-        offmol = Molecule.from_smiles(smiles_expl,
-                                      toolkit_registry=toolkit_wrapper,
-                                      hydrogens_are_explicit=True)
+        offmol = Molecule.from_smiles(
+            smiles_expl, toolkit_registry=toolkit_wrapper, hydrogens_are_explicit=True
+        )
         assert offmol.n_atoms == 4
         # It's debatable whether this next function should pass. Strictly speaking, the hydrogens in this SMILES
         # _are_ explicit, so allowing "hydrogens_are_explicit=False" through here is allowing a contradiction.
         # We might rethink the name of this kwarg.
 
-        offmol = Molecule.from_smiles(smiles_expl,
-                                      toolkit_registry=toolkit_wrapper,
-                                      hydrogens_are_explicit=False)
+        offmol = Molecule.from_smiles(
+            smiles_expl, toolkit_registry=toolkit_wrapper, hydrogens_are_explicit=False
+        )
         assert offmol.n_atoms == 4
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
-    @pytest.mark.parametrize('molecule', get_mini_drug_bank(RDKitToolkitWrapper))
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
+    @pytest.mark.parametrize("molecule", get_mini_drug_bank(RDKitToolkitWrapper))
     def test_to_inchi(self, molecule):
         """Test conversion to standard and non-standard InChI"""
 
         toolkit = RDKitToolkitWrapper()
         inchi = molecule.to_inchi(toolkit_registry=toolkit)
-        non_standard = molecule.to_inchi(fixed_hydrogens=True,toolkit_registry=toolkit)
+        non_standard = molecule.to_inchi(fixed_hydrogens=True, toolkit_registry=toolkit)
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
-    @pytest.mark.parametrize('molecule', get_mini_drug_bank(RDKitToolkitWrapper))
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
+    @pytest.mark.parametrize("molecule", get_mini_drug_bank(RDKitToolkitWrapper))
     def test_to_inchikey(self, molecule):
         """Test the conversion to standard and non-standard InChIKey"""
 
         toolkit = RDKitToolkitWrapper()
         inchikey = molecule.to_inchikey(toolkit_registry=toolkit)
-        non_standard_key = molecule.to_inchikey(fixed_hydrogens=True, toolkit_registry=toolkit)
+        non_standard_key = molecule.to_inchikey(
+            fixed_hydrogens=True, toolkit_registry=toolkit
+        )
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_from_bad_inchi(self):
         """Test building a molecule from a bad InChI string"""
 
         toolkit = RDKitToolkitWrapper()
-        inchi = 'InChI=1S/ksbfksfksfksbfks'
+        inchi = "InChI=1S/ksbfksfksfksbfks"
         with pytest.raises(RuntimeError):
             mol = Molecule.from_inchi(inchi, toolkit_registry=toolkit)
 
-    inchi_data = [{'molecule': create_ethanol(), 'standard_inchi': 'InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3',
-                   'fixed_hydrogen_inchi': 'InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3'},
-                  {'molecule': create_reversed_ethanol(), 'standard_inchi': 'InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3',
-                   'fixed_hydrogen_inchi': 'InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3'},
-                  {'molecule': create_acetaldehyde(), 'standard_inchi': 'InChI=1S/C2H4O/c1-2-3/h2H,1H3',
-                   'fixed_hydrogen_inchi': 'InChI=1/C2H4O/c1-2-3/h2H,1H3'},
-                  {'molecule': create_cyclohexane(), 'standard_inchi': 'InChI=1S/C6H12/c1-2-4-6-5-3-1/h1-6H2',
-                   'fixed_hydrogen_inchi': 'InChI=1/C6H12/c1-2-4-6-5-3-1/h1-6H2'}
-                  ]
+    inchi_data = [
+        {
+            "molecule": create_ethanol(),
+            "standard_inchi": "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3",
+            "fixed_hydrogen_inchi": "InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3",
+        },
+        {
+            "molecule": create_reversed_ethanol(),
+            "standard_inchi": "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3",
+            "fixed_hydrogen_inchi": "InChI=1/C2H6O/c1-2-3/h3H,2H2,1H3",
+        },
+        {
+            "molecule": create_acetaldehyde(),
+            "standard_inchi": "InChI=1S/C2H4O/c1-2-3/h2H,1H3",
+            "fixed_hydrogen_inchi": "InChI=1/C2H4O/c1-2-3/h2H,1H3",
+        },
+        {
+            "molecule": create_cyclohexane(),
+            "standard_inchi": "InChI=1S/C6H12/c1-2-4-6-5-3-1/h1-6H2",
+            "fixed_hydrogen_inchi": "InChI=1/C6H12/c1-2-4-6-5-3-1/h1-6H2",
+        },
+    ]
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
-    @pytest.mark.parametrize('data', inchi_data)
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
+    @pytest.mark.parametrize("data", inchi_data)
     def test_from_inchi(self, data):
         """Test building a molecule from standard and non-standard InChI strings."""
 
         toolkit = RDKitToolkitWrapper()
 
-        ref_mol = data['molecule']
+        ref_mol = data["molecule"]
         # make a molecule from inchi
-        inchi_mol = Molecule.from_inchi(data['standard_inchi'], toolkit_registry=toolkit)
-        assert inchi_mol.to_inchi(toolkit_registry=toolkit) == data['standard_inchi']
+        inchi_mol = Molecule.from_inchi(
+            data["standard_inchi"], toolkit_registry=toolkit
+        )
+        assert inchi_mol.to_inchi(toolkit_registry=toolkit) == data["standard_inchi"]
 
         def compare_mols(ref_mol, inchi_mol):
             assert ref_mol.n_atoms == inchi_mol.n_atoms
@@ -1259,13 +1681,20 @@ class TestRDKitToolkitWrapper:
         compare_mols(ref_mol, inchi_mol)
 
         # now make the molecule from the non-standard inchi and compare
-        nonstandard_inchi_mol = Molecule.from_inchi(data['fixed_hydrogen_inchi'])
-        assert nonstandard_inchi_mol.to_inchi(fixed_hydrogens=True, toolkit_registry=toolkit) == data['fixed_hydrogen_inchi']
+        nonstandard_inchi_mol = Molecule.from_inchi(data["fixed_hydrogen_inchi"])
+        assert (
+            nonstandard_inchi_mol.to_inchi(
+                fixed_hydrogens=True, toolkit_registry=toolkit
+            )
+            == data["fixed_hydrogen_inchi"]
+        )
 
         compare_mols(ref_mol, nonstandard_inchi_mol)
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
-    @pytest.mark.parametrize('molecule', get_mini_drug_bank(RDKitToolkitWrapper))
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
+    @pytest.mark.parametrize("molecule", get_mini_drug_bank(RDKitToolkitWrapper))
     def test_non_standard_inchi_round_trip(self, molecule):
         """Test if a molecule can survive an InChi round trip test in some cases the standard InChI
         will not be enough to ensure information is preserved so we test the non-standard inchi here."""
@@ -1297,50 +1726,98 @@ class TestRDKitToolkitWrapper:
                 # Some molecules graphs change during the round trip testing
                 # we test quite strict isomorphism here
                 with pytest.raises(AssertionError):
-                    assert molecule.is_isomorphic_with(mol2, bond_order_matching=False, toolkit_registry=toolkit)
+                    assert molecule.is_isomorphic_with(
+                        mol2, bond_order_matching=False, toolkit_registry=toolkit
+                    )
             else:
-                assert molecule.is_isomorphic_with(mol2, bond_order_matching=False, toolkit_registry=toolkit)
+                assert molecule.is_isomorphic_with(
+                    mol2, bond_order_matching=False, toolkit_registry=toolkit
+                )
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_smiles_charged(self):
         """Test RDKitWrapper functions for reading/writing charged SMILES"""
         toolkit_wrapper = RDKitToolkitWrapper()
         # This differs from OE's expected output due to different canonicalization schemes
-        smiles = '[H][C]([H])([H])[N+]([H])([H])[H]'
-        molecule = Molecule.from_smiles(smiles,
-                                        toolkit_registry=toolkit_wrapper)
+        smiles = "[H][C]([H])([H])[N+]([H])([H])[H]"
+        molecule = Molecule.from_smiles(smiles, toolkit_registry=toolkit_wrapper)
         smiles2 = molecule.to_smiles(toolkit_registry=toolkit_wrapper)
         assert smiles == smiles2
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_to_from_rdkit_core_props_filled(self):
         """Test RDKitToolkitWrapper to_rdkit() and from_rdkit() when given populated core property fields"""
         toolkit_wrapper = RDKitToolkitWrapper()
 
         # Replacing with a simple molecule with stereochemistry
-        input_smiles = r'C\C(F)=C(/F)C[C@@](C)(Cl)Br'
-        expected_output_smiles = r'[H][C]([H])([H])/[C]([F])=[C](\[F])[C]([H])([H])[C@@]([Cl])([Br])[C]([H])([H])[H]'
+        input_smiles = r"C\C(F)=C(/F)C[C@@](C)(Cl)Br"
+        expected_output_smiles = r"[H][C]([H])([H])/[C]([F])=[C](\[F])[C]([H])([H])[C@@]([Cl])([Br])[C]([H])([H])[H]"
         molecule = Molecule.from_smiles(input_smiles, toolkit_registry=toolkit_wrapper)
-        assert molecule.to_smiles(toolkit_registry=toolkit_wrapper) == expected_output_smiles
+        assert (
+            molecule.to_smiles(toolkit_registry=toolkit_wrapper)
+            == expected_output_smiles
+        )
 
         # Populate core molecule property fields
-        molecule.name = 'Alice'
-        partial_charges = unit.Quantity(np.array([-.9, -.8, -.7, -.6,
-                                                  -.5, -.4, -.3, -.2,
-                                                  -.1,  0.,  .1,  .2,
-                                                   .3,  .4,  .5,  .6,
-                                                   .7,  .8]), unit.elementary_charge)
+        molecule.name = "Alice"
+        partial_charges = unit.Quantity(
+            np.array(
+                [
+                    -0.9,
+                    -0.8,
+                    -0.7,
+                    -0.6,
+                    -0.5,
+                    -0.4,
+                    -0.3,
+                    -0.2,
+                    -0.1,
+                    0.0,
+                    0.1,
+                    0.2,
+                    0.3,
+                    0.4,
+                    0.5,
+                    0.6,
+                    0.7,
+                    0.8,
+                ]
+            ),
+            unit.elementary_charge,
+        )
         molecule.partial_charges = partial_charges
-        coords = unit.Quantity(np.array([['0.0', '1.0', '2.0'],    ['3.0', '4.0', '5.0'],    ['6.0', '7.0', '8.0'],
-                                         ['9.0', '10.0', '11.0'] , ['12.0', '13.0', '14.0'], ['15.0', '16.0', '17.0'],
-                                         ['18.0', '19.0', '20.0'], ['21.0', '22.0', '23.0'], ['24.0', '25.0', '26.0'],
-                                         ['27.0', '28.0', '29.0'], ['30.0', '31.0', '32.0'], ['33.0', '34.0', '35.0'],
-                                         ['36.0', '37.0', '38.0'], ['39.0', '40.0', '41.0'], ['42.0', '43.0', '44.0'],
-                                         ['45.0', '46.0', '47.0'], ['48.0', '49.0', '50.0'], ['51.0', '52.0', '53.0']]),
-                                    unit.angstrom)
+        coords = unit.Quantity(
+            np.array(
+                [
+                    ["0.0", "1.0", "2.0"],
+                    ["3.0", "4.0", "5.0"],
+                    ["6.0", "7.0", "8.0"],
+                    ["9.0", "10.0", "11.0"],
+                    ["12.0", "13.0", "14.0"],
+                    ["15.0", "16.0", "17.0"],
+                    ["18.0", "19.0", "20.0"],
+                    ["21.0", "22.0", "23.0"],
+                    ["24.0", "25.0", "26.0"],
+                    ["27.0", "28.0", "29.0"],
+                    ["30.0", "31.0", "32.0"],
+                    ["33.0", "34.0", "35.0"],
+                    ["36.0", "37.0", "38.0"],
+                    ["39.0", "40.0", "41.0"],
+                    ["42.0", "43.0", "44.0"],
+                    ["45.0", "46.0", "47.0"],
+                    ["48.0", "49.0", "50.0"],
+                    ["51.0", "52.0", "53.0"],
+                ]
+            ),
+            unit.angstrom,
+        )
         molecule.add_conformer(coords)
         # Populate core atom property fields
-        molecule.atoms[2].name = 'Bob'
+        molecule.atoms[2].name = "Bob"
         # Ensure one atom has its stereochemistry specified
         central_carbon_stereo_specified = False
         for atom in molecule.atoms:
@@ -1358,7 +1835,7 @@ class TestRDKitToolkitWrapper:
         molecule2 = Molecule.from_rdkit(rdmol)
 
         # Test that properties survived first conversion
-        #assert molecule.to_dict() == molecule2.to_dict()
+        # assert molecule.to_dict() == molecule2.to_dict()
         assert molecule.name == molecule2.name
         # NOTE: This expects the same indexing scheme in the original and new molecule
 
@@ -1376,19 +1853,27 @@ class TestRDKitToolkitWrapper:
             pc1_ul = pc1 / unit.elementary_charge
             pc2_ul = pc2 / unit.elementary_charge
             assert_almost_equal(pc1_ul, pc2_ul, decimal=6)
-        assert molecule2.to_smiles(toolkit_registry=toolkit_wrapper) == expected_output_smiles
+        assert (
+            molecule2.to_smiles(toolkit_registry=toolkit_wrapper)
+            == expected_output_smiles
+        )
         # TODO: This should be its own test
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_to_from_rdkit_core_props_unset(self):
         """Test RDKitToolkitWrapper to_rdkit() and from_rdkit() when given empty core property fields"""
         toolkit_wrapper = RDKitToolkitWrapper()
 
         # Replacing with a simple molecule with stereochemistry
-        input_smiles = r'C\C(F)=C(/F)C[C@](C)(Cl)Br'
-        expected_output_smiles = r'[H][C]([H])([H])/[C]([F])=[C](\[F])[C]([H])([H])[C@]([Cl])([Br])[C]([H])([H])[H]'
+        input_smiles = r"C\C(F)=C(/F)C[C@](C)(Cl)Br"
+        expected_output_smiles = r"[H][C]([H])([H])/[C]([F])=[C](\[F])[C]([H])([H])[C@]([Cl])([Br])[C]([H])([H])[H]"
         molecule = Molecule.from_smiles(input_smiles, toolkit_registry=toolkit_wrapper)
-        assert molecule.to_smiles(toolkit_registry=toolkit_wrapper) == expected_output_smiles
+        assert (
+            molecule.to_smiles(toolkit_registry=toolkit_wrapper)
+            == expected_output_smiles
+        )
 
         # Ensure one atom has its stereochemistry specified
         central_carbon_stereo_specified = False
@@ -1421,150 +1906,193 @@ class TestRDKitToolkitWrapper:
         assert molecule.partial_charges is None
         assert molecule2.partial_charges is None
 
-        assert molecule2.to_smiles(toolkit_registry=toolkit_wrapper) == expected_output_smiles
+        assert (
+            molecule2.to_smiles(toolkit_registry=toolkit_wrapper)
+            == expected_output_smiles
+        )
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_file_extension_case(self):
         """
         Test round-trips of some file extensions when called directly from the toolkit wrappers,
         including lower- and uppercase file extensions. Note that this test does not ensure
         accuracy, it only tests that reading/writing without raising an exception.
         """
-        mols_in = RDKitToolkitWrapper().from_file(file_path=get_data_file_path('molecules/ethanol.sdf'), file_format='sdf')
+        mols_in = RDKitToolkitWrapper().from_file(
+            file_path=get_data_file_path("molecules/ethanol.sdf"), file_format="sdf"
+        )
 
         assert len(mols_in) > 0
 
-        mols_in = RDKitToolkitWrapper().from_file(file_path=get_data_file_path('molecules/ethanol.sdf'), file_format='SDF')
+        mols_in = RDKitToolkitWrapper().from_file(
+            file_path=get_data_file_path("molecules/ethanol.sdf"), file_format="SDF"
+        )
 
         assert len(mols_in) > 0
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_get_sdf_coordinates(self):
         """Test RDKitToolkitWrapper for importing a single set of coordinates from a sdf file"""
         toolkit_wrapper = RDKitToolkitWrapper()
-        filename = get_data_file_path('molecules/toluene.sdf')
+        filename = get_data_file_path("molecules/toluene.sdf")
         molecule = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule.conformers) == 1
         assert molecule.conformers[0].shape == (15, 3)
-        assert_almost_equal(molecule.conformers[0][5][1] / unit.angstrom, 2.0104, decimal=4)
+        assert_almost_equal(
+            molecule.conformers[0][5][1] / unit.angstrom, 2.0104, decimal=4
+        )
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_read_sdf_charges(self):
         """Test RDKitToolkitWrapper for importing a charges from a sdf file"""
         toolkit_wrapper = RDKitToolkitWrapper()
-        filename = get_data_file_path('molecules/ethanol_partial_charges.sdf')
+        filename = get_data_file_path("molecules/ethanol_partial_charges.sdf")
         molecule = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert molecule.partial_charges is not None
         assert molecule.partial_charges[0] == -0.4 * unit.elementary_charge
         assert molecule.partial_charges[-1] == 0.4 * unit.elementary_charge
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_write_sdf_charges(self):
         """Test RDKitToolkitWrapper for writing partial charges to a sdf file"""
         from io import StringIO
+
         toolkit_wrapper = RDKitToolkitWrapper()
         ethanol = create_ethanol()
         sio = StringIO()
-        ethanol.to_file(sio, 'SDF', toolkit_registry=toolkit_wrapper)
+        ethanol.to_file(sio, "SDF", toolkit_registry=toolkit_wrapper)
         sdf_text = sio.getvalue()
         # The output lines of interest here will look like
         # >  <atom.dprop.PartialCharge>  (1)
         # -0.40000000000000002 -0.29999999999999999 -0.20000000000000001 -0.10000000000000001 0.01 0.10000000000000001 0.20000000000000001 0.29999999999999999 0.40000000000000002
 
         # Parse the SDF text, grabbing the numeric line above
-        sdf_split = sdf_text.split('\n')
+        sdf_split = sdf_text.split("\n")
         charge_line_found = False
         for line in sdf_split:
             if charge_line_found:
                 charges = [float(i) for i in line.split()]
                 break
-            if '>  <atom.dprop.PartialCharge>' in line:
+            if ">  <atom.dprop.PartialCharge>" in line:
                 charge_line_found = True
 
         # Make sure that a charge line was ever found
         assert charge_line_found
 
         # Make sure that the charges found were correct
-        assert_almost_equal(charges, [-0.4, -0.3, -0.2, -0.1, 0.00001, 0.1, 0.2, 0.3, 0.4])
+        assert_almost_equal(
+            charges, [-0.4, -0.3, -0.2, -0.1, 0.00001, 0.1, 0.2, 0.3, 0.4]
+        )
 
-
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_sdf_properties_roundtrip(self):
         """Test RDKitToolkitWrapper for performing a round trip of a molecule with defined partial charges
         and entries in the properties dict to and from a sdf file"""
         toolkit_wrapper = RDKitToolkitWrapper()
         ethanol = create_ethanol()
         # Write ethanol to a temporary file, and then immediately read it.
-        with NamedTemporaryFile(suffix='.sdf') as iofile:
-            ethanol.to_file(iofile.name, file_format='SDF', toolkit_registry=toolkit_wrapper)
-            ethanol2 = Molecule.from_file(iofile.name, file_format='SDF', toolkit_registry=toolkit_wrapper)
+        with NamedTemporaryFile(suffix=".sdf") as iofile:
+            ethanol.to_file(
+                iofile.name, file_format="SDF", toolkit_registry=toolkit_wrapper
+            )
+            ethanol2 = Molecule.from_file(
+                iofile.name, file_format="SDF", toolkit_registry=toolkit_wrapper
+            )
         assert (ethanol.partial_charges == ethanol2.partial_charges).all()
 
         # Now test with no properties or charges
         ethanol = create_ethanol()
         ethanol.partial_charges = None
         # Write ethanol to a temporary file, and then immediately read it.
-        with NamedTemporaryFile(suffix='.sdf') as iofile:
-            ethanol.to_file(iofile.name, file_format='SDF', toolkit_registry=toolkit_wrapper)
-            ethanol2 = Molecule.from_file(iofile.name, file_format='SDF', toolkit_registry=toolkit_wrapper)
+        with NamedTemporaryFile(suffix=".sdf") as iofile:
+            ethanol.to_file(
+                iofile.name, file_format="SDF", toolkit_registry=toolkit_wrapper
+            )
+            ethanol2 = Molecule.from_file(
+                iofile.name, file_format="SDF", toolkit_registry=toolkit_wrapper
+            )
         assert ethanol2.partial_charges is None
         assert ethanol2.properties == {}
 
-
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_write_sdf_no_charges(self):
         """Test RDKitToolkitWrapper for writing an SDF file with no charges"""
         from io import StringIO
+
         toolkit_wrapper = RDKitToolkitWrapper()
         ethanol = create_ethanol()
         ethanol.partial_charges = None
         sio = StringIO()
-        ethanol.to_file(sio, 'SDF', toolkit_registry=toolkit_wrapper)
+        ethanol.to_file(sio, "SDF", toolkit_registry=toolkit_wrapper)
         sdf_text = sio.getvalue()
         # In our current configuration, if the OFFMol doesn't have partial charges, we DO NOT want a partial charge
         # block to be written. For reference, it's possible to indicate that a partial charge is not known by writing
         # out "n/a" (or another placeholder) in the partial charge block atoms without charges.
-        assert '>  <atom.dprop.PartialCharge>' not in sdf_text
+        assert ">  <atom.dprop.PartialCharge>" not in sdf_text
 
-
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_load_multiconformer_sdf_as_separate_molecules(self):
         """
         Test RDKitToolkitWrapper for reading a "multiconformer" SDF, which the OFF
         Toolkit should treat as separate molecules
         """
         toolkit_wrapper = RDKitToolkitWrapper()
-        filename = get_data_file_path('molecules/methane_multiconformer.sdf')
+        filename = get_data_file_path("molecules/methane_multiconformer.sdf")
         molecules = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecules) == 2
         assert len(molecules[0].conformers) == 1
         assert len(molecules[1].conformers) == 1
         assert molecules[0].conformers[0].shape == (5, 3)
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_load_multiconformer_sdf_as_separate_molecules_properties(self):
         """
         Test RDKitToolkitWrapper for reading a "multiconformer" SDF, which the OFF
         Toolkit should treat as separate molecules
         """
         toolkit_wrapper = RDKitToolkitWrapper()
-        filename = get_data_file_path('molecules/methane_multiconformer_properties.sdf')
+        filename = get_data_file_path("molecules/methane_multiconformer_properties.sdf")
         molecules = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecules) == 2
         assert len(molecules[0].conformers) == 1
         assert len(molecules[1].conformers) == 1
         assert molecules[0].conformers[0].shape == (5, 3)
         # The first molecule in the SDF has the following properties and charges:
-        assert molecules[0].properties['test_property_key'] == 'test_property_value'
-        np.testing.assert_allclose(molecules[0].partial_charges / unit.elementary_charge,
-                                          [-0.108680, 0.027170, 0.027170, 0.027170, 0.027170])
+        assert molecules[0].properties["test_property_key"] == "test_property_value"
+        np.testing.assert_allclose(
+            molecules[0].partial_charges / unit.elementary_charge,
+            [-0.108680, 0.027170, 0.027170, 0.027170, 0.027170],
+        )
         # The second molecule in the SDF has the following properties and charges:
-        assert molecules[1].properties['test_property_key'] == 'test_property_value2'
-        assert molecules[1].properties['another_test_property_key'] == 'another_test_property_value'
-        np.testing.assert_allclose(molecules[1].partial_charges / unit.elementary_charge,
-                                   [0.027170, 0.027170, 0.027170, 0.027170, -0.108680])
+        assert molecules[1].properties["test_property_key"] == "test_property_value2"
+        assert (
+            molecules[1].properties["another_test_property_key"]
+            == "another_test_property_value"
+        )
+        np.testing.assert_allclose(
+            molecules[1].partial_charges / unit.elementary_charge,
+            [0.027170, 0.027170, 0.027170, 0.027170, -0.108680],
+        )
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_write_multiconformer_mol_as_sdf(self):
         """
         Test RDKitToolkitWrapper for writing a multiconformer molecule to SDF. The OFF toolkit should only
@@ -1573,27 +2101,36 @@ class TestRDKitToolkitWrapper:
         from io import StringIO
 
         toolkit_wrapper = RDKitToolkitWrapper()
-        filename = get_data_file_path('molecules/ethanol.sdf')
+        filename = get_data_file_path("molecules/ethanol.sdf")
         ethanol = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
-        ethanol.partial_charges = np.array([-4., -3., -2., -1., 0., 1., 2., 3., 4.]) * unit.elementary_charge
-        ethanol.properties['test_prop'] = 'test_value'
-        new_conf = ethanol.conformers[0] + (np.ones(ethanol.conformers[0].shape) * unit.angstrom)
+        ethanol.partial_charges = (
+            np.array([-4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0])
+            * unit.elementary_charge
+        )
+        ethanol.properties["test_prop"] = "test_value"
+        new_conf = ethanol.conformers[0] + (
+            np.ones(ethanol.conformers[0].shape) * unit.angstrom
+        )
         ethanol.add_conformer(new_conf)
         sio = StringIO()
-        ethanol.to_file(sio, 'sdf', toolkit_registry=toolkit_wrapper)
+        ethanol.to_file(sio, "sdf", toolkit_registry=toolkit_wrapper)
         data = sio.getvalue()
         # In SD format, each molecule ends with "$$$$"
-        assert data.count('$$$$') == 1
+        assert data.count("$$$$") == 1
         # A basic SDF for ethanol would be 27 lines, though the properties add three more
-        assert len(data.split('\n')) == 30
-        assert 'test_prop' in data
-        assert '<atom.dprop.PartialCharge>' in data
+        assert len(data.split("\n")) == 30
+        assert "test_prop" in data
+        assert "<atom.dprop.PartialCharge>" in data
         # Ensure the first conformer's first atom's X coordinate is in the file
         assert str(ethanol.conformers[0][0][0].value_in_unit(unit.angstrom))[:5] in data
         # Ensure the SECOND conformer's first atom's X coordinate is NOT in the file
-        assert str(ethanol.conformers[1][0][0].in_units_of(unit.angstrom))[:5] not in data
+        assert (
+            str(ethanol.conformers[1][0][0].in_units_of(unit.angstrom))[:5] not in data
+        )
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_write_milticonformer_pdb(self):
         """
         Make sure RDKit can write multi conformer PDB files.
@@ -1602,76 +2139,94 @@ class TestRDKitToolkitWrapper:
 
         toolkit = RDKitToolkitWrapper()
         # load up a multiconformer pdb file and condense down the conformers
-        molecules = Molecule.from_file(get_data_file_path('molecules/butane_multi.sdf'), toolkit_registry=toolkit)
+        molecules = Molecule.from_file(
+            get_data_file_path("molecules/butane_multi.sdf"), toolkit_registry=toolkit
+        )
         butane = molecules.pop(0)
         for mol in molecules:
             butane.add_conformer(mol.conformers[0])
         assert butane.n_conformers == 7
         sio = StringIO()
-        butane.to_file(sio, 'pdb', toolkit_registry=toolkit)
+        butane.to_file(sio, "pdb", toolkit_registry=toolkit)
         # we need to make sure each conformer is wrote to the file
         pdb = sio.getvalue()
         for i in range(1, 8):
-            assert f'MODEL        {i}' in pdb
+            assert f"MODEL        {i}" in pdb
 
     # Unskip this when we implement PDB-reading support for RDKitToolkitWrapper
     @pytest.mark.skip
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_get_pdb_coordinates(self):
         """Test RDKitToolkitWrapper for importing a single set of coordinates from a pdb file"""
         toolkit_wrapper = RDKitToolkitWrapper()
-        filename = get_data_file_path('molecules/toluene.pdb')
+        filename = get_data_file_path("molecules/toluene.pdb")
         molecule = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule.conformers) == 1
-        assert molecule.conformers[0].shape == (15,3)
+        assert molecule.conformers[0].shape == (15, 3)
 
     # Unskip this when we implement PDB-reading support for RDKitToolkitWrapper
     @pytest.mark.skip
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_load_aromatic_pdb(self):
         """Test OpenEyeToolkitWrapper for importing molecule conformers"""
         toolkit_wrapper = RDKitToolkitWrapper()
-        filename = get_data_file_path('molecules/toluene.pdb')
+        filename = get_data_file_path("molecules/toluene.pdb")
         molecule = Molecule.from_file(filename, toolkit_registry=toolkit_wrapper)
         assert len(molecule.conformers) == 1
-        assert molecule.conformers[0].shape == (15,3)
+        assert molecule.conformers[0].shape == (15, 3)
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_generate_conformers(self):
         """Test RDKitToolkitWrapper generate_conformers()"""
         toolkit_wrapper = RDKitToolkitWrapper()
-        smiles = '[H]C([H])([H])C([H])([H])[H]'
+        smiles = "[H]C([H])([H])C([H])([H])[H]"
         molecule = toolkit_wrapper.from_smiles(smiles)
         molecule.generate_conformers()
         # TODO: Make this test more robust
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_generate_multiple_conformers(self):
         """Test RDKitToolkitWrapper generate_conformers() for generating multiple conformers"""
         toolkit_wrapper = RDKitToolkitWrapper()
-        smiles = 'CCCCCCC'
+        smiles = "CCCCCCC"
         molecule = toolkit_wrapper.from_smiles(smiles)
-        molecule.generate_conformers(rms_cutoff=1 * unit.angstrom,
-                                     n_conformers=100,
-                                     toolkit_registry=toolkit_wrapper)
+        molecule.generate_conformers(
+            rms_cutoff=1 * unit.angstrom,
+            n_conformers=100,
+            toolkit_registry=toolkit_wrapper,
+        )
         assert molecule.n_conformers > 1
-        assert not (molecule.conformers[0] == (0. * unit.angstrom)).all()
+        assert not (molecule.conformers[0] == (0.0 * unit.angstrom)).all()
 
         # Ensure rms_cutoff kwarg is working
         molecule2 = toolkit_wrapper.from_smiles(smiles)
-        molecule2.generate_conformers(rms_cutoff=0.1 * unit.angstrom,
-                                      n_conformers=100,
-                                      toolkit_registry=toolkit_wrapper)
+        molecule2.generate_conformers(
+            rms_cutoff=0.1 * unit.angstrom,
+            n_conformers=100,
+            toolkit_registry=toolkit_wrapper,
+        )
         assert molecule2.n_conformers > molecule.n_conformers
 
         # Ensure n_conformers kwarg is working
         molecule2 = toolkit_wrapper.from_smiles(smiles)
-        molecule2.generate_conformers(rms_cutoff=0.1 * unit.angstrom,
-                                      n_conformers=10,
-                                      toolkit_registry=toolkit_wrapper)
+        molecule2.generate_conformers(
+            rms_cutoff=0.1 * unit.angstrom,
+            n_conformers=10,
+            toolkit_registry=toolkit_wrapper,
+        )
         assert molecule2.n_conformers == 10
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_find_rotatable_bonds(self):
         """Test finding rotatable bonds while ignoring some groups"""
 
@@ -1684,29 +2239,33 @@ class TestRDKitToolkitWrapper:
             assert ethanol.atoms[bond.atom2_index].atomic_number != 1
 
         # now ignore the C-O bond, forwards
-        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups='[#6:1]-[#8:2]')
+        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups="[#6:1]-[#8:2]")
         assert len(bonds) == 1
         assert ethanol.atoms[bonds[0].atom1_index].atomic_number == 6
         assert ethanol.atoms[bonds[0].atom2_index].atomic_number == 6
 
         # now ignore the O-C bond, backwards
-        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups='[#8:1]-[#6:2]')
+        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups="[#8:1]-[#6:2]")
         assert len(bonds) == 1
         assert ethanol.atoms[bonds[0].atom1_index].atomic_number == 6
         assert ethanol.atoms[bonds[0].atom2_index].atomic_number == 6
 
         # now ignore the C-C bond
-        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups='[#6:1]-[#6:2]')
+        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups="[#6:1]-[#6:2]")
         assert len(bonds) == 1
         assert ethanol.atoms[bonds[0].atom1_index].atomic_number == 6
         assert ethanol.atoms[bonds[0].atom2_index].atomic_number == 8
 
         # ignore a list of searches, forward
-        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups=['[#6:1]-[#8:2]', '[#6:1]-[#6:2]'])
+        bonds = ethanol.find_rotatable_bonds(
+            ignore_functional_groups=["[#6:1]-[#8:2]", "[#6:1]-[#6:2]"]
+        )
         assert bonds == []
 
         # ignore a list of searches, backwards
-        bonds = ethanol.find_rotatable_bonds(ignore_functional_groups=['[#6:1]-[#6:2]', '[#8:1]-[#6:2]'])
+        bonds = ethanol.find_rotatable_bonds(
+            ignore_functional_groups=["[#6:1]-[#6:2]", "[#8:1]-[#6:2]"]
+        )
         assert bonds == []
 
         # test  molecules that should have no rotatable bonds
@@ -1714,18 +2273,18 @@ class TestRDKitToolkitWrapper:
         bonds = cyclohexane.find_rotatable_bonds()
         assert bonds == []
 
-        methane = Molecule.from_smiles('C')
+        methane = Molecule.from_smiles("C")
         bonds = methane.find_rotatable_bonds()
         assert bonds == []
 
-        ethene = Molecule.from_smiles('C=C')
+        ethene = Molecule.from_smiles("C=C")
         bonds = ethene.find_rotatable_bonds()
         assert bonds == []
 
-        terminal_forwards = '[*]~[*:1]-[X2H1,X3H2,X4H3:2]-[#1]'
-        terminal_backwards = '[#1]-[X2H1,X3H2,X4H3:1]-[*:2]~[*]'
+        terminal_forwards = "[*]~[*:1]-[X2H1,X3H2,X4H3:2]-[#1]"
+        terminal_backwards = "[#1]-[X2H1,X3H2,X4H3:1]-[*:2]~[*]"
         # test removing terminal rotors
-        toluene = Molecule.from_file(get_data_file_path('molecules/toluene.sdf'))
+        toluene = Molecule.from_file(get_data_file_path("molecules/toluene.sdf"))
         bonds = toluene.find_rotatable_bonds()
         assert len(bonds) == 1
         assert toluene.atoms[bonds[0].atom1_index].atomic_number == 6
@@ -1736,10 +2295,14 @@ class TestRDKitToolkitWrapper:
         assert bonds == []
 
         # find terminal bonds backwards
-        bonds = toluene.find_rotatable_bonds(ignore_functional_groups=terminal_backwards)
+        bonds = toluene.find_rotatable_bonds(
+            ignore_functional_groups=terminal_backwards
+        )
         assert bonds == []
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_to_rdkit_losing_aromaticity_(self):
         # test the example given in issue #513
         # <https://github.com/openforcefield/openforcefield/issues/513>
@@ -1753,18 +2316,19 @@ class TestRDKitToolkitWrapper:
             assert offatom.is_aromatic is rdatom.GetIsAromatic()
 
     @pytest.mark.slow
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_substructure_search_on_large_molecule(self):
         """Test RDKitToolkitWrapper substructure search when a large number hits are found"""
 
         tk = RDKitToolkitWrapper()
-        smiles = "C"*3000
+        smiles = "C" * 3000
         molecule = tk.from_smiles(smiles)
         query = "[C:1]~[C:2]"
         ret = molecule.chemical_environment_matches(query, toolkit_registry=tk)
         assert len(ret) == 5998
         assert len(ret[0]) == 2
-
 
         # TODO: Add test for higher bonds orders
         # TODO: Add test for aromaticity
@@ -1776,16 +2340,19 @@ class TestRDKitToolkitWrapper:
         # TODO: Add write tests for all formats
 
 
-
-
 class TestAmberToolsToolkitWrapper:
     """Test the AmberToolsToolkitWrapper"""
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-                    reason='RDKitToolkit and AmberToolsToolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
     def test_compute_partial_charges_am1bcc(self):
         """Test AmberToolsToolkitWrapper compute_partial_charges_am1bcc()"""
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
         molecule = create_ethanol()
         molecule.compute_partial_charges_am1bcc(toolkit_registry=toolkit_registry)
         charge_sum = 0 * unit.elementary_charge
@@ -1796,327 +2363,462 @@ class TestAmberToolsToolkitWrapper:
         assert abs(charge_sum) < 0.001 * unit.elementary_charge
         assert abs_charge_sum > 0.25 * unit.elementary_charge
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-                        reason='RDKitToolkit and AmberToolsToolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
     def test_compute_partial_charges_am1bcc_net_charge(self):
         """Test AmberToolsToolkitWrapper assign_partial_charges() on a molecule with a net -1 charge"""
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
         molecule = create_acetate()
         molecule.compute_partial_charges_am1bcc(toolkit_registry=toolkit_registry)
         charge_sum = 0 * unit.elementary_charge
         for pc in molecule._partial_charges:
             charge_sum += pc
-        assert -0.99 * unit.elementary_charge > charge_sum > -1.01 * unit.elementary_charge
+        assert (
+            -0.99 * unit.elementary_charge > charge_sum > -1.01 * unit.elementary_charge
+        )
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-                        reason='RDKitToolkit and AmberToolsToolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
     def test_compute_partial_charges_am1bcc_wrong_n_confs(self):
         """
         Test AmberToolsToolkitWrapper compute_partial_charges_am1bcc() when requesting to use an incorrect number of
         conformers
         """
         from openforcefield.tests.test_forcefield import create_ethanol
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
+
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
         molecule = create_ethanol()
-        molecule.generate_conformers(n_conformers=2, rms_cutoff=0.1*unit.angstrom)
+        molecule.generate_conformers(n_conformers=2, rms_cutoff=0.1 * unit.angstrom)
 
         # Try passing in the incorrect number of confs, but without specifying strict_n_conformers,
         # which should produce a warning
-        with pytest.warns(IncorrectNumConformersWarning,
-                          match="has 2 conformers, but charge method 'am1bcc' expects exactly 1."):
-            molecule.compute_partial_charges_am1bcc(toolkit_registry=toolkit_registry,
-                                                    use_conformers=molecule.conformers,
-                                                    strict_n_conformers=False)
+        with pytest.warns(
+            IncorrectNumConformersWarning,
+            match="has 2 conformers, but charge method 'am1bcc' expects exactly 1.",
+        ):
+            molecule.compute_partial_charges_am1bcc(
+                toolkit_registry=toolkit_registry,
+                use_conformers=molecule.conformers,
+                strict_n_conformers=False,
+            )
 
         # Try again, with strict_n_confs as true, but not including use_confs, so the
         # recommended number of confs will be generated
-        molecule.compute_partial_charges_am1bcc(toolkit_registry=toolkit_registry,
-                                                strict_n_conformers=True)
+        molecule.compute_partial_charges_am1bcc(
+            toolkit_registry=toolkit_registry, strict_n_conformers=True
+        )
 
         # Test calling the ToolkitWrapper _indirectly_, though the Molecule API,
         # which should raise the first error encountered
-        with pytest.raises(ValueError,
-                           match=f"has 2 conformers, but charge method 'am1bcc' "
-                                 f"expects exactly 1."):
-            molecule.compute_partial_charges_am1bcc(toolkit_registry=toolkit_registry,
-                                                   use_conformers=molecule.conformers,
-                                                   strict_n_conformers=True)
+        with pytest.raises(
+            ValueError,
+            match=f"has 2 conformers, but charge method 'am1bcc' "
+            f"expects exactly 1.",
+        ):
+            molecule.compute_partial_charges_am1bcc(
+                toolkit_registry=toolkit_registry,
+                use_conformers=molecule.conformers,
+                strict_n_conformers=True,
+            )
 
         # Test calling the ToolkitWrapper _indirectly_, though a ToolkitRegistry,
         # specifying raise_exception_types=[]
         # which should aggregate any exceptions and bundle all of the messages
         # in a failed task together in a single ValueError.
-        with pytest.raises(ValueError,
-                           match=f"has 2 conformers, but charge method 'am1bcc' "
-                                 f"expects exactly 1."):
-            toolkit_registry.call('compute_partial_charges_am1bcc',
-                                  molecule=molecule,
-                                  use_conformers=molecule.conformers,
-                                  strict_n_conformers=True,
-                                  raise_exception_types=[])
+        with pytest.raises(
+            ValueError,
+            match=f"has 2 conformers, but charge method 'am1bcc' "
+            f"expects exactly 1.",
+        ):
+            toolkit_registry.call(
+                "compute_partial_charges_am1bcc",
+                molecule=molecule,
+                use_conformers=molecule.conformers,
+                strict_n_conformers=True,
+                raise_exception_types=[],
+            )
 
         # Test calling the ToolkitWrapper _directly_, passing in the incorrect number of
         # confs, and specify strict_n_conformers, which should produce an IncorrectNumConformersError
-        with pytest.raises(IncorrectNumConformersError,
-                           match=f"has 2 conformers, but charge method 'am1bcc' "
-                                 f"expects exactly 1."):
+        with pytest.raises(
+            IncorrectNumConformersError,
+            match=f"has 2 conformers, but charge method 'am1bcc' "
+            f"expects exactly 1.",
+        ):
             ATTKW = AmberToolsToolkitWrapper()
-            ATTKW.compute_partial_charges_am1bcc(molecule=molecule,
-                                                 use_conformers=molecule.conformers,
-                                                 strict_n_conformers=True)
+            ATTKW.compute_partial_charges_am1bcc(
+                molecule=molecule,
+                use_conformers=molecule.conformers,
+                strict_n_conformers=True,
+            )
 
-
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-                        reason='RDKitToolkit and AmberToolsToolkit not available')
-    @pytest.mark.parametrize("partial_charge_method", ['am1bcc', 'am1-mulliken', 'gasteiger'])
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
+    @pytest.mark.parametrize(
+        "partial_charge_method", ["am1bcc", "am1-mulliken", "gasteiger"]
+    )
     def test_assign_partial_charges_neutral(self, partial_charge_method):
         """Test AmberToolsToolkitWrapper assign_partial_charges()"""
         from openforcefield.tests.test_forcefield import create_ethanol
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
+
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
         molecule = create_ethanol()
-        molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                        partial_charge_method=partial_charge_method)
-        charge_sum = 0. * unit.elementary_charge
+        molecule.assign_partial_charges(
+            toolkit_registry=toolkit_registry,
+            partial_charge_method=partial_charge_method,
+        )
+        charge_sum = 0.0 * unit.elementary_charge
         for pc in molecule.partial_charges:
             charge_sum += pc
-        assert -1.e-5 < charge_sum.value_in_unit(unit.elementary_charge) < 1.e-5
+        assert -1.0e-5 < charge_sum.value_in_unit(unit.elementary_charge) < 1.0e-5
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-                        reason='RDKitToolkit and AmberToolsToolkit not available')
-    @pytest.mark.parametrize("partial_charge_method", ['am1bcc', 'am1-mulliken'])
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
+    @pytest.mark.parametrize("partial_charge_method", ["am1bcc", "am1-mulliken"])
     def test_assign_partial_charges_conformer_dependence(self, partial_charge_method):
         """Test AmberToolsToolkitWrapper assign_partial_charges()'s use_conformers kwarg
         to ensure charges are really conformer dependent. Skip Gasteiger because it isn't
         conformer dependent."""
         from openforcefield.tests.test_forcefield import create_ethanol
         import copy
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
+
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
         molecule = create_ethanol()
         molecule.generate_conformers(n_conformers=1)
-        molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                        partial_charge_method=partial_charge_method,
-                                        use_conformers=molecule.conformers)
+        molecule.assign_partial_charges(
+            toolkit_registry=toolkit_registry,
+            partial_charge_method=partial_charge_method,
+            use_conformers=molecule.conformers,
+        )
         pcs1 = copy.deepcopy(molecule.partial_charges)
         # This test case needs a pretty extreme coordinate change since ambertools only
         # stores partial charges to 1e-3
-        molecule._conformers[0][0][0] += 3. * unit.angstrom
-        molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                        partial_charge_method=partial_charge_method,
-                                        use_conformers=molecule.conformers)
+        molecule._conformers[0][0][0] += 3.0 * unit.angstrom
+        molecule.assign_partial_charges(
+            toolkit_registry=toolkit_registry,
+            partial_charge_method=partial_charge_method,
+            use_conformers=molecule.conformers,
+        )
         for pc1, pc2 in zip(pcs1, molecule.partial_charges):
-            assert abs(pc1 - pc2) > 1.e-3 * unit.elementary_charge
+            assert abs(pc1 - pc2) > 1.0e-3 * unit.elementary_charge
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-                        reason='RDKitToolkit and AmberToolsToolkit not available')
-    @pytest.mark.parametrize("partial_charge_method", ['am1bcc', 'am1-mulliken', 'gasteiger'])
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
+    @pytest.mark.parametrize(
+        "partial_charge_method", ["am1bcc", "am1-mulliken", "gasteiger"]
+    )
     def test_assign_partial_charges_net_charge(self, partial_charge_method):
         """
         Test AmberToolsToolkitWrapper assign_partial_charges().
         """
         from openforcefield.tests.test_forcefield import create_acetate
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
+
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
         molecule = create_acetate()
-        molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                        partial_charge_method=partial_charge_method)
-        charge_sum = 0. * unit.elementary_charge
+        molecule.assign_partial_charges(
+            toolkit_registry=toolkit_registry,
+            partial_charge_method=partial_charge_method,
+        )
+        charge_sum = 0.0 * unit.elementary_charge
         for pc in molecule.partial_charges:
             charge_sum += pc
         assert -1.01 < charge_sum.value_in_unit(unit.elementary_charge) < -0.99
 
-
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-                        reason='RDKitToolkit and AmberToolsToolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
     def test_assign_partial_charges_bad_charge_method(self):
         """Test AmberToolsToolkitWrapper assign_partial_charges() for a nonexistent charge method"""
         from openforcefield.tests.test_forcefield import create_ethanol
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
+
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
         molecule = create_ethanol()
 
         # For now, ToolkitRegistries lose track of what exception type
         # was thrown inside them, so we just check for a ValueError here
-        with pytest.raises(ValueError, match="is not available from AmberToolsToolkitWrapper") as excinfo:
-            molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                            partial_charge_method="NotARealChargeMethod")
+        with pytest.raises(
+            ValueError, match="is not available from AmberToolsToolkitWrapper"
+        ) as excinfo:
+            molecule.assign_partial_charges(
+                toolkit_registry=toolkit_registry,
+                partial_charge_method="NotARealChargeMethod",
+            )
 
         # ToolkitWrappers raise a specific exception class, so we test that here
-        with pytest.raises(ChargeMethodUnavailableError, match="is not available from AmberToolsToolkitWrapper") as excinfo:
+        with pytest.raises(
+            ChargeMethodUnavailableError,
+            match="is not available from AmberToolsToolkitWrapper",
+        ) as excinfo:
             ATTKW = AmberToolsToolkitWrapper()
-            ATTKW.assign_partial_charges(molecule=molecule,
-                                         partial_charge_method="NotARealChargeMethod")
+            ATTKW.assign_partial_charges(
+                molecule=molecule, partial_charge_method="NotARealChargeMethod"
+            )
 
-
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-                        reason='RDKitToolkit and AmberToolsToolkit not available')
-    @pytest.mark.parametrize("partial_charge_method,expected_n_confs", [('am1bcc', 1),
-                                                                        ('am1-mulliken', 1),
-                                                                        ('gasteiger', 0)])
-    def test_assign_partial_charges_wrong_n_confs(self, partial_charge_method, expected_n_confs):
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
+    @pytest.mark.parametrize(
+        "partial_charge_method,expected_n_confs",
+        [("am1bcc", 1), ("am1-mulliken", 1), ("gasteiger", 0)],
+    )
+    def test_assign_partial_charges_wrong_n_confs(
+        self, partial_charge_method, expected_n_confs
+    ):
         """
         Test AmberToolsToolkitWrapper assign_partial_charges() when requesting to use an incorrect number of
         conformers
         """
         from openforcefield.tests.test_forcefield import create_ethanol
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
+
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
         molecule = create_ethanol()
-        molecule.generate_conformers(n_conformers=2, rms_cutoff=0.01*unit.angstrom)
+        molecule.generate_conformers(n_conformers=2, rms_cutoff=0.01 * unit.angstrom)
 
         # Try passing in the incorrect number of confs, but without specifying strict_n_conformers,
         # which should produce a warning
-        with pytest.warns(IncorrectNumConformersWarning,
-                          match=f"has 2 conformers, but charge method '{partial_charge_method}' "
-                                f"expects exactly {expected_n_confs}."):
-            molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                            partial_charge_method=partial_charge_method,
-                                            use_conformers=molecule.conformers,
-                                            strict_n_conformers=False)
+        with pytest.warns(
+            IncorrectNumConformersWarning,
+            match=f"has 2 conformers, but charge method '{partial_charge_method}' "
+            f"expects exactly {expected_n_confs}.",
+        ):
+            molecule.assign_partial_charges(
+                toolkit_registry=toolkit_registry,
+                partial_charge_method=partial_charge_method,
+                use_conformers=molecule.conformers,
+                strict_n_conformers=False,
+            )
 
         # Try again, with strict_n_confs as true, but not including use_confs, so the
         # recommended number of confs will be generated
-        molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                        partial_charge_method=partial_charge_method,
-                                        strict_n_conformers=True)
+        molecule.assign_partial_charges(
+            toolkit_registry=toolkit_registry,
+            partial_charge_method=partial_charge_method,
+            strict_n_conformers=True,
+        )
 
         # Test calling the ToolkitWrapper _indirectly_, though the Molecule API
         # which should aggregate any exceptions and bundle all of the messages
         # in a failed task together in a single ValueError.
-        with pytest.raises(ValueError,
-                           match=f"has 2 conformers, but charge method '{partial_charge_method}' "
-                                 f"expects exactly {expected_n_confs}."):
-            molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                            partial_charge_method=partial_charge_method,
-                                            use_conformers=molecule.conformers,
-                                            strict_n_conformers=True)
+        with pytest.raises(
+            ValueError,
+            match=f"has 2 conformers, but charge method '{partial_charge_method}' "
+            f"expects exactly {expected_n_confs}.",
+        ):
+            molecule.assign_partial_charges(
+                toolkit_registry=toolkit_registry,
+                partial_charge_method=partial_charge_method,
+                use_conformers=molecule.conformers,
+                strict_n_conformers=True,
+            )
 
         # Test calling the ToolkitWrapper _directly_, passing in the incorrect number of
         # confs, and specify strict_n_conformers, which should produce an IncorrectNumConformersError
-        with pytest.raises(IncorrectNumConformersError,
-                           match=f"has 2 conformers, but charge method '{partial_charge_method}' "
-                                 f"expects exactly {expected_n_confs}."):
+        with pytest.raises(
+            IncorrectNumConformersError,
+            match=f"has 2 conformers, but charge method '{partial_charge_method}' "
+            f"expects exactly {expected_n_confs}.",
+        ):
             ATTKW = AmberToolsToolkitWrapper()
-            ATTKW.assign_partial_charges(molecule=molecule,
-                                         partial_charge_method=partial_charge_method,
-                                         use_conformers=molecule.conformers,
-                                         strict_n_conformers=True)
+            ATTKW.assign_partial_charges(
+                molecule=molecule,
+                partial_charge_method=partial_charge_method,
+                use_conformers=molecule.conformers,
+                strict_n_conformers=True,
+            )
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-                        reason='RDKitToolkit and AmberToolsToolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
     def test_assign_fractional_bond_orders(self):
         """Test OpenEyeToolkitWrapper assign_fractional_bond_orders()"""
 
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
-        smiles = '[H]C([H])([H])C([H])([H])[H]'
-        molecule = toolkit_registry.call('from_smiles', smiles)
-        for bond_order_model in ['am1-wiberg']:
-            molecule.assign_fractional_bond_orders(toolkit_registry=toolkit_registry, bond_order_model=bond_order_model)
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
+        smiles = "[H]C([H])([H])C([H])([H])[H]"
+        molecule = toolkit_registry.call("from_smiles", smiles)
+        for bond_order_model in ["am1-wiberg"]:
+            molecule.assign_fractional_bond_orders(
+                toolkit_registry=toolkit_registry, bond_order_model=bond_order_model
+            )
             # TODO: Add test for equivalent Wiberg orders for equivalent bonds
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-                        reason='RDKitToolkit and AmberToolsToolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
     def test_assign_fractional_bond_orders_neutral_charge_mol(self):
         """Test OpenEyeToolkitWrapper assign_fractional_bond_orders() for neutral and charged molecule.
         Also tests using existing conformers"""
 
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
         # Reading neutral molecule from file
-        filename = get_data_file_path('molecules/CID20742535_neutral.sdf')
+        filename = get_data_file_path("molecules/CID20742535_neutral.sdf")
         molecule1 = Molecule.from_file(filename)
         # Reading negative molecule from file
-        filename = get_data_file_path('molecules/CID20742535_anion.sdf')
+        filename = get_data_file_path("molecules/CID20742535_anion.sdf")
         molecule2 = Molecule.from_file(filename)
 
         # Checking that only one additional bond is present in the neutral molecule
-        assert (len(molecule1.bonds) == len(molecule2.bonds) + 1)
+        assert len(molecule1.bonds) == len(molecule2.bonds) + 1
 
-        for bond_order_model in ['am1-wiberg']:
-            molecule1.assign_fractional_bond_orders(toolkit_registry=toolkit_registry,
-                                                    bond_order_model=bond_order_model,
-                                                    use_conformers=molecule1.conformers)
+        for bond_order_model in ["am1-wiberg"]:
+            molecule1.assign_fractional_bond_orders(
+                toolkit_registry=toolkit_registry,
+                bond_order_model=bond_order_model,
+                use_conformers=molecule1.conformers,
+            )
 
             for i in molecule1.bonds:
                 if i.is_aromatic:
                     # Checking aromatic bonds
-                    assert (1.05 < i.fractional_bond_order < 1.65)
-                elif (i.atom1.atomic_number == 1 or i.atom2.atomic_number == 1):
+                    assert 1.05 < i.fractional_bond_order < 1.65
+                elif i.atom1.atomic_number == 1 or i.atom2.atomic_number == 1:
                     # Checking bond order of C-H or O-H bonds are around 1
-                    assert (0.85 < i.fractional_bond_order < 1.05)
-                elif (i.atom1.atomic_number == 8 or i.atom2.atomic_number == 8):
+                    assert 0.85 < i.fractional_bond_order < 1.05
+                elif i.atom1.atomic_number == 8 or i.atom2.atomic_number == 8:
                     # Checking C-O single bond
                     wbo_C_O_neutral = i.fractional_bond_order
-                    assert (1.0 < wbo_C_O_neutral < 1.5)
+                    assert 1.0 < wbo_C_O_neutral < 1.5
                 else:
                     # Should be C-C single bond
-                    assert (i.atom1_index == 4 and i.atom2_index == 6) or (i.atom1_index == 6 and i.atom2_index == 4)
+                    assert (i.atom1_index == 4 and i.atom2_index == 6) or (
+                        i.atom1_index == 6 and i.atom2_index == 4
+                    )
                     wbo_C_C_neutral = i.fractional_bond_order
-                    assert (1.0 < wbo_C_C_neutral < 1.3)
+                    assert 1.0 < wbo_C_C_neutral < 1.3
 
-            molecule2.assign_fractional_bond_orders(toolkit_registry=toolkit_registry,
-                                                    bond_order_model=bond_order_model,
-                                                    use_conformers=molecule2.conformers)
+            molecule2.assign_fractional_bond_orders(
+                toolkit_registry=toolkit_registry,
+                bond_order_model=bond_order_model,
+                use_conformers=molecule2.conformers,
+            )
             for i in molecule2.bonds:
                 if i.is_aromatic:
                     # Checking aromatic bonds
-                    assert (1.05 < i.fractional_bond_order < 1.65)
+                    assert 1.05 < i.fractional_bond_order < 1.65
 
-                elif (i.atom1.atomic_number == 1 or i.atom2.atomic_number == 1):
+                elif i.atom1.atomic_number == 1 or i.atom2.atomic_number == 1:
                     # Checking bond order of C-H or O-H bonds are around 1
-                    assert (0.85 < i.fractional_bond_order < 1.05)
-                elif (i.atom1.atomic_number == 8 or i.atom2.atomic_number == 8):
+                    assert 0.85 < i.fractional_bond_order < 1.05
+                elif i.atom1.atomic_number == 8 or i.atom2.atomic_number == 8:
                     # Checking C-O single bond
                     wbo_C_O_anion = i.fractional_bond_order
-                    assert (1.3 < wbo_C_O_anion < 1.8)
+                    assert 1.3 < wbo_C_O_anion < 1.8
                 else:
                     # Should be C-C single bond
-                    assert (i.atom1_index == 4 and i.atom2_index == 6) or (i.atom1_index == 6 and i.atom2_index == 4)
+                    assert (i.atom1_index == 4 and i.atom2_index == 6) or (
+                        i.atom1_index == 6 and i.atom2_index == 4
+                    )
                     wbo_C_C_anion = i.fractional_bond_order
-                    assert (1.0 < wbo_C_C_anion < 1.3)
+                    assert 1.0 < wbo_C_C_anion < 1.3
 
             # Wiberg bond order of C-C single bond is higher in the anion
-            assert (wbo_C_C_anion > wbo_C_C_neutral)
+            assert wbo_C_C_anion > wbo_C_C_neutral
             # Wiberg bond order of C-O bond is higher in the anion
-            assert (wbo_C_O_anion > wbo_C_O_neutral)
+            assert wbo_C_O_anion > wbo_C_O_neutral
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-                        reason='RDKitToolkit and AmberToolsToolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
     def test_assign_fractional_bond_orders_charged(self):
         """Test OpenEyeToolkitWrapper assign_fractional_bond_orders() on a molecule with net charge +1"""
 
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
-        smiles = '[H]C([H])([H])[N+]([H])([H])[H]'
-        molecule = toolkit_registry.call('from_smiles', smiles)
-        for bond_order_model in ['am1-wiberg']:
-            molecule.assign_fractional_bond_orders(toolkit_registry=toolkit_registry,
-                                                    bond_order_model=bond_order_model)
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
+        smiles = "[H]C([H])([H])[N+]([H])([H])[H]"
+        molecule = toolkit_registry.call("from_smiles", smiles)
+        for bond_order_model in ["am1-wiberg"]:
+            molecule.assign_fractional_bond_orders(
+                toolkit_registry=toolkit_registry, bond_order_model=bond_order_model
+            )
             # TODO: Add test for equivalent Wiberg orders for equivalent bonds
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-                        reason='RDKitToolkit and AmberToolsToolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
     def test_assign_fractional_bond_orders_invalid_method(self):
         """
         Test that AmberToolsToolkitWrapper.assign_fractional_bond_orders() raises the
         correct error if an invalid charge model is provided
         """
 
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
-        smiles = '[H]C([H])([H])[N+]([H])([H])[H]'
-        molecule = toolkit_registry.call('from_smiles', smiles)
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
+        smiles = "[H]C([H])([H])[N+]([H])([H])[H]"
+        molecule = toolkit_registry.call("from_smiles", smiles)
 
-        expected_error = "Bond order model 'not a real charge model' is not supported by " \
-                         "AmberToolsToolkitWrapper. Supported models are ([[]'am1-wiberg'[]])"
+        expected_error = (
+            "Bond order model 'not a real charge model' is not supported by "
+            "AmberToolsToolkitWrapper. Supported models are ([[]'am1-wiberg'[]])"
+        )
         with pytest.raises(ValueError, match=expected_error) as excinfo:
-            molecule.assign_fractional_bond_orders(toolkit_registry=AmberToolsToolkitWrapper(),
-                                                   bond_order_model='not a real charge model')
+            molecule.assign_fractional_bond_orders(
+                toolkit_registry=AmberToolsToolkitWrapper(),
+                bond_order_model="not a real charge model",
+            )
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-                        reason='RDKitToolkit and AmberToolsToolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
     def test_assign_fractional_bond_orders_double_bond(self):
         """Test OpenEyeToolkitWrapper assign_fractional_bond_orders() on a molecule with a double bond"""
 
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
-        smiles = r'C\C(F)=C(/F)C[C@@](C)(Cl)Br'
-        molecule = toolkit_registry.call('from_smiles', smiles)
-        for bond_order_model in ['am1-wiberg']:
-            molecule.assign_fractional_bond_orders(toolkit_registry=toolkit_registry,
-                                                   bond_order_model=bond_order_model)
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
+        smiles = r"C\C(F)=C(/F)C[C@@](C)(Cl)Br"
+        molecule = toolkit_registry.call("from_smiles", smiles)
+        for bond_order_model in ["am1-wiberg"]:
+            molecule.assign_fractional_bond_orders(
+                toolkit_registry=toolkit_registry, bond_order_model=bond_order_model
+            )
             # TODO: Add test for equivalent Wiberg orders for equivalent bonds
 
         double_bond_has_wbo_near_2 = False
@@ -2129,54 +2831,69 @@ class TestAmberToolsToolkitWrapper:
 
 class TestBuiltInToolkitWrapper:
     """Test the BuiltInToolkitWrapper"""
-    @pytest.mark.parametrize("partial_charge_method", ['zeros', 'formal_charge'])
+
+    @pytest.mark.parametrize("partial_charge_method", ["zeros", "formal_charge"])
     def test_assign_partial_charges_neutral(self, partial_charge_method):
         """Test BuiltInToolkitWrapper assign_partial_charges()"""
         from openforcefield.tests.test_forcefield import create_ethanol
+
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[BuiltInToolkitWrapper])
         molecule = create_ethanol()
-        molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                        partial_charge_method=partial_charge_method)
-        charge_sum = 0. * unit.elementary_charge
+        molecule.assign_partial_charges(
+            toolkit_registry=toolkit_registry,
+            partial_charge_method=partial_charge_method,
+        )
+        charge_sum = 0.0 * unit.elementary_charge
         for pc in molecule.partial_charges:
             charge_sum += pc
-        assert -1.e-6 < charge_sum.value_in_unit(unit.elementary_charge) < 1.e-6
+        assert -1.0e-6 < charge_sum.value_in_unit(unit.elementary_charge) < 1.0e-6
 
-    @pytest.mark.parametrize("partial_charge_method", ['formal_charge'])
+    @pytest.mark.parametrize("partial_charge_method", ["formal_charge"])
     def test_assign_partial_charges_net_charge(self, partial_charge_method):
         """
         Test BuiltInToolkitWrapper assign_partial_charges(). Only formal_charge is tested, since zeros will not
         sum up to the proper number
         """
         from openforcefield.tests.test_forcefield import create_acetate
+
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[BuiltInToolkitWrapper])
         molecule = create_acetate()
-        molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                        partial_charge_method=partial_charge_method)
-        charge_sum = 0. * unit.elementary_charge
+        molecule.assign_partial_charges(
+            toolkit_registry=toolkit_registry,
+            partial_charge_method=partial_charge_method,
+        )
+        charge_sum = 0.0 * unit.elementary_charge
         for pc in molecule.partial_charges:
             charge_sum += pc
-        assert -1.e-6 < charge_sum.value_in_unit(unit.elementary_charge) + 1. < 1.e-6
-
+        assert -1.0e-6 < charge_sum.value_in_unit(unit.elementary_charge) + 1.0 < 1.0e-6
 
     def test_assign_partial_charges_bad_charge_method(self):
         """Test BuiltInToolkitWrapper assign_partial_charges() for a nonexistent charge method"""
         from openforcefield.tests.test_forcefield import create_ethanol
+
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[BuiltInToolkitWrapper])
         molecule = create_ethanol()
 
         # For now, the Molecule API passes raise_exception_types=[] to ToolkitRegistry.call,
         # which loses track of what exception type
         # was thrown inside them, so we just check for a ValueError here
-        with pytest.raises(ValueError, match="is not supported by the Built-in toolkit") as excinfo:
-            molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                            partial_charge_method="NotARealChargeMethod")
+        with pytest.raises(
+            ValueError, match="is not supported by the Built-in toolkit"
+        ) as excinfo:
+            molecule.assign_partial_charges(
+                toolkit_registry=toolkit_registry,
+                partial_charge_method="NotARealChargeMethod",
+            )
 
         # ToolkitWrappers raise a specific exception class, so we test that here
-        with pytest.raises(ChargeMethodUnavailableError, match="is not supported by the Built-in toolkit") as excinfo:
+        with pytest.raises(
+            ChargeMethodUnavailableError,
+            match="is not supported by the Built-in toolkit",
+        ) as excinfo:
             BITKW = BuiltInToolkitWrapper()
-            BITKW.assign_partial_charges(molecule=molecule,
-                                         partial_charge_method="NotARealChargeMethod")
+            BITKW.assign_partial_charges(
+                molecule=molecule, partial_charge_method="NotARealChargeMethod"
+            )
 
     def test_assign_partial_charges_wrong_n_confs(self):
         """
@@ -2184,46 +2901,61 @@ class TestBuiltInToolkitWrapper:
         conformers
         """
         from openforcefield.tests.test_forcefield import create_ethanol
+
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[BuiltInToolkitWrapper])
         molecule = create_ethanol()
         molecule.generate_conformers(n_conformers=1)
-        with pytest.warns(IncorrectNumConformersWarning,
-                          match="has 1 conformers, but charge method 'zeros' expects exactly 0."):
-            molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                            partial_charge_method="zeros",
-                                            use_conformers=molecule.conformers,
-                                            strict_n_conformers=False)
+        with pytest.warns(
+            IncorrectNumConformersWarning,
+            match="has 1 conformers, but charge method 'zeros' expects exactly 0.",
+        ):
+            molecule.assign_partial_charges(
+                toolkit_registry=toolkit_registry,
+                partial_charge_method="zeros",
+                use_conformers=molecule.conformers,
+                strict_n_conformers=False,
+            )
 
         # Specify strict_n_conformers=True, but not use_conformers, so a recommended number of
         # conformers will be generated internally
-        molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                        partial_charge_method="zeros",
-                                        strict_n_conformers=True)
+        molecule.assign_partial_charges(
+            toolkit_registry=toolkit_registry,
+            partial_charge_method="zeros",
+            strict_n_conformers=True,
+        )
 
         # For now, the Molecule API passes raise_exception_types=[] to ToolkitRegistry.call,
         # which loses track of what exception type
         # was thrown inside them, so we just check for a ValueError here
-        with pytest.raises(ValueError,
-                           match=f"has 1 conformers, but charge method 'zeros' "
-                                 f"expects exactly 0."):
-            molecule.assign_partial_charges(toolkit_registry=toolkit_registry,
-                                            partial_charge_method="zeros",
-                                            use_conformers=molecule.conformers,
-                                            strict_n_conformers=True)
+        with pytest.raises(
+            ValueError,
+            match=f"has 1 conformers, but charge method 'zeros' " f"expects exactly 0.",
+        ):
+            molecule.assign_partial_charges(
+                toolkit_registry=toolkit_registry,
+                partial_charge_method="zeros",
+                use_conformers=molecule.conformers,
+                strict_n_conformers=True,
+            )
 
         # Test calling the ToolkitWrapper _directly_, passing in the incorrect number of
         # confs, and specify strict_n_conformers, which should produce an IncorrectNumConformersError
-        with pytest.raises(IncorrectNumConformersError,
-                           match=f"has 1 conformers, but charge method 'zeros' "
-                                 f"expects exactly 0."):
+        with pytest.raises(
+            IncorrectNumConformersError,
+            match=f"has 1 conformers, but charge method 'zeros' " f"expects exactly 0.",
+        ):
             BITKW = BuiltInToolkitWrapper()
-            BITKW.assign_partial_charges(molecule=molecule,
-                                         partial_charge_method="zeros",
-                                         use_conformers=molecule.conformers,
-                                         strict_n_conformers=True)
+            BITKW.assign_partial_charges(
+                molecule=molecule,
+                partial_charge_method="zeros",
+                use_conformers=molecule.conformers,
+                strict_n_conformers=True,
+            )
+
 
 class TestToolkitWrapper:
     """Test the ToolkitWrapper class"""
+
     def test_check_n_conformers(self):
         """Ensure that _check_n_conformers is working properly"""
         tkw = ToolkitWrapper()
@@ -2231,25 +2963,39 @@ class TestToolkitWrapper:
 
         ## Test molecule with no conformers
         # Check with no min or max should pass
-        tkw._check_n_conformers(mol, 'nocharge')
+        tkw._check_n_conformers(mol, "nocharge")
         # Check with min=1 should warn
-        with pytest.warns(IncorrectNumConformersWarning,
-                           match="has 0 conformers, but charge method 'nocharge' expects at least 1"):
-            tkw._check_n_conformers(mol, 'nocharge', min_confs=1)
+        with pytest.warns(
+            IncorrectNumConformersWarning,
+            match="has 0 conformers, but charge method 'nocharge' expects at least 1",
+        ):
+            tkw._check_n_conformers(mol, "nocharge", min_confs=1)
         # Check with min=1 and strict_n_conformers should raise an error
-        with pytest.raises(IncorrectNumConformersError,
-                           match="has 0 conformers, but charge method 'nocharge' expects at least 1"):
-            tkw._check_n_conformers(mol, 'nocharge', min_confs=1, strict_n_conformers=True)
+        with pytest.raises(
+            IncorrectNumConformersError,
+            match="has 0 conformers, but charge method 'nocharge' expects at least 1",
+        ):
+            tkw._check_n_conformers(
+                mol, "nocharge", min_confs=1, strict_n_conformers=True
+            )
         # Check with min=1, max=1 and strict_n_conformers should raise an error
-        with pytest.raises(IncorrectNumConformersError,
-                           match="has 0 conformers, but charge method 'nocharge' expects exactly 1"):
-            tkw._check_n_conformers(mol, 'nocharge', min_confs=1, max_confs=1, strict_n_conformers=True)
+        with pytest.raises(
+            IncorrectNumConformersError,
+            match="has 0 conformers, but charge method 'nocharge' expects exactly 1",
+        ):
+            tkw._check_n_conformers(
+                mol, "nocharge", min_confs=1, max_confs=1, strict_n_conformers=True
+            )
         # Check with min=1, max=2 and strict_n_conformers should raise an error
-        with pytest.raises(IncorrectNumConformersError,
-                           match="has 0 conformers, but charge method 'nocharge' expects between 1 and 2"):
-            tkw._check_n_conformers(mol, 'nocharge', min_confs=1, max_confs=2, strict_n_conformers=True)
+        with pytest.raises(
+            IncorrectNumConformersError,
+            match="has 0 conformers, but charge method 'nocharge' expects between 1 and 2",
+        ):
+            tkw._check_n_conformers(
+                mol, "nocharge", min_confs=1, max_confs=2, strict_n_conformers=True
+            )
         # Check with max=1 should pass
-        tkw._check_n_conformers(mol, 'nocharge', max_confs=1, strict_n_conformers=True)
+        tkw._check_n_conformers(mol, "nocharge", max_confs=1, strict_n_conformers=True)
 
         ## Test molecule with conformers
         # Add some conformers
@@ -2258,205 +3004,339 @@ class TestToolkitWrapper:
             mol.add_conformer(mol.conformers[0])
 
         # Check with no min or max should pass
-        tkw._check_n_conformers(mol, 'nocharge')
+        tkw._check_n_conformers(mol, "nocharge")
 
         ## min_confs checks
         # Check with min=1 should be fine
-        tkw._check_n_conformers(mol, 'nocharge', min_confs=1)
+        tkw._check_n_conformers(mol, "nocharge", min_confs=1)
         # Check with min=10 should be fine
-        tkw._check_n_conformers(mol, 'nocharge', min_confs=10)
+        tkw._check_n_conformers(mol, "nocharge", min_confs=10)
         # Check with min=11 should warn
-        with pytest.warns(IncorrectNumConformersWarning,
-                           match="has 10 conformers, but charge method 'nocharge' expects at least 11"):
-            tkw._check_n_conformers(mol, 'nocharge', min_confs=11)
+        with pytest.warns(
+            IncorrectNumConformersWarning,
+            match="has 10 conformers, but charge method 'nocharge' expects at least 11",
+        ):
+            tkw._check_n_conformers(mol, "nocharge", min_confs=11)
         # Check with min=11 and strict_n_conformers should raise an error
-        with pytest.raises(IncorrectNumConformersError,
-                           match="has 10 conformers, but charge method 'nocharge' expects at least 11"):
-            tkw._check_n_conformers(mol, 'nocharge', min_confs=11, strict_n_conformers=True)
+        with pytest.raises(
+            IncorrectNumConformersError,
+            match="has 10 conformers, but charge method 'nocharge' expects at least 11",
+        ):
+            tkw._check_n_conformers(
+                mol, "nocharge", min_confs=11, strict_n_conformers=True
+            )
 
         ## max_confs checks
         # Check with max=1 and strict_n_conformers should raise an error
-        with pytest.raises(IncorrectNumConformersError,
-                           match="has 10 conformers, but charge method 'nocharge' expects at most 1"):
-            tkw._check_n_conformers(mol, 'nocharge', max_confs=1, strict_n_conformers=True)
+        with pytest.raises(
+            IncorrectNumConformersError,
+            match="has 10 conformers, but charge method 'nocharge' expects at most 1",
+        ):
+            tkw._check_n_conformers(
+                mol, "nocharge", max_confs=1, strict_n_conformers=True
+            )
         # Check with max=10 and strict_n_conformers should be OK
-        tkw._check_n_conformers(mol, 'nocharge', max_confs=10, strict_n_conformers=True)
+        tkw._check_n_conformers(mol, "nocharge", max_confs=10, strict_n_conformers=True)
         # Check with max=11 and strict_n_conformers should be OK
-        tkw._check_n_conformers(mol, 'nocharge', max_confs=11, strict_n_conformers=True)
+        tkw._check_n_conformers(mol, "nocharge", max_confs=11, strict_n_conformers=True)
 
         ## min_confs and max_confs checks
         # Check with max=10 and min=10 and strict_n_conformers should be OK
-        tkw._check_n_conformers(mol, 'nocharge', min_confs=10, max_confs=10, strict_n_conformers=True)
+        tkw._check_n_conformers(
+            mol, "nocharge", min_confs=10, max_confs=10, strict_n_conformers=True
+        )
         # Check with max=10 and min=9 and strict_n_conformers should be OK
-        tkw._check_n_conformers(mol, 'nocharge', min_confs=9, max_confs=10, strict_n_conformers=True)
+        tkw._check_n_conformers(
+            mol, "nocharge", min_confs=9, max_confs=10, strict_n_conformers=True
+        )
         # Check with max=11 and min=10 and strict_n_conformers should be OK
-        tkw._check_n_conformers(mol, 'nocharge', min_confs=10, max_confs=11, strict_n_conformers=True)
+        tkw._check_n_conformers(
+            mol, "nocharge", min_confs=10, max_confs=11, strict_n_conformers=True
+        )
         # Check with max=11 and min=9 and strict_n_conformers should be OK
-        tkw._check_n_conformers(mol, 'nocharge', min_confs=9, max_confs=11, strict_n_conformers=True)
+        tkw._check_n_conformers(
+            mol, "nocharge", min_confs=9, max_confs=11, strict_n_conformers=True
+        )
         # Check with min=9 and max=9 and strict_n_conformers should raise an error
-        with pytest.raises(IncorrectNumConformersError,
-                           match="has 10 conformers, but charge method 'nocharge' expects exactly 9"):
-            tkw._check_n_conformers(mol, 'nocharge', min_confs=9, max_confs=9, strict_n_conformers=True)
+        with pytest.raises(
+            IncorrectNumConformersError,
+            match="has 10 conformers, but charge method 'nocharge' expects exactly 9",
+        ):
+            tkw._check_n_conformers(
+                mol, "nocharge", min_confs=9, max_confs=9, strict_n_conformers=True
+            )
         # Check with min=1 and max=9 and strict_n_conformers should raise an error
-        with pytest.raises(IncorrectNumConformersError,
-                           match="has 10 conformers, but charge method 'nocharge' expects between 1 and 9"):
-            tkw._check_n_conformers(mol, 'nocharge', min_confs=1, max_confs=9, strict_n_conformers=True)
+        with pytest.raises(
+            IncorrectNumConformersError,
+            match="has 10 conformers, but charge method 'nocharge' expects between 1 and 9",
+        ):
+            tkw._check_n_conformers(
+                mol, "nocharge", min_confs=1, max_confs=9, strict_n_conformers=True
+            )
         # Check with min=11 and max=12 and strict_n_conformers should raise an error
-        with pytest.raises(IncorrectNumConformersError,
-                           match="has 10 conformers, but charge method 'nocharge' expects between 11 and 12"):
-            tkw._check_n_conformers(mol, 'nocharge', min_confs=11, max_confs=12, strict_n_conformers=True)
+        with pytest.raises(
+            IncorrectNumConformersError,
+            match="has 10 conformers, but charge method 'nocharge' expects between 11 and 12",
+        ):
+            tkw._check_n_conformers(
+                mol, "nocharge", min_confs=11, max_confs=12, strict_n_conformers=True
+            )
 
 
 class TestToolkitRegistry:
     """Test the ToolkitRegistry class"""
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_add_bad_toolkit(self):
         registry = ToolkitRegistry(toolkit_precedence=[RDKitToolkitWrapper])
         with pytest.raises(InvalidToolkitError):
-            registry.add_toolkit('rdkit as a string')
+            registry.add_toolkit("rdkit as a string")
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
-    @pytest.mark.skipif(OpenEyeToolkitWrapper.is_available(), reason='Skipping while OpenEye is available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
+    @pytest.mark.skipif(
+        OpenEyeToolkitWrapper.is_available(),
+        reason="Skipping while OpenEye is available",
+    )
     def test_register_unavailable_toolkit(self):
         registry = ToolkitRegistry(toolkit_precedence=[RDKitToolkitWrapper])
         with pytest.raises(ToolkitUnavailableException):
-            registry.register_toolkit(toolkit_wrapper=OpenEyeToolkitWrapper, exception_if_unavailable=True)
+            registry.register_toolkit(
+                toolkit_wrapper=OpenEyeToolkitWrapper, exception_if_unavailable=True
+            )
 
-    @pytest.mark.skipif(not OpenEyeToolkitWrapper.is_available(), reason='OpenEye Toolkit not available')
+    @pytest.mark.skipif(
+        not OpenEyeToolkitWrapper.is_available(), reason="OpenEye Toolkit not available"
+    )
     def test_register_openeye(self):
         """Test creation of toolkit registry with OpenEye toolkit"""
         # Test registration of OpenEyeToolkitWrapper
         toolkit_precedence = [OpenEyeToolkitWrapper]
-        registry = ToolkitRegistry(toolkit_precedence=toolkit_precedence, register_imported_toolkit_wrappers=False)
+        registry = ToolkitRegistry(
+            toolkit_precedence=toolkit_precedence,
+            register_imported_toolkit_wrappers=False,
+        )
 
-        assert set(type(c) for c in registry.registered_toolkits) == set([OpenEyeToolkitWrapper])
+        assert set(type(c) for c in registry.registered_toolkits) == set(
+            [OpenEyeToolkitWrapper]
+        )
 
         # Test ToolkitRegistry.resolve()
-        assert registry.resolve('to_smiles') == registry.registered_toolkits[0].to_smiles
+        assert (
+            registry.resolve("to_smiles") == registry.registered_toolkits[0].to_smiles
+        )
 
         # Test ToolkitRegistry.call()
-        smiles = '[H]C([H])([H])C([H])([H])[H]'
-        molecule = registry.call('from_smiles', smiles)
-        smiles2 = registry.call('to_smiles', molecule)
+        smiles = "[H]C([H])([H])C([H])([H])[H]"
+        molecule = registry.call("from_smiles", smiles)
+        smiles2 = registry.call("to_smiles", molecule)
         assert smiles == smiles2
 
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_register_rdkit(self):
         """Test creation of toolkit registry with RDKit toolkit"""
         # Test registration of RDKitToolkitWrapper
         toolkit_precedence = [RDKitToolkitWrapper]
-        registry = ToolkitRegistry(toolkit_precedence=toolkit_precedence,
-                                   register_imported_toolkit_wrappers=False)
+        registry = ToolkitRegistry(
+            toolkit_precedence=toolkit_precedence,
+            register_imported_toolkit_wrappers=False,
+        )
 
-        assert set([ type(c) for c in registry.registered_toolkits]) == set([RDKitToolkitWrapper])
+        assert set([type(c) for c in registry.registered_toolkits]) == set(
+            [RDKitToolkitWrapper]
+        )
 
         # Test ToolkitRegistry.resolve()
-        assert registry.resolve('to_smiles') == registry.registered_toolkits[0].to_smiles
+        assert (
+            registry.resolve("to_smiles") == registry.registered_toolkits[0].to_smiles
+        )
 
         # Test ToolkitRegistry.call()
-        smiles = '[H][C]([H])([H])[C]([H])([H])[H]'
-        molecule = registry.call('from_smiles', smiles)
-        smiles2 = registry.call('to_smiles', molecule)
+        smiles = "[H][C]([H])([H])[C]([H])([H])[H]"
+        molecule = registry.call("from_smiles", smiles)
+        smiles2 = registry.call("to_smiles", molecule)
         assert smiles == smiles2
 
     @pytest.mark.skipif(
-        not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-        reason='RDKitToolkitWrapper or AmberToolsToolkit is not available'
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkitWrapper or AmberToolsToolkit is not available",
     )
     def test_register_ambertools(self):
         """Test creation of toolkit registry with AmberToolsToolkitWrapper"""
         # Test registration of AmberToolsToolkitWrapper
         toolkit_precedence = [AmberToolsToolkitWrapper]
-        registry = ToolkitRegistry(toolkit_precedence=toolkit_precedence,
-                                   register_imported_toolkit_wrappers=False)
+        registry = ToolkitRegistry(
+            toolkit_precedence=toolkit_precedence,
+            register_imported_toolkit_wrappers=False,
+        )
 
-        assert set([ type(c) for c in registry.registered_toolkits]) == set([AmberToolsToolkitWrapper])
+        assert set([type(c) for c in registry.registered_toolkits]) == set(
+            [AmberToolsToolkitWrapper]
+        )
 
         # Test ToolkitRegistry.resolve()
-        registry.resolve('assign_partial_charges')
-        assert registry.resolve('assign_partial_charges') == registry.registered_toolkits[0].assign_partial_charges
+        registry.resolve("assign_partial_charges")
+        assert (
+            registry.resolve("assign_partial_charges")
+            == registry.registered_toolkits[0].assign_partial_charges
+        )
 
         # Test ToolkitRegistry.call()
-        molecule = RDKitToolkitWrapper().from_file(file_path=get_data_file_path('molecules/ethanol.sdf'), file_format='SDF')[0]
-        registry.call('assign_partial_charges', molecule)
+        molecule = RDKitToolkitWrapper().from_file(
+            file_path=get_data_file_path("molecules/ethanol.sdf"), file_format="SDF"
+        )[0]
+        registry.call("assign_partial_charges", molecule)
         charges_from_registry = molecule.partial_charges
         AmberToolsToolkitWrapper().assign_partial_charges(molecule)
         charges_from_toolkit = molecule.partial_charges
 
         assert np.allclose(charges_from_registry, charges_from_toolkit)
 
-    @pytest.mark.skipif(not AmberToolsToolkitWrapper.is_available(),
-                        reason='AmberToolsToolkit not available')
-    @pytest.mark.skipif(not RDKitToolkitWrapper.is_available(), reason='RDKit Toolkit not available')
+    @pytest.mark.skipif(
+        not AmberToolsToolkitWrapper.is_available(),
+        reason="AmberToolsToolkit not available",
+    )
+    @pytest.mark.skipif(
+        not RDKitToolkitWrapper.is_available(), reason="RDKit Toolkit not available"
+    )
     def test_register_rdkit_and_ambertools(self):
         """Test creation of toolkit registry with RDKitToolkitWrapper and AmberToolsToolkitWrapper"""
         toolkit_precedence = [RDKitToolkitWrapper, AmberToolsToolkitWrapper]
-        registry = ToolkitRegistry(toolkit_precedence=toolkit_precedence,
-                                   register_imported_toolkit_wrappers=False)
+        registry = ToolkitRegistry(
+            toolkit_precedence=toolkit_precedence,
+            register_imported_toolkit_wrappers=False,
+        )
 
-        assert set([ type(c) for c in registry.registered_toolkits]) == set([RDKitToolkitWrapper, AmberToolsToolkitWrapper])
+        assert set([type(c) for c in registry.registered_toolkits]) == set(
+            [RDKitToolkitWrapper, AmberToolsToolkitWrapper]
+        )
 
         # Test ToolkitRegistry.resolve()
-        assert registry.resolve('assign_partial_charges') == registry.registered_toolkits[1].assign_partial_charges
-        assert registry.resolve('from_smiles') == registry.registered_toolkits[0].from_smiles
+        assert (
+            registry.resolve("assign_partial_charges")
+            == registry.registered_toolkits[1].assign_partial_charges
+        )
+        assert (
+            registry.resolve("from_smiles")
+            == registry.registered_toolkits[0].from_smiles
+        )
 
         # Test ToolkitRegistry.call() for each toolkit
-        smiles = '[H][C]([H])([H])[C]([H])([H])[H]'
-        molecule = registry.call('from_smiles', smiles)
-        smiles2 = registry.call('to_smiles', molecule)
+        smiles = "[H][C]([H])([H])[C]([H])([H])[H]"
+        molecule = registry.call("from_smiles", smiles)
+        smiles2 = registry.call("to_smiles", molecule)
 
         # Round-tripping SMILES is not 100% reliable, so just ensure it returned something
         assert isinstance(smiles2, str)
 
         # This method is available in AmberToolsToolkitWrapper, but not RDKitToolkitWrapper
-        registry.call('assign_partial_charges', molecule)
+        registry.call("assign_partial_charges", molecule)
 
     @pytest.mark.skipif(
-        not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-        reason='RDKitToolkit or AmberToolsToolkit is not available')
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit or AmberToolsToolkit is not available",
+    )
     def test_deregister_toolkit(self):
         """Test removing an instantiated toolkit from the registry"""
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
 
-        assert any([isinstance(tk, AmberToolsToolkitWrapper) for tk in toolkit_registry._toolkits])
-        assert any([isinstance(tk, RDKitToolkitWrapper) for tk in toolkit_registry._toolkits])
+        assert any(
+            [
+                isinstance(tk, AmberToolsToolkitWrapper)
+                for tk in toolkit_registry._toolkits
+            ]
+        )
+        assert any(
+            [isinstance(tk, RDKitToolkitWrapper) for tk in toolkit_registry._toolkits]
+        )
 
         toolkit_registry.deregister_toolkit(toolkit_registry._toolkits[-1])
-        assert any([isinstance(tk, AmberToolsToolkitWrapper) for tk in toolkit_registry._toolkits])
-        assert not any([isinstance(tk, RDKitToolkitWrapper) for tk in toolkit_registry._toolkits])
+        assert any(
+            [
+                isinstance(tk, AmberToolsToolkitWrapper)
+                for tk in toolkit_registry._toolkits
+            ]
+        )
+        assert not any(
+            [isinstance(tk, RDKitToolkitWrapper) for tk in toolkit_registry._toolkits]
+        )
 
         toolkit_registry.deregister_toolkit(toolkit_registry._toolkits[-1])
-        assert not any([isinstance(tk, AmberToolsToolkitWrapper) for tk in toolkit_registry._toolkits])
-        assert not any([isinstance(tk, RDKitToolkitWrapper) for tk in toolkit_registry._toolkits])
+        assert not any(
+            [
+                isinstance(tk, AmberToolsToolkitWrapper)
+                for tk in toolkit_registry._toolkits
+            ]
+        )
+        assert not any(
+            [isinstance(tk, RDKitToolkitWrapper) for tk in toolkit_registry._toolkits]
+        )
 
     @pytest.mark.skipif(
-        not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-        reason='RDKitToolkit and AmberToolsToolkit not available')
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
     def test_deregister_toolkit_by_class(self):
         """Test removing a toolkit from the registry by matching class types"""
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper])
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper, RDKitToolkitWrapper]
+        )
 
-        assert any([isinstance(tk, AmberToolsToolkitWrapper) for tk in toolkit_registry._toolkits])
-        assert any([isinstance(tk, RDKitToolkitWrapper) for tk in toolkit_registry._toolkits])
+        assert any(
+            [
+                isinstance(tk, AmberToolsToolkitWrapper)
+                for tk in toolkit_registry._toolkits
+            ]
+        )
+        assert any(
+            [isinstance(tk, RDKitToolkitWrapper) for tk in toolkit_registry._toolkits]
+        )
 
         toolkit_registry.deregister_toolkit(RDKitToolkitWrapper)
-        assert any([isinstance(tk, AmberToolsToolkitWrapper) for tk in toolkit_registry._toolkits])
-        assert not any([isinstance(tk, RDKitToolkitWrapper) for tk in toolkit_registry._toolkits])
+        assert any(
+            [
+                isinstance(tk, AmberToolsToolkitWrapper)
+                for tk in toolkit_registry._toolkits
+            ]
+        )
+        assert not any(
+            [isinstance(tk, RDKitToolkitWrapper) for tk in toolkit_registry._toolkits]
+        )
 
         toolkit_registry.deregister_toolkit(AmberToolsToolkitWrapper)
-        assert not any([isinstance(tk, AmberToolsToolkitWrapper) for tk in toolkit_registry._toolkits])
-        assert not any([isinstance(tk, RDKitToolkitWrapper) for tk in toolkit_registry._toolkits])
+        assert not any(
+            [
+                isinstance(tk, AmberToolsToolkitWrapper)
+                for tk in toolkit_registry._toolkits
+            ]
+        )
+        assert not any(
+            [isinstance(tk, RDKitToolkitWrapper) for tk in toolkit_registry._toolkits]
+        )
 
     @pytest.mark.skipif(
-        not RDKitToolkitWrapper.is_available() or not AmberToolsToolkitWrapper.is_available(),
-        reason='RDKitToolkit and AmberToolsToolkit not available')
+        not RDKitToolkitWrapper.is_available()
+        or not AmberToolsToolkitWrapper.is_available(),
+        reason="RDKitToolkit and AmberToolsToolkit not available",
+    )
     def test_deregister_toolkit_bad_inputs(self):
         """Test bad inputs to deregister_toolkit"""
-        toolkit_registry = ToolkitRegistry(toolkit_precedence=[AmberToolsToolkitWrapper])
+        toolkit_registry = ToolkitRegistry(
+            toolkit_precedence=[AmberToolsToolkitWrapper]
+        )
 
         with pytest.raises(InvalidToolkitError):
-            toolkit_registry.deregister_toolkit('rdkit as a string')
+            toolkit_registry.deregister_toolkit("rdkit as a string")
 
         # Attempt to deregister a toolkit that is not registered
         with pytest.raises(ToolkitUnavailableException):
@@ -2469,13 +3349,16 @@ class TestToolkitRegistry:
 
         # Keep a copy of the original registry since this is a "global" variable accessible to other modules
         from copy import deepcopy
+
         global_registry_copy = deepcopy(GLOBAL_TOOLKIT_REGISTRY)
         first_toolkit = type(GLOBAL_TOOLKIT_REGISTRY.registered_toolkits[0])
         num_toolkits = len(GLOBAL_TOOLKIT_REGISTRY.registered_toolkits)
 
         GLOBAL_TOOLKIT_REGISTRY.deregister_toolkit(first_toolkit)
 
-        assert first_toolkit not in [type(tk) for tk in GLOBAL_TOOLKIT_REGISTRY.registered_toolkits]
+        assert first_toolkit not in [
+            type(tk) for tk in GLOBAL_TOOLKIT_REGISTRY.registered_toolkits
+        ]
         assert len(GLOBAL_TOOLKIT_REGISTRY.registered_toolkits) == num_toolkits - 1
 
         GLOBAL_TOOLKIT_REGISTRY = deepcopy(global_registry_copy)
@@ -2484,31 +3367,57 @@ class TestToolkitRegistry:
         """Test creation of toolkit registry with Built-in toolkit"""
         # Test registration of BuiltInToolkitWrapper
         toolkit_precedence = [BuiltInToolkitWrapper]
-        registry = ToolkitRegistry(toolkit_precedence=toolkit_precedence,
-                                   register_imported_toolkit_wrappers=False)
-        #registry.register_toolkit(BuiltInToolkitWrapper)
-        assert set([ type(c) for c in registry.registered_toolkits]) == set([BuiltInToolkitWrapper])
+        registry = ToolkitRegistry(
+            toolkit_precedence=toolkit_precedence,
+            register_imported_toolkit_wrappers=False,
+        )
+        # registry.register_toolkit(BuiltInToolkitWrapper)
+        assert set([type(c) for c in registry.registered_toolkits]) == set(
+            [BuiltInToolkitWrapper]
+        )
 
         # Test ToolkitRegistry.resolve()
-        assert registry.resolve('assign_partial_charges') == registry.registered_toolkits[0].assign_partial_charges
+        assert (
+            registry.resolve("assign_partial_charges")
+            == registry.registered_toolkits[0].assign_partial_charges
+        )
 
-    @pytest.mark.skipif(not AmberToolsToolkitWrapper.is_available(), reason='AmberTools Toolkit not available')
+    @pytest.mark.skipif(
+        not AmberToolsToolkitWrapper.is_available(),
+        reason="AmberTools Toolkit not available",
+    )
     def test_call_raise_first_error(self):
         """Test to ensure proper behavior of raise_first_error kwarg to ToolkitRegistry.call"""
-        toolkit_precedence = [BuiltInToolkitWrapper, RDKitToolkitWrapper, AmberToolsToolkitWrapper]
-        registry = ToolkitRegistry(toolkit_precedence=toolkit_precedence,
-                                   register_imported_toolkit_wrappers=False)
-        mol = registry.call('from_smiles', 'C')
+        toolkit_precedence = [
+            BuiltInToolkitWrapper,
+            RDKitToolkitWrapper,
+            AmberToolsToolkitWrapper,
+        ]
+        registry = ToolkitRegistry(
+            toolkit_precedence=toolkit_precedence,
+            register_imported_toolkit_wrappers=False,
+        )
+        mol = registry.call("from_smiles", "C")
         # Specify that the ToolkitRegistry should raise the first ChargeMethodUnavailableError it encounters
-        with pytest.raises(ChargeMethodUnavailableError, match='"notarealchargemethod"" is not supported by the Built-in toolkit.'):
-            registry.call('assign_partial_charges',
-                          molecule=mol,
-                          partial_charge_method="NotARealChargeMethod",
-                          raise_exception_types=[ChargeMethodUnavailableError])
+        with pytest.raises(
+            ChargeMethodUnavailableError,
+            match='"notarealchargemethod"" is not supported by the Built-in toolkit.',
+        ):
+            registry.call(
+                "assign_partial_charges",
+                molecule=mol,
+                partial_charge_method="NotARealChargeMethod",
+                raise_exception_types=[ChargeMethodUnavailableError],
+            )
         # Specify that the ToolkitRegistry should collect all the errors it encounters and
         # ensure it raises a single ValueError when no ToolkitWrappers succeed
-        with pytest.raises(ValueError, match="partial_charge_method \'notarealchargemethod\' is not available from AmberToolsToolkitWrapper"):
-            registry.call('assign_partial_charges',
-                          molecule=mol,
-                          partial_charge_method="NotARealChargeMethod",
-                          raise_exception_types=[])
+        with pytest.raises(
+            ValueError,
+            match="partial_charge_method 'notarealchargemethod' is not available from AmberToolsToolkitWrapper",
+        ):
+            registry.call(
+                "assign_partial_charges",
+                molecule=mol,
+                partial_charge_method="NotARealChargeMethod",
+                raise_exception_types=[],
+            )

--- a/openforcefield/tests/test_utils.py
+++ b/openforcefield/tests/test_utils.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python
 
-#=============================================================================================
+# =============================================================================================
 # MODULE DOCSTRING
-#=============================================================================================
+# =============================================================================================
 
 """
 Tests for utility methods
 
 """
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import ast
 import os
@@ -22,58 +22,77 @@ from simtk import unit
 from openforcefield import utils
 
 
-#=============================================================================================
+# =============================================================================================
 # TESTS
-#=============================================================================================
+# =============================================================================================
+
 
 def test_subclasses():
     """Test that all subclasses (and descendents) are correctly identified by all_subclasses()"""
+
     class Foo:
         pass
+
     class FooSubclass1(Foo):
         pass
+
     class FooSubclass2(Foo):
         pass
+
     class FooSubSubclass(FooSubclass1):
         pass
 
-    subclass_names = [ cls.__name__ for cls in utils.all_subclasses(Foo) ]
-    assert set(subclass_names) == set(['FooSubclass1', 'FooSubclass2', 'FooSubSubclass'])
+    subclass_names = [cls.__name__ for cls in utils.all_subclasses(Foo)]
+    assert set(subclass_names) == set(
+        ["FooSubclass1", "FooSubclass2", "FooSubSubclass"]
+    )
+
 
 def test_temporary_cd():
     """Test temporary_cd() context manager"""
     initial_dir = os.getcwd()
-    temporary_dir = '/'
+    temporary_dir = "/"
     from openforcefield.utils import temporary_cd
+
     with temporary_cd(temporary_dir):
         assert os.getcwd() == temporary_dir
     assert os.getcwd() == initial_dir
 
+
 def test_get_data_file_path():
     """Test get_data_file_path()"""
     from openforcefield.utils import get_data_file_path
-    filename = get_data_file_path('test_forcefields/tip3p.offxml')
+
+    filename = get_data_file_path("test_forcefields/tip3p.offxml")
     assert os.path.exists(filename)
 
 
-@pytest.mark.parametrize('unit_string,expected_unit',[
-    ('kilocalories_per_mole', unit.kilocalories_per_mole),
-    ('kilocalories_per_mole/angstrom**2', unit.kilocalories_per_mole/unit.angstrom**2),
-    ('joule/(mole * nanometer**2)', unit.joule/(unit.mole * unit.nanometer**2)),
-    ('picosecond**(-1)', unit.picosecond**(-1)),
-    ('300.0 * kelvin', 300*unit.kelvin),
-    ('1 * kilojoule + 500 * joule', 1.5*unit.kilojoule),
-    ('1 / meter', 1.0 / unit.meter)
-])
+@pytest.mark.parametrize(
+    "unit_string,expected_unit",
+    [
+        ("kilocalories_per_mole", unit.kilocalories_per_mole),
+        (
+            "kilocalories_per_mole/angstrom**2",
+            unit.kilocalories_per_mole / unit.angstrom ** 2,
+        ),
+        ("joule/(mole * nanometer**2)", unit.joule / (unit.mole * unit.nanometer ** 2)),
+        ("picosecond**(-1)", unit.picosecond ** (-1)),
+        ("300.0 * kelvin", 300 * unit.kelvin),
+        ("1 * kilojoule + 500 * joule", 1.5 * unit.kilojoule),
+        ("1 / meter", 1.0 / unit.meter),
+    ],
+)
 def test_ast_eval(unit_string, expected_unit):
     """Test that _ast_eval() correctly parses string quantities."""
     from openforcefield.utils.utils import _ast_eval
-    ast_root_node = ast.parse(unit_string, mode='eval').body
+
+    ast_root_node = ast.parse(unit_string, mode="eval").body
     parsed_units = _ast_eval(ast_root_node)
     assert parsed_units == expected_unit
 
+
 def test_dimensionless_units():
-    assert utils.string_to_unit('dimensionless') == unit.dimensionless
+    assert utils.string_to_unit("dimensionless") == unit.dimensionless
 
     unit_string = utils.unit_to_string(unit.dimensionless)
     unit_value = utils.string_to_unit(unit_string)

--- a/openforcefield/tests/test_utils_collections.py
+++ b/openforcefield/tests/test_utils_collections.py
@@ -24,8 +24,8 @@ from openforcefield.utils.collections import ValidatedList, ValidatedDict
 # Test Callbackable class
 # =====================================================================
 
-class TestValidatedMixin:
 
+class TestValidatedMixin:
     def test_pickle(self):
         """Test pickle roundtripping"""
         # TODO: implement this test
@@ -37,67 +37,69 @@ class TestValidatedList(TestValidatedMixin):
 
     def test_validators(self):
         """Validators of ValidatedList are called correctly."""
+
         def is_positive(value):
             if value <= 0:
-                raise TypeError('value is not positive')
+                raise TypeError("value is not positive")
 
         # The constructor should check all elements.
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             ValidatedList([1, -2], validator=is_positive)
 
         l = ValidatedList([1, 2, 3], validator=is_positive)
 
         # __setitem__()
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             l[2] = -1
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             l[0:2] = [2, 3, -1]
 
         # append()
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             l.append(-4)
 
         # extend() and __iadd__()
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             l.extend([6, -1])
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             l += [6, -1]
 
         # insert()
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             l.insert(1, -3)
 
     def test_converters(self):
         """Custom converters of ValidatedList are called correctly."""
         # All elements are converted on construction.
-        l = ValidatedList([1, 2.0, '3'], converter=int)
+        l = ValidatedList([1, 2.0, "3"], converter=int)
         assert l == [1, 2, 3]
 
         # __setitem__()
-        l[2] = '4'
+        l[2] = "4"
         assert l[2] == 4
-        l[0:3] = ['2', '3', 4]
+        l[0:3] = ["2", "3", 4]
         assert l == [2, 3, 4]
 
         # append()
-        l.append('5')
+        l.append("5")
         assert l[3] == 5
 
         # extend() and __iadd__()
-        l.extend([6, '7'])
+        l.extend([6, "7"])
         assert l[5] == 7
-        l += ['8', 9]
+        l += ["8", 9]
         assert l[6] == 8
 
         # insert()
-        l.insert(5, '10')
+        l.insert(5, "10")
         assert l[5] == 10
 
     def test_validators_and_converters(self):
         """Custom converters of ValidatedList are called correctly."""
+
         def is_positive(value):
             if value <= 0:
-                raise TypeError('value is not positive')
+                raise TypeError("value is not positive")
 
         # Validators are run after converters.
         l = ValidatedList([1, 2, -3], converter=abs, validator=is_positive)
@@ -106,54 +108,55 @@ class TestValidatedList(TestValidatedMixin):
         # __setitem__
         l[2] = -1
         assert l[2] == 1
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             l[2] = 0
         l[0:3] = [2, 3, -1]
         assert l == [2, 3, 1]
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             l[0:3] = [2, 3, 0]
 
         # append()
         l.append(-4)
         assert l[-1] == 4
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             l.append(0)
 
         # extend() and __iadd__()
         l.extend([6, -1])
         assert l[-2:] == [6, 1]
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             l.extend([6, 0])
         l += [6, -2]
         assert l[-2:] == [6, 2]
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             l += [6, 0]
 
         # insert()
         l.insert(1, -3)
         assert l[1] == 3
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             l.insert(1, 0)
 
     def test_multiple_converters(self):
         """Multiple converters of ValidatedList are called in order."""
         l = ValidatedList([1, 2, -3], converter=[abs, str])
-        assert l == ['1', '2', '3']
+        assert l == ["1", "2", "3"]
 
     def test_multiple_validators(self):
         """Multiple converters of ValidatedList are called in order."""
+
         def is_positive(value):
             if value <= 0:
-                raise TypeError('value must be positive')
+                raise TypeError("value must be positive")
 
         def is_odd(value):
             if value % 2 == 0:
-                raise TypeError('value must be odd')
+                raise TypeError("value must be odd")
 
-        with pytest.raises(TypeError, match='value must be positive'):
+        with pytest.raises(TypeError, match="value must be positive"):
             ValidatedList([-1, -3], validator=[is_positive, is_odd])
 
-        with pytest.raises(TypeError, match='value must be odd'):
+        with pytest.raises(TypeError, match="value must be odd"):
             ValidatedList([2, 4], validator=[is_positive, is_odd])
 
     def test_copy(self):
@@ -174,95 +177,100 @@ class TestValidatedDict(TestValidatedMixin):
 
     def test_validators(self):
         """Validators of ValidatedDict are called correctly."""
+
         def is_positive(value):
             if value <= 0:
-                raise TypeError('value is not positive')
+                raise TypeError("value is not positive")
 
         # The constructor should check all elements.
-        with pytest.raises(TypeError, match='value is not positive'):
-            ValidatedDict({'a': 1, 'b': -2}, validator=is_positive)
+        with pytest.raises(TypeError, match="value is not positive"):
+            ValidatedDict({"a": 1, "b": -2}, validator=is_positive)
 
-        d = ValidatedDict({'x': 1, 'y': 2, 'z': 3}, validator=is_positive)
+        d = ValidatedDict({"x": 1, "y": 2, "z": 3}, validator=is_positive)
 
         # __setitem__()
-        with pytest.raises(TypeError, match='value is not positive'):
-            d['me!'] = -1
+        with pytest.raises(TypeError, match="value is not positive"):
+            d["me!"] = -1
 
         # update()
-        with pytest.raises(TypeError, match='value is not positive'):
-            d.update((('moe', 2), ('larry', 3), ('curly', -4)))
-        with pytest.raises(TypeError, match='value is not positive'):
-            d.update({'moe': 2, 'larry': 3, 'curly': -4})
+        with pytest.raises(TypeError, match="value is not positive"):
+            d.update((("moe", 2), ("larry", 3), ("curly", -4)))
+        with pytest.raises(TypeError, match="value is not positive"):
+            d.update({"moe": 2, "larry": 3, "curly": -4})
 
     def test_converters(self):
         """Custom converters of ValidatedDict are called correctly."""
         # All elements are converted on construction.
-        d = ValidatedDict({'x': 1, 'y': 2.0, 'z': '3'}, converter=int)
-        assert d == {'x': 1, 'y': 2, 'z': 3}
+        d = ValidatedDict({"x": 1, "y": 2.0, "z": "3"}, converter=int)
+        assert d == {"x": 1, "y": 2, "z": 3}
 
         # __setitem__()
-        d['y'] = '4'
-        assert d['y'] == 4
-        d['w'] = '-20'
-        assert d['w'] == -20
+        d["y"] = "4"
+        assert d["y"] == 4
+        d["w"] = "-20"
+        assert d["w"] == -20
 
         # update()
-        d.update({6: '7'})
+        d.update({6: "7"})
         assert d[6] == 7
 
-        d.update(((6, '8'), ('shemp', '-30')))
+        d.update(((6, "8"), ("shemp", "-30")))
         assert d[6] == 8
-        assert d['shemp'] == -30
+        assert d["shemp"] == -30
 
     def test_validators_and_converters(self):
         """Custom converters of ValidatedDict are called correctly."""
+
         def is_positive(value):
             if value <= 0:
-                raise TypeError('value is not positive')
+                raise TypeError("value is not positive")
 
         # Validators are run after converters.
-        d = ValidatedDict({'a': 1, 'b': 2, 'c': -3}, converter=abs, validator=is_positive)
-        assert d == {'a': 1, 'b': 2, 'c': 3}
+        d = ValidatedDict(
+            {"a": 1, "b": 2, "c": -3}, converter=abs, validator=is_positive
+        )
+        assert d == {"a": 1, "b": 2, "c": 3}
 
         # __setitem__
         d[2] = -1
         assert d[2] == 1
-        with pytest.raises(TypeError, match='value is not positive'):
+        with pytest.raises(TypeError, match="value is not positive"):
             d[2] = 0
 
         # update()
-        d.update({'x': 6, 'y': -1})
-        assert d['y'] == 1
-        with pytest.raises(TypeError, match='value is not positive'):
+        d.update({"x": 6, "y": -1})
+        assert d["y"] == 1
+        with pytest.raises(TypeError, match="value is not positive"):
             d.update({6: 0})
 
-        d.update((('x', 6), ('y', -1)))
-        assert d['y'] == 1
+        d.update((("x", 6), ("y", -1)))
+        assert d["y"] == 1
 
     def test_multiple_converters(self):
         """Multiple converters of ValidatedDict are called in order."""
-        d = ValidatedDict({'u': 1, 'v': 2, 'w': -3}, converter=[abs, str])
-        assert d == {'u': '1', 'v': '2', 'w': '3'}
+        d = ValidatedDict({"u": 1, "v": 2, "w": -3}, converter=[abs, str])
+        assert d == {"u": "1", "v": "2", "w": "3"}
 
     def test_multiple_validators(self):
         """Multiple converters of ValidatedDict are called in order."""
+
         def is_positive(value):
             if value <= 0:
-                raise TypeError('value must be positive')
+                raise TypeError("value must be positive")
 
         def is_odd(value):
             if value % 2 == 0:
-                raise TypeError('value must be odd')
+                raise TypeError("value must be odd")
 
-        with pytest.raises(TypeError, match='value must be positive'):
-            ValidatedDict({'first': -1, 'second': -3}, validator=[is_positive, is_odd])
+        with pytest.raises(TypeError, match="value must be positive"):
+            ValidatedDict({"first": -1, "second": -3}, validator=[is_positive, is_odd])
 
-        with pytest.raises(TypeError, match='value must be odd'):
-            ValidatedDict({'first': 2, 'second': 4}, validator=[is_positive, is_odd])
+        with pytest.raises(TypeError, match="value must be odd"):
+            ValidatedDict({"first": 2, "second": 4}, validator=[is_positive, is_odd])
 
     def test_copy(self):
         """A copy of a ValidatedDict returns another ValidatedDict."""
-        d = ValidatedDict({'a': 1, 'b': 2, 'c': 3})
+        d = ValidatedDict({"a": 1, "b": 2, "c": 3})
         assert isinstance(d.copy(), ValidatedDict)
         assert isinstance(copy.copy(d), ValidatedDict)
         assert isinstance(copy.deepcopy(d), ValidatedDict)

--- a/openforcefield/tests/test_utils_serialization.py
+++ b/openforcefield/tests/test_utils_serialization.py
@@ -1,42 +1,39 @@
 #!/usr/bin/env python
 
-#=============================================================================================
+# =============================================================================================
 # MODULE DOCSTRING
-#=============================================================================================
+# =============================================================================================
 
 """
 Tests for utility methods for serialization
 
 """
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import pytest
 
 
-#=============================================================================================
+# =============================================================================================
 # TESTS
-#=============================================================================================
+# =============================================================================================
 
 from openforcefield.utils.serialization import Serializable
 
-class Thing(Serializable):
 
+class Thing(Serializable):
     def __init__(self, description, mylist):
         self.description = description
         self.mylist = mylist
 
     def to_dict(self):
-        return {
-            'description' : self.description,
-            'mylist' : self.mylist
-        }
+        return {"description": self.description, "mylist": self.mylist}
 
     @classmethod
     def from_dict(cls, d):
-        return cls(d['description'], d['mylist'])
+        return cls(d["description"], d["mylist"])
 
     def __eq__(self, other):
         """Comparator for asserting object field equality."""
@@ -48,11 +45,11 @@ class Thing(Serializable):
 # DEBUG
 def write(filename, contents):
     if type(contents) == str:
-        mode = 'w'
+        mode = "w"
     elif type(contents) == bytes:
-        mode = 'wb'
+        mode = "wb"
     else:
-        raise Exception('Cannot handle contents of type {}'.format(type(contents)))
+        raise Exception("Cannot handle contents of type {}".format(type(contents)))
     with open(filename, mode) as outfile:
         outfile.write(contents)
 
@@ -62,7 +59,7 @@ class TestUtilsSerialization:
 
     @classmethod
     def setup_class(cls):
-        cls.thing = Thing('blorb', [1, 2, 3])
+        cls.thing = Thing("blorb", [1, 2, 3])
 
     def test_json(self):
         """Test JSON serialization"""
@@ -82,9 +79,13 @@ class TestUtilsSerialization:
         thing_from_bson = self.thing.__class__.from_bson(bson_thing)
         assert self.thing == thing_from_bson
 
-    @pytest.mark.wip(reason=("the current implementation of to_toml cannot handle dict "
-                             "keys associated to None (e.g. the ToolkitAM1BCC tag in the "
-                             "TestUtilsSMIRNOFFSerialization suite)."))
+    @pytest.mark.wip(
+        reason=(
+            "the current implementation of to_toml cannot handle dict "
+            "keys associated to None (e.g. the ToolkitAM1BCC tag in the "
+            "TestUtilsSMIRNOFFSerialization suite)."
+        )
+    )
     def test_toml(self):
         """Test TOML serialization"""
         toml_thing = self.thing.to_toml()
@@ -94,12 +95,16 @@ class TestUtilsSerialization:
     def test_messagepack(self):
         """Test MessagePack serialization"""
         messagepack_thing = self.thing.to_messagepack()
-        thing_from_messagepack = self.thing.__class__.from_messagepack(messagepack_thing)
+        thing_from_messagepack = self.thing.__class__.from_messagepack(
+            messagepack_thing
+        )
         assert self.thing == thing_from_messagepack
 
-    @pytest.mark.wip(reason='from/to_xml is not implemented yet. This test fails '
-                            'because the list of integers is saved in the XML as '
-                            'a list of numeric strings.')
+    @pytest.mark.wip(
+        reason="from/to_xml is not implemented yet. This test fails "
+        "because the list of integers is saved in the XML as "
+        "a list of numeric strings."
+    )
     def test_xml(self):
         """Test XML serialization"""
         xml_thing = self.thing.to_xml()
@@ -116,6 +121,7 @@ class TestUtilsSerialization:
 class DictionaryContainer(Serializable):
     def __init__(self, dictionary):
         import copy
+
         self.dictionary = copy.deepcopy(dictionary)
 
     def to_dict(self):
@@ -135,12 +141,13 @@ class TestUtilsSMIRNOFFSerialization(TestUtilsSerialization):
 
     @classmethod
     def setup_class(cls):
-        cls.thing = Thing('blorb', [1, 2, 3])
+        cls.thing = Thing("blorb", [1, 2, 3])
         # Create an example object holding the SMIRNOFF xmltodict dictionary representation
         import xmltodict
         from openforcefield.utils import get_data_file_path
-        filename = get_data_file_path('test_forcefields/smirnoff99Frosst.offxml')
-        with open(filename, 'r') as f:
+
+        filename = get_data_file_path("test_forcefields/smirnoff99Frosst.offxml")
+        with open(filename, "r") as f:
             xml = f.read()
             dictionary = xmltodict.parse(xml)
             cls.thing = DictionaryContainer(dictionary)

--- a/openforcefield/tests/utils.py
+++ b/openforcefield/tests/utils.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python
 
-#=============================================================================================
+# =============================================================================================
 # MODULE DOCSTRING
-#=============================================================================================
+# =============================================================================================
 
 """
 Utilities for testing.
 
 """
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import collections
 import copy
@@ -27,9 +27,10 @@ from simtk import unit, openmm
 from openforcefield.utils import get_data_file_path
 
 
-#=============================================================================================
+# =============================================================================================
 # Shortcut functions to get file paths to test data.
-#=============================================================================================
+# =============================================================================================
+
 
 def get_amber_file_path(prefix):
     """Get AMBER prmtop and inpcrd test data filepaths.
@@ -48,13 +49,13 @@ def get_amber_file_path(prefix):
         Absolute path to the AMBER inpcrd filepath in testdata/systems/amber
 
     """
-    prefix = os.path.join('systems', 'amber', prefix)
-    prmtop_filepath = get_data_file_path(prefix+'.prmtop')
-    inpcrd_filepath = get_data_file_path(prefix+'.inpcrd')
+    prefix = os.path.join("systems", "amber", prefix)
+    prmtop_filepath = get_data_file_path(prefix + ".prmtop")
+    inpcrd_filepath = get_data_file_path(prefix + ".inpcrd")
     return prmtop_filepath, inpcrd_filepath
 
 
-def get_packmol_pdb_file_path(prefix='cyclohexane_ethanol_0.4_0.6'):
+def get_packmol_pdb_file_path(prefix="cyclohexane_ethanol_0.4_0.6"):
     """Get PDB filename for a packmol-generated box
 
     Parameters
@@ -67,12 +68,12 @@ def get_packmol_pdb_file_path(prefix='cyclohexane_ethanol_0.4_0.6'):
     pdb_filename : str
         Absolute path to the PDB file
     """
-    prefix = os.path.join('systems', 'packmol_boxes', prefix)
-    pdb_filename = get_data_file_path(prefix+'.pdb')
+    prefix = os.path.join("systems", "packmol_boxes", prefix)
+    pdb_filename = get_data_file_path(prefix + ".pdb")
     return pdb_filename
 
 
-def get_monomer_mol2_file_path(prefix='ethanol'):
+def get_monomer_mol2_file_path(prefix="ethanol"):
     """Get absolute filepath for a mol2 file denoting a small molecule monomer in testdata
 
     Parameters
@@ -86,19 +87,21 @@ def get_monomer_mol2_file_path(prefix='ethanol'):
         Absolute path to the mol2 file
     """
     # TODO: The mol2 files in this folder are not tripos mol2 files. Delete or convert them.
-    prefix = os.path.join('systems', 'monomers', prefix)
-    mol2_filename = get_data_file_path(prefix + '.mol2')
+    prefix = os.path.join("systems", "monomers", prefix)
+    mol2_filename = get_data_file_path(prefix + ".mol2")
     return mol2_filename
 
 
 def extract_compressed_molecules(tar_file_name, file_subpaths=None, filter_func=None):
     if (file_subpaths is None) == (filter_func is None):
-        raise ValueError('Only one between file_subpaths and filter_func must be specified.')
+        raise ValueError(
+            "Only one between file_subpaths and filter_func must be specified."
+        )
 
     # Find the path of the tarfile with respect to the data/molecules/ folder.
-    molecules_dir_path = get_data_file_path('molecules')
+    molecules_dir_path = get_data_file_path("molecules")
     tar_file_path = os.path.join(molecules_dir_path, tar_file_name)
-    tar_root_dir_name = tar_file_name.split('.')[0]
+    tar_root_dir_name = tar_file_name.split(".")[0]
 
     # Return value: Paths to the extracted molecules.
     extracted_file_paths = None
@@ -107,14 +110,18 @@ def extract_compressed_molecules(tar_file_name, file_subpaths=None, filter_func=
     if file_subpaths is not None:
         # We can already check the paths of the extracted files
         # and skipping opening the tarball if not necessary.
-        extracted_file_paths = [os.path.join(molecules_dir_path, tar_root_dir_name, file_subpath)
-                                for file_subpath in file_subpaths]
+        extracted_file_paths = [
+            os.path.join(molecules_dir_path, tar_root_dir_name, file_subpath)
+            for file_subpath in file_subpaths
+        ]
 
         # Remove files that we have already extracted.
         # Also, we augument the subpath with its root directory.
-        file_subpaths_set = {os.path.join(tar_root_dir_name, subpath)
-                             for subpath, fullpath in zip(file_subpaths, extracted_file_paths)
-                             if not os.path.isfile(fullpath)}
+        file_subpaths_set = {
+            os.path.join(tar_root_dir_name, subpath)
+            for subpath, fullpath in zip(file_subpaths, extracted_file_paths)
+            if not os.path.isfile(fullpath)
+        }
 
         # If everything was already extracted, we don't need to open the tarball.
         if len(file_subpaths_set) == 0:
@@ -128,25 +135,30 @@ def extract_compressed_molecules(tar_file_name, file_subpaths=None, filter_func=
         filter_func = lambda x: True
 
     # Determine opening mode.
-    if '.gz' in tar_file_name:
-        mode = 'r:gz'
+    if ".gz" in tar_file_name:
+        mode = "r:gz"
     else:
-        mode = 'r'
+        mode = "r"
 
     # Extract required files.
     import tarfile
+
     with tarfile.open(tar_file_path, mode) as tar_file:
         # Gather the paths to extract. Remove the
         members = [m for m in tar_file.getmembers() if filter_func(m.name)]
 
         # Built the paths to the extracted molecules we didn't already.
         if extracted_file_paths is None:
-            extracted_file_paths = [os.path.join(molecules_dir_path, m.name)
-                                    for m in members]
+            extracted_file_paths = [
+                os.path.join(molecules_dir_path, m.name) for m in members
+            ]
 
         # Extract only the members that we haven't already extracted.
-        members = [member for member, fullpath in zip(members, extracted_file_paths)
-                   if not os.path.isfile(fullpath)]
+        members = [
+            member
+            for member, fullpath in zip(members, extracted_file_paths)
+            if not os.path.isfile(fullpath)
+        ]
         tar_file.extractall(path=molecules_dir_path, members=members)
 
     return extracted_file_paths
@@ -171,36 +183,39 @@ def get_alkethoh_file_path(alkethoh_name, get_amber=False):
 
     """
     # Determine if this is a ring or a chain molecule and the subfolder name.
-    is_ring = alkethoh_name[9] == 'r'
-    alkethoh_subdir_name = 'rings' if is_ring else 'chain'
-    alkethoh_subdir_name = 'AlkEthOH_' + alkethoh_subdir_name + '_filt1'
+    is_ring = alkethoh_name[9] == "r"
+    alkethoh_subdir_name = "rings" if is_ring else "chain"
+    alkethoh_subdir_name = "AlkEthOH_" + alkethoh_subdir_name + "_filt1"
 
     # Determine which paths have to be returned.
     file_base_subpath = os.path.join(alkethoh_subdir_name, alkethoh_name)
     # We always return the mol2 file.
-    file_subpaths = [file_base_subpath + '_tripos.mol2']
+    file_subpaths = [file_base_subpath + "_tripos.mol2"]
     # Check if we need to return also Amber files.
     if get_amber:
-        file_subpaths.append(file_base_subpath + '.top')
-        file_subpaths.append(file_base_subpath + '.crd')
+        file_subpaths.append(file_base_subpath + ".top")
+        file_subpaths.append(file_base_subpath + ".crd")
 
-    return extract_compressed_molecules('AlkEthOH_tripos.tar.gz', file_subpaths=file_subpaths)
+    return extract_compressed_molecules(
+        "AlkEthOH_tripos.tar.gz", file_subpaths=file_subpaths
+    )
 
 
 def get_freesolv_file_path(freesolv_id, ff_version):
-    file_base_name = 'mobley_' + freesolv_id
-    mol2_file_subpath = os.path.join('mol2files_sybyl', file_base_name + '.mol2')
-    xml_dir = 'xml_' + ff_version.replace('.', '_')
-    xml_file_subpath = os.path.join(xml_dir, file_base_name + '_vacuum.xml')
+    file_base_name = "mobley_" + freesolv_id
+    mol2_file_subpath = os.path.join("mol2files_sybyl", file_base_name + ".mol2")
+    xml_dir = "xml_" + ff_version.replace(".", "_")
+    xml_file_subpath = os.path.join(xml_dir, file_base_name + "_vacuum.xml")
 
     # Extract the files if needed.
     file_subpaths = [mol2_file_subpath, xml_file_subpath]
-    return extract_compressed_molecules('FreeSolv.tar.gz', file_subpaths=file_subpaths)
+    return extract_compressed_molecules("FreeSolv.tar.gz", file_subpaths=file_subpaths)
 
 
-#=============================================================================================
+# =============================================================================================
 # Shortcut functions to create System objects from system files.
-#=============================================================================================
+# =============================================================================================
+
 
 def create_system_from_amber(prmtop_file_path, inpcrd_file_path, *args, **kwargs):
     """Create an OpenMM System and Topology from the AMBER files.
@@ -237,9 +252,10 @@ def create_system_from_amber(prmtop_file_path, inpcrd_file_path, *args, **kwargs
     return system, prmtop_file.topology, positions
 
 
-#=============================================================================================
+# =============================================================================================
 # Utility functions for energy comparisons.
-#=============================================================================================
+# =============================================================================================
+
 
 def quantities_allclose(quantity1, quantity2, **kwargs):
     """Check if two Quantity objects are close.
@@ -265,16 +281,19 @@ def quantities_allclose(quantity1, quantity2, **kwargs):
     if isinstance(quantity1, unit.Quantity):
         # Check that the two Quantities have compatible units.
         if not quantity1.unit.is_compatible(quantity2.unit):
-            raise ValueError("The two quantities don't have compatible units: "
-                             "{} and {}".format(quantity1.unit, quantity2.unit))
+            raise ValueError(
+                "The two quantities don't have compatible units: "
+                "{} and {}".format(quantity1.unit, quantity2.unit)
+            )
         # Compare the values stripped of the units.
         quantity1 = quantity1.value_in_unit_system(unit.md_unit_system)
         quantity2 = quantity2.value_in_unit_system(unit.md_unit_system)
     return np.allclose(quantity1, quantity2, **kwargs)
 
 
-def get_context_potential_energy(context, positions, box_vectors=None,
-                                 by_force_group=True):
+def get_context_potential_energy(
+    context, positions, box_vectors=None, by_force_group=True
+):
     """Compute the potential energy of a System in a Context object.
 
     This is simply a shortcut that takes care of setting
@@ -331,13 +350,16 @@ class FailedEnergyComparisonError(AssertionError):
     potential_energy2
 
     """
+
     def __init__(self, err_msg, potential_energy1, potential_energy2):
         super().__init__(err_msg)
         self.potential_energy1 = potential_energy1
         self.potential_energy2 = potential_energy2
 
 
-def compare_context_energies(context1, context2, *args, rtol=1.e-5, atol=1.e-8, **kwargs):
+def compare_context_energies(
+    context1, context2, *args, rtol=1.0e-5, atol=1.0e-8, **kwargs
+):
     """Compare energies of two Contexts given the same positions.
 
     Parameters
@@ -394,17 +416,18 @@ def compare_context_energies(context1, context2, *args, rtol=1.e-5, atol=1.e-8, 
     # dictionary and we need to compare force group by force group.
     if isinstance(potential_energy1, unit.Quantity):
         raise_assert(
-            assertion=quantities_allclose(potential_energy1, potential_energy2,
-                                          rtol=rtol, atol=atol),
-            err_msg='potential energy 1 {}, potential energy 2: {}',
-            format_args=(potential_energy1, potential_energy2)
+            assertion=quantities_allclose(
+                potential_energy1, potential_energy2, rtol=rtol, atol=atol
+            ),
+            err_msg="potential energy 1 {}, potential energy 2: {}",
+            format_args=(potential_energy1, potential_energy2),
         )
     else:  # potential_energy1 is a dict.
         # If the two context expose different force groups raise an error.
         raise_assert(
             assertion=set(potential_energy1) == set(potential_energy2),
-            err_msg='The two contexts have different force groups: context1 {}, context2 {}',
-            format_args=(sorted(potential_energy1), sorted(potential_energy2))
+            err_msg="The two contexts have different force groups: context1 {}, context2 {}",
+            format_args=(sorted(potential_energy1), sorted(potential_energy2)),
         )
 
         # Check the potential energies of all force groups.
@@ -413,16 +436,24 @@ def compare_context_energies(context1, context2, *args, rtol=1.e-5, atol=1.e-8, 
             energy2 = potential_energy2[force_group]
             raise_assert(
                 assertion=quantities_allclose(energy1, energy2, rtol=rtol, atol=atol),
-                err_msg='Force group {} do not have the same energies: context1 {}, context2 {}',
-                format_args=(force_group, energy1, energy2)
+                err_msg="Force group {} do not have the same energies: context1 {}, context2 {}",
+                format_args=(force_group, energy1, energy2),
             )
 
     return potential_energy1, potential_energy2
 
 
-def compare_system_energies(system1, system2, positions, box_vectors=None,
-                            by_force_type=True, ignore_charges=False,
-                            modify_system=False, rtol=1.e-5, atol=1.e-8):
+def compare_system_energies(
+    system1,
+    system2,
+    positions,
+    box_vectors=None,
+    by_force_type=True,
+    ignore_charges=False,
+    modify_system=False,
+    rtol=1.0e-5,
+    atol=1.0e-8,
+):
     """Compare energies of two Systems given the same positions.
 
     Parameters
@@ -493,7 +524,7 @@ def compare_system_energies(system1, system2, positions, box_vectors=None,
         force_names1 = {f.__class__.__name__ for f in system1.getForces()}
         force_names2 = {f.__class__.__name__ for f in system2.getForces()}
         if set(force_names1) != set(force_names2):
-            err_msg = 'The two Systems have different forces to compare:\n - system1 {}\n - system2 {}'
+            err_msg = "The two Systems have different forces to compare:\n - system1 {}\n - system2 {}"
             raise ValueError(err_msg.format(sorted(force_names1), sorted(force_names2)))
 
         # Create a map from force group to force class and viceversa.
@@ -521,32 +552,49 @@ def compare_system_energies(system1, system2, positions, box_vectors=None,
 
             # Set particle charges to 0.0.
             for particle_idx in range(nonbonded_force.getNumParticles()):
-                charge, sigma, epsilon = nonbonded_force.getParticleParameters(particle_idx)
+                charge, sigma, epsilon = nonbonded_force.getParticleParameters(
+                    particle_idx
+                )
                 nonbonded_force.setParticleParameters(particle_idx, 0.0, sigma, epsilon)
 
             # Set particle exceptions charge products to 0.0.
             for exception_idx in range(nonbonded_force.getNumExceptions()):
-                atom1, atom2, chargeprod, sigma, epsilon = nonbonded_force.getExceptionParameters(exception_idx)
-                nonbonded_force.setExceptionParameters(exception_idx, atom1, atom2, 0.0, sigma, epsilon)
+                (
+                    atom1,
+                    atom2,
+                    chargeprod,
+                    sigma,
+                    epsilon,
+                ) = nonbonded_force.getExceptionParameters(exception_idx)
+                nonbonded_force.setExceptionParameters(
+                    exception_idx, atom1, atom2, 0.0, sigma, epsilon
+                )
 
     # Create Contexts and compare the energies.
-    integrator = openmm.VerletIntegrator(1.0*unit.femtoseconds)
+    integrator = openmm.VerletIntegrator(1.0 * unit.femtoseconds)
     context1 = openmm.Context(system1, integrator)
     context2 = openmm.Context(system2, copy.deepcopy(integrator))
 
     def map_energies_by_force_type(potential_energy1, potential_energy2):
         """Convert dictionary force_group -> energy to force_type -> energy."""
-        potential_energy1 = {group_to_force[group]: energy
-                             for group, energy in potential_energy1.items()}
-        potential_energy2 = {group_to_force[group]: energy
-                             for group, energy in potential_energy2.items()}
+        potential_energy1 = {
+            group_to_force[group]: energy for group, energy in potential_energy1.items()
+        }
+        potential_energy2 = {
+            group_to_force[group]: energy for group, energy in potential_energy2.items()
+        }
         return potential_energy1, potential_energy2
 
     # Catch the exception and log table force type -> energy.
     try:
         potential_energy1, potential_energy2 = compare_context_energies(
-            context1, context2, positions, box_vectors,
-            by_force_group=by_force_type, rtol=rtol, atol=atol
+            context1,
+            context2,
+            positions,
+            box_vectors,
+            by_force_group=by_force_type,
+            rtol=rtol,
+            atol=atol,
         )
     except FailedEnergyComparisonError as e:
         # We don't need to convert force groups into force types
@@ -557,8 +605,8 @@ def compare_system_energies(system1, system2, positions, box_vectors=None,
             e.potential_energy1, e.potential_energy2
         )
         # Pretty-print the dictionaries.
-        table = '\n\npotential energy system1:\n' + pprint.pformat(potential_energy1)
-        table += '\n\npotential energy system2:\n' + pprint.pformat(potential_energy2)
+        table = "\n\npotential energy system1:\n" + pprint.pformat(potential_energy1)
+        table += "\n\npotential energy system2:\n" + pprint.pformat(potential_energy2)
         raise type(e)(str(e) + table, e.potential_energy1, e.potential_energy2)
 
     if by_force_type:
@@ -566,9 +614,10 @@ def compare_system_energies(system1, system2, positions, box_vectors=None,
     return potential_energy1, potential_energy2
 
 
-#=============================================================================================
+# =============================================================================================
 # Utility functions for parameters comparisons.
-#=============================================================================================
+# =============================================================================================
+
 
 class _ParametersComparer:
     """This is just a convenience class to compare and print parameters.
@@ -631,12 +680,15 @@ class _ParametersComparer:
         diff_list = []
         for par_name in sorted(diff.keys()):
             par1, par2 = diff[par_name]
-            diff_list.append('{par_name}: {par1} != {par2}'.format(
-                par_name=par_name, par1=par1, par2=par2))
-        separator = '\n' if new_line else ''
+            diff_list.append(
+                "{par_name}: {par1} != {par2}".format(
+                    par_name=par_name, par1=par1, par2=par2
+                )
+            )
+        separator = "\n" if new_line else ""
         diff_str = separator.join(diff_list)
         if indent:
-            diff_str = textwrap.indent(diff_str, prefix='    ')
+            diff_str = textwrap.indent(diff_str, prefix="    ")
         return diff_str
 
     def _get_diff(self, other):
@@ -659,8 +711,10 @@ class _ParametersComparer:
         parameter_order = sorted(self.parameters)
         # Quantities in a dictionary are normally printed in the
         # format "Quantity(value, unit=unit)" so we make it prettier.
-        par_str = ', '.join('{}: {}'.format(p, self.parameters[p]) for p in parameter_order)
-        return '(' + par_str + ')'
+        par_str = ", ".join(
+            "{}: {}".format(p, self.parameters[p]) for p in parameter_order
+        )
+        return "(" + par_str + ")"
 
 
 class _TorsionParametersComparer:
@@ -709,27 +763,27 @@ class _TorsionParametersComparer:
         diff_str : str
 
         """
-        diff_str = 'Parameters in first system:\n'
+        diff_str = "Parameters in first system:\n"
         diff_str += self._pretty_format_parameters(self.parameters, new_line=new_line)
-        diff_str += '\nParameters in second system:\n'
+        diff_str += "\nParameters in second system:\n"
         diff_str += self._pretty_format_parameters(other.parameters, new_line=new_line)
         if indent:
-            diff_str = textwrap.indent(diff_str, '    ')
+            diff_str = textwrap.indent(diff_str, "    ")
         return diff_str
 
     def _pretty_format_parameters(self, parameters, new_line=True, indent=True):
         # Reorder the parameters by periodicity and then phase to print in deterministic order.
-        sort_key = lambda x: (x.parameters['periodicity'], x.parameters['phase'])
+        sort_key = lambda x: (x.parameters["periodicity"], x.parameters["phase"])
         parameters = sorted(parameters, key=sort_key)
         # Quantities in a dictionary are normally printed in the
         # format "Quantity(value, unit=unit)" so we make it prettier.
-        separator = '\n' if new_line else ', '
-        prefix = '['
+        separator = "\n" if new_line else ", "
+        prefix = "["
         if indent and new_line:
-            separator += '    '
+            separator += "    "
         elif indent:
-            prefix += '    '
-        return prefix + separator.join(str(pars) for pars in parameters) + ']'
+            prefix += "    "
+        return prefix + separator.join(str(pars) for pars in parameters) + "]"
 
     def __eq__(self, other):
         # Look for self.parameters that don't match any other.parameters.
@@ -746,7 +800,9 @@ class _TorsionParametersComparer:
         return True
 
     def __str__(self):
-        return self._pretty_format_parameters(self.parameters, new_line=False, indent=False)
+        return self._pretty_format_parameters(
+            self.parameters, new_line=False, indent=False
+        )
 
 
 class FailedParameterComparisonError(AssertionError):
@@ -760,13 +816,19 @@ class FailedParameterComparisonError(AssertionError):
         (parameter_force1, parameter_force2).
 
     """
+
     def __init__(self, err_msg, different_parameters):
         super().__init__(err_msg)
         self.different_parameters = different_parameters
 
 
-def _compare_parameters(parameters_force1, parameters_force2, interaction_type,
-                        force_name='', systems_labels=None):
+def _compare_parameters(
+    parameters_force1,
+    parameters_force2,
+    interaction_type,
+    force_name="",
+    systems_labels=None,
+):
     """Compare the parameters of 2 forces and raises an exception if they are different.
 
     Parameters
@@ -799,17 +861,17 @@ def _compare_parameters(parameters_force1, parameters_force2, interaction_type,
         with the different parameters.
 
     """
-    diff_msg = ''
+    diff_msg = ""
 
     # First check the parameters that are unique to only one of the forces.
     unique_keys1 = set(parameters_force1) - set(parameters_force2)
     unique_keys2 = set(parameters_force2) - set(parameters_force1)
-    err_msg = '\n\n{} force has the following unique ' + interaction_type + 's: {}\n'
+    err_msg = "\n\n{} force has the following unique " + interaction_type + "s: {}\n"
     if len(unique_keys1) != 0:
-        force_label = systems_labels[0] if systems_labels is not None else 'First'
+        force_label = systems_labels[0] if systems_labels is not None else "First"
         diff_msg += err_msg.format(force_label, sorted(unique_keys1))
     if len(unique_keys2) != 0:
-        force_label = systems_labels[1] if systems_labels is not None else 'Second'
+        force_label = systems_labels[1] if systems_labels is not None else "Second"
         diff_msg += err_msg.format(force_label, sorted(unique_keys2))
 
     # Create a diff for entries that have same keys but different parameters.
@@ -819,29 +881,35 @@ def _compare_parameters(parameters_force1, parameters_force2, interaction_type,
             different_parameters[key] = (parameters_force1[key], parameters_force2[key])
 
     # Handle force and systems labels default arguments.
-    if force_name != '':
-        force_name += ' '  # Add space after.
+    if force_name != "":
+        force_name += " "  # Add space after.
     if systems_labels is not None:
-        systems_labels = ' for the {} and {} systems respectively'.format(*systems_labels)
+        systems_labels = " for the {} and {} systems respectively".format(
+            *systems_labels
+        )
     else:
-        systems_labels = ''
+        systems_labels = ""
 
     # Print error.
     if len(different_parameters) > 0:
-        diff_msg += ('\n\nThe following {interaction}s have different parameters '
-                     'in the two {force_name}forces{systems_labels}:'.format(
-            interaction=interaction_type, force_name=force_name,
-            systems_labels=systems_labels)
+        diff_msg += (
+            "\n\nThe following {interaction}s have different parameters "
+            "in the two {force_name}forces{systems_labels}:".format(
+                interaction=interaction_type,
+                force_name=force_name,
+                systems_labels=systems_labels,
+            )
         )
         for key in sorted(different_parameters.keys()):
             param1, param2 = different_parameters[key]
             parameters_diff = param1.pretty_format_diff(param2)
-            diff_msg += '\n{} {}:\n{}'.format(interaction_type, key, parameters_diff)
+            diff_msg += "\n{} {}:\n{}".format(interaction_type, key, parameters_diff)
 
-    if diff_msg != '':
-        diff_msg = ('A difference between {} was detected. '
-                    'Details follow.').format(interaction_type) + diff_msg
-        raise FailedParameterComparisonError(diff_msg + '\n', different_parameters)
+    if diff_msg != "":
+        diff_msg = ("A difference between {} was detected. " "Details follow.").format(
+            interaction_type
+        ) + diff_msg
+        raise FailedParameterComparisonError(diff_msg + "\n", different_parameters)
 
 
 @functools.singledispatch
@@ -878,8 +946,10 @@ def _get_force_parameters(force, system, ignored_parameters):
         "proper torsion", "bond").
 
     """
-    raise NotImplementedError('Comparison between {}s is not currently '
-                              'supported.'.format(type(force)))
+    raise NotImplementedError(
+        "Comparison between {}s is not currently " "supported.".format(type(force))
+    )
+
 
 @_get_force_parameters.register(openmm.HarmonicBondForce)
 def _get_bond_force_parameters(force, _, ignored_parameters):
@@ -898,7 +968,7 @@ def _get_bond_force_parameters(force, _, ignored_parameters):
         force_parameters[bond_key] = _ParametersComparer(r0=r0, k=k)
         force_parameters[bond_key].remove_parameters(ignored_parameters)
 
-    return {'bond': force_parameters}
+    return {"bond": force_parameters}
 
 
 @_get_force_parameters.register(openmm.HarmonicAngleForce)
@@ -918,7 +988,7 @@ def _get_angle_force_parameters(force, _, ignored_parameters):
         force_parameters[angle_key] = _ParametersComparer(theta0=theta0, k=k)
         force_parameters[angle_key].remove_parameters(ignored_parameters)
 
-    return {'angle': force_parameters}
+    return {"angle": force_parameters}
 
 
 @_get_force_parameters.register(openmm.NonbondedForce)
@@ -931,26 +1001,30 @@ def _get_nonbonded_force_parameters(force, _, ignored_parameters):
 
         # Ignore sigma parameter if epsilon is 0.0.
         particle_parameters[particle_idx] = _ParametersComparer(
-            charge=charge, epsilon=epsilon)
+            charge=charge, epsilon=epsilon
+        )
         if (epsilon / epsilon.unit) != 0.0:
-            particle_parameters[particle_idx].parameters['sigma'] = sigma
+            particle_parameters[particle_idx].parameters["sigma"] = sigma
         particle_parameters[particle_idx].remove_parameters(ignored_parameters)
 
     # Build the dictionary representation of the particle exceptions.
     exception_parameters = {}
     for exception_idx in range(force.getNumExceptions()):
-        atom1, atom2, chargeprod, sigma, epsilon = force.getExceptionParameters(exception_idx)
+        atom1, atom2, chargeprod, sigma, epsilon = force.getExceptionParameters(
+            exception_idx
+        )
 
         # Reorder the atom indices to have a canonical key.
         exception_key = tuple(sorted([atom1, atom2]))
         # Ignore sigma parameter if epsilon is 0.0.
         exception_parameters[exception_key] = _ParametersComparer(
-            charge=chargeprod, epsilon=epsilon)
+            charge=chargeprod, epsilon=epsilon
+        )
         if (epsilon / epsilon.unit) != 0.0:
-            exception_parameters[exception_key].parameters['sigma'] = sigma
+            exception_parameters[exception_key].parameters["sigma"] = sigma
         exception_parameters[exception_key].remove_parameters(ignored_parameters)
 
-    return {'particle': particle_parameters, 'particle exception': exception_parameters}
+    return {"particle": particle_parameters, "particle exception": exception_parameters}
 
 
 def _merge_impropers_folds(improper_parameters):
@@ -971,10 +1045,12 @@ def _merge_impropers_folds(improper_parameters):
 
                 # If phase and periodicity match, sum the force constants
                 # and remove one _ParametersComparer object from the list.
-                if (parameters1['phase'] == parameters2['phase'] and
-                    parameters1['periodicity'] == parameters2['periodicity']):
+                if (
+                    parameters1["phase"] == parameters2["phase"]
+                    and parameters1["periodicity"] == parameters2["periodicity"]
+                ):
                     # Update the force constant of the first parameter.
-                    parameters1['k'] += parameters2['k']
+                    parameters1["k"] += parameters2["k"]
                     # Remove the second parameter from the list.
                     del improper_comparer.parameters[comparer2_idx]
                     break
@@ -992,14 +1068,14 @@ def _get_torsion_force_parameters(force, system, ignored_parameters):
     the current three-fold.
 
     """
-    if 'n_improper_folds' not in ignored_parameters:
+    if "n_improper_folds" not in ignored_parameters:
         ignore_n_folds = False
     else:
         ignore_n_folds = True
         # Create a copy of ignored_parameters without n_improper_folds
         # that must be removed later from the _ParametersComparer object.
         ignored_parameters = copy.deepcopy(ignored_parameters)
-        ignored_parameters.remove('n_improper_folds')
+        ignored_parameters.remove("n_improper_folds")
 
     # Find all bonds. We'll use this to distinguish
     # between proper and improper torsions.
@@ -1008,7 +1084,9 @@ def _get_torsion_force_parameters(force, system, ignored_parameters):
     proper_parameters = {}
     improper_parameters = {}
     for torsion_idx in range(force.getNumTorsions()):
-        atom1, atom2, atom3, atom4, periodicity, phase, k = force.getTorsionParameters(torsion_idx)
+        atom1, atom2, atom3, atom4, periodicity, phase, k = force.getTorsionParameters(
+            torsion_idx
+        )
 
         # Ignore torsions that don't contribute to the energy.
         if (k / k.unit) == 0.0:
@@ -1016,10 +1094,12 @@ def _get_torsion_force_parameters(force, system, ignored_parameters):
 
         torsion_key = [atom1, atom2, atom3, atom4]
         if len(set(torsion_key)) != 4:
-            raise ValueError('Torsion {} is defined on less than 4 atoms: {}'.format(torsion_key))
+            raise ValueError(
+                "Torsion {} is defined on less than 4 atoms: {}".format(torsion_key)
+            )
 
         # Check if this is proper or not.
-        torsion_bonds = [(torsion_key[i], torsion_key[i+1]) for i in range(3)]
+        torsion_bonds = [(torsion_key[i], torsion_key[i + 1]) for i in range(3)]
         is_proper = all(bond in bond_set for bond in torsion_bonds)
 
         # Determine the canonical order of the torsion key.
@@ -1046,7 +1126,10 @@ def _get_torsion_force_parameters(force, system, ignored_parameters):
     if ignore_n_folds:
         _merge_impropers_folds(improper_parameters)
 
-    return {'proper torsion': proper_parameters, 'improper torsion': improper_parameters}
+    return {
+        "proper torsion": proper_parameters,
+        "improper torsion": improper_parameters,
+    }
 
 
 def _find_all_bonds(system):
@@ -1067,7 +1150,9 @@ def _find_all_bonds(system):
 
     """
     # Find the force with information on the bonds.
-    bond_force = [f for f in system.getForces() if isinstance(f, openmm.HarmonicBondForce)]
+    bond_force = [
+        f for f in system.getForces() if isinstance(f, openmm.HarmonicBondForce)
+    ]
     assert len(bond_force) == 1
     bond_force = bond_force[0]
 
@@ -1139,8 +1224,8 @@ def _get_improper_torsion_canonical_order(bond_set, i0, i1, i2, i3):
     for (a, b) in itertools.combinations([i0, i1, i2, i3], 2):
         if (a, b) in bond_set:
             i, j = mapping[a], mapping[b]
-            connections[i, j] += 1.
-            connections[j, i] += 1.
+            connections[i, j] += 1.0
+            connections[j, i] += 1.0
 
     central_ind = connections.sum(0).argmax()
     central_ind = inv_mapping[central_ind]
@@ -1150,8 +1235,13 @@ def _get_improper_torsion_canonical_order(bond_set, i0, i1, i2, i3):
     return central_ind, other_ind[0], other_ind[1], other_ind[2]
 
 
-def compare_system_parameters(system1, system2, systems_labels=None,
-                              ignore_charges=False, ignore_improper_folds=False):
+def compare_system_parameters(
+    system1,
+    system2,
+    systems_labels=None,
+    ignore_charges=False,
+    ignore_improper_folds=False,
+):
     """Check that two OpenMM systems have the same parameters.
 
     Parameters
@@ -1183,25 +1273,29 @@ def compare_system_parameters(system1, system2, systems_labels=None,
     # Determine parameters to ignore.
     ignored_parameters_by_force = {}
     if ignore_charges:
-        ignored_parameters_by_force['NonbondedForce'] = ['charge', 'chargeprod']
+        ignored_parameters_by_force["NonbondedForce"] = ["charge", "chargeprod"]
     if ignore_improper_folds:
-        ignored_parameters_by_force['PeriodicTorsionForce'] = ['n_improper_folds']
+        ignored_parameters_by_force["PeriodicTorsionForce"] = ["n_improper_folds"]
 
     # We need to perform some checks on the type and number of forces in the Systems.
-    force_names1 = collections.Counter(f.__class__.__name__ for f in system1.getForces())
-    force_names2 = collections.Counter(f.__class__.__name__ for f in system2.getForces())
-    err_msg = 'Only systems having 1 force per type are supported.'
+    force_names1 = collections.Counter(
+        f.__class__.__name__ for f in system1.getForces()
+    )
+    force_names2 = collections.Counter(
+        f.__class__.__name__ for f in system2.getForces()
+    )
+    err_msg = "Only systems having 1 force per type are supported."
     assert set(force_names1.values()) == {1}, err_msg
     assert set(force_names2.values()) == {1}, err_msg
 
     # Remove the center-of-mass motion remover force from comparison.
     for force_names in [force_names1, force_names2]:
-        if 'CMMotionRemover' in force_names:
-            del force_names['CMMotionRemover']
+        if "CMMotionRemover" in force_names:
+            del force_names["CMMotionRemover"]
 
     # Check that the two systems have the same forces.
     if set(force_names1) != set(force_names2):
-        err_msg = 'The two Systems have different forces to compare:\n - system1 {}\n - system2 {}'
+        err_msg = "The two Systems have different forces to compare:\n - system1 {}\n - system2 {}"
         raise ValueError(err_msg.format(sorted(force_names1), sorted(force_names2)))
 
     # Find all the pair of forces to compare.
@@ -1209,7 +1303,7 @@ def compare_system_parameters(system1, system2, systems_labels=None,
     for system in [system1, system2]:
         for force in system.getForces():
             # Skip CMMotionRemover.
-            if force.__class__.__name__ == 'CMMotionRemover':
+            if force.__class__.__name__ == "CMMotionRemover":
                 continue
             force_pairs[force.__class__.__name__].append(force)
 
@@ -1228,18 +1322,29 @@ def compare_system_parameters(system1, system2, systems_labels=None,
         # Compare the forces and raise an error if a difference is detected.
         for parameter_type, parameters1 in parameters_force1.items():
             parameters2 = parameters_force2[parameter_type]
-            _compare_parameters(parameters1, parameters2,
-                                interaction_type=parameter_type,
-                                force_name=force_name,
-                                systems_labels=systems_labels)
+            _compare_parameters(
+                parameters1,
+                parameters2,
+                interaction_type=parameter_type,
+                force_name=force_name,
+                systems_labels=systems_labels,
+            )
 
 
-#=============================================================================================
+# =============================================================================================
 # Utility functions to compare SMIRNOFF and AMBER force fields.
-#=============================================================================================
+# =============================================================================================
 
-def compare_amber_smirnoff(prmtop_file_path, inpcrd_file_path, forcefield, molecule,
-                           check_parameters=True, check_energies=True, **kwargs):
+
+def compare_amber_smirnoff(
+    prmtop_file_path,
+    inpcrd_file_path,
+    forcefield,
+    molecule,
+    check_parameters=True,
+    check_energies=True,
+    **kwargs
+):
     """
     Compare energies and parameters for OpenMM Systems/topologies created
     from an AMBER prmtop and crd versus from a SMIRNOFF forcefield file which
@@ -1293,7 +1398,8 @@ def compare_amber_smirnoff(prmtop_file_path, inpcrd_file_path, forcefield, molec
     # Create System from AMBER files. By default, contrarily to ForceField,
     # systems from AMBER files are created with removeCMMotion=True
     amber_system, openmm_topology, positions = create_system_from_amber(
-        prmtop_file_path, inpcrd_file_path, removeCMMotion=False)
+        prmtop_file_path, inpcrd_file_path, removeCMMotion=False
+    )
     box_vectors = amber_system.getDefaultPeriodicBoxVectors()
 
     # Create System from forcefield.
@@ -1302,13 +1408,14 @@ def compare_amber_smirnoff(prmtop_file_path, inpcrd_file_path, forcefield, molec
 
     # Test energies and parameters.
     if check_parameters:
-        compare_system_parameters(amber_system, ff_system,
-                                  systems_labels=('AMBER', 'SMIRNOFF'),
-                                  **kwargs)
+        compare_system_parameters(
+            amber_system, ff_system, systems_labels=("AMBER", "SMIRNOFF"), **kwargs
+        )
 
     if check_energies:
         amber_energies, forcefield_energies = compare_system_energies(
-            amber_system, ff_system, positions, box_vectors, **kwargs)
+            amber_system, ff_system, positions, box_vectors, **kwargs
+        )
 
-        return {'AMBER': amber_energies, 'SMIRNOFF': forcefield_energies}
+        return {"AMBER": amber_energies, "SMIRNOFF": forcefield_energies}
     return None

--- a/openforcefield/topology/__init__.py
+++ b/openforcefield/topology/__init__.py
@@ -1,11 +1,25 @@
 from openforcefield.topology.molecule import (
-    Particle, Atom, Bond,
-    VirtualSite, BondChargeVirtualSite, MonovalentLonePairVirtualSite, DivalentLonePairVirtualSite, TrivalentLonePairVirtualSite,
-    FrozenMolecule, Molecule
+    Particle,
+    Atom,
+    Bond,
+    VirtualSite,
+    BondChargeVirtualSite,
+    MonovalentLonePairVirtualSite,
+    DivalentLonePairVirtualSite,
+    TrivalentLonePairVirtualSite,
+    FrozenMolecule,
+    Molecule,
 )
 
 from openforcefield.topology.topology import (
-    DuplicateUniqueMoleculeError, NotBondedError,
-    ValenceDict, ImproperDict, SortedDict,
-    TopologyAtom, TopologyBond, TopologyVirtualSite, TopologyMolecule, Topology
+    DuplicateUniqueMoleculeError,
+    NotBondedError,
+    ValenceDict,
+    ImproperDict,
+    SortedDict,
+    TopologyAtom,
+    TopologyBond,
+    TopologyVirtualSite,
+    TopologyMolecule,
+    Topology,
 )

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#=============================================================================================
+# =============================================================================================
 # MODULE DOCSTRING
-#=============================================================================================
+# =============================================================================================
 """
 Molecular chemical entity representation and routines to interface with cheminformatics toolkits
 
@@ -29,9 +29,9 @@ Molecular chemical entity representation and routines to interface with cheminfo
 
 """
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import numpy as np
 from collections import OrderedDict, Counter
@@ -48,18 +48,29 @@ import networkx as nx
 from networkx.algorithms.isomorphism import GraphMatcher
 
 import openforcefield
-from openforcefield.utils import serialize_numpy, deserialize_numpy, quantity_to_string, \
-    string_to_quantity, check_units_are_compatible
-from openforcefield.utils.toolkits import ToolkitRegistry, ToolkitWrapper, RDKitToolkitWrapper, OpenEyeToolkitWrapper,\
-    InvalidToolkitError, UndefinedStereochemistryError, GLOBAL_TOOLKIT_REGISTRY
+from openforcefield.utils import (
+    serialize_numpy,
+    deserialize_numpy,
+    quantity_to_string,
+    string_to_quantity,
+    check_units_are_compatible,
+)
+from openforcefield.utils.toolkits import (
+    ToolkitRegistry,
+    ToolkitWrapper,
+    RDKitToolkitWrapper,
+    OpenEyeToolkitWrapper,
+    InvalidToolkitError,
+    UndefinedStereochemistryError,
+    GLOBAL_TOOLKIT_REGISTRY,
+)
 from openforcefield.utils.toolkits import DEFAULT_AROMATICITY_MODEL
 from openforcefield.utils.serialization import Serializable
 
 
-
-#=============================================================================================
+# =============================================================================================
 # GLOBAL PARAMETERS
-#=============================================================================================
+# =============================================================================================
 
 # TODO: Can we have the `ALLOWED_*_MODELS` list automatically appear in the docstrings below?
 # TODO: Should `ALLOWED_*_MODELS` be objects instead of strings?
@@ -68,13 +79,13 @@ from openforcefield.utils.serialization import Serializable
 # TODO: Allow all OpenEye aromaticity models to be used with OpenEye names?
 #       Only support OEAroModel_MDL in RDKit version?
 
-#=============================================================================================
+# =============================================================================================
 # PRIVATE SUBROUTINES
-#=============================================================================================
+# =============================================================================================
 
-#=============================================================================================
+# =============================================================================================
 # Particle
-#=============================================================================================
+# =============================================================================================
 
 
 class Particle(Serializable):
@@ -104,7 +115,7 @@ class Particle(Serializable):
         Set the particle's molecule pointer. Note that this will only work if the particle currently
         doesn't have a molecule
         """
-        #TODO: Add informative exception here
+        # TODO: Add informative exception here
         assert self._molecule is None
         self._molecule = molecule
 
@@ -134,9 +145,9 @@ class Particle(Serializable):
         raise NotImplementedError()  # TODO
 
 
-#=============================================================================================
+# =============================================================================================
 # Atom
-#=============================================================================================
+# =============================================================================================
 
 
 class Atom(Particle):
@@ -157,13 +168,15 @@ class Atom(Particle):
     .. warning :: This API is experimental and subject to change.
     """
 
-    def __init__(self,
-                 atomic_number,
-                 formal_charge,
-                 is_aromatic,
-                 name=None,
-                 molecule=None,
-                 stereochemistry=None):
+    def __init__(
+        self,
+        atomic_number,
+        formal_charge,
+        is_aromatic,
+        name=None,
+        molecule=None,
+        stereochemistry=None,
+    ):
         """
         Create an immutable Atom object.
 
@@ -204,11 +217,11 @@ class Atom(Particle):
         self._is_aromatic = is_aromatic
         self._stereochemistry = stereochemistry
         if name is None:
-            name = ''
+            name = ""
         self._name = name
         self._molecule = molecule
         ## From Jeff: I'm going to assume that this is implicit in the parent Molecule's ordering of atoms
-        #self._molecule_atom_index = molecule_atom_index
+        # self._molecule_atom_index = molecule_atom_index
         self._bonds = list()
         self._virtual_sites = list()
 
@@ -226,7 +239,7 @@ class Atom(Particle):
 """
 
         self._bonds.append(bond)
-        #self._stereochemistry = None
+        # self._stereochemistry = None
 
     def add_virtual_site(self, vsite):
         """Adds a bond that this atom is involved in
@@ -247,14 +260,14 @@ class Atom(Particle):
 """
         # TODO
         atom_dict = OrderedDict()
-        atom_dict['atomic_number'] = self._atomic_number
-        atom_dict['formal_charge'] = self._formal_charge / unit.elementary_charge
-        atom_dict['is_aromatic'] = self._is_aromatic
-        atom_dict['stereochemistry'] = self._stereochemistry
+        atom_dict["atomic_number"] = self._atomic_number
+        atom_dict["formal_charge"] = self._formal_charge / unit.elementary_charge
+        atom_dict["is_aromatic"] = self._is_aromatic
+        atom_dict["stereochemistry"] = self._stereochemistry
         # TODO: Should we let atoms have names?
-        atom_dict['name'] = self._name
+        atom_dict["name"] = self._name
         # TODO: Should this be implicit in the atom ordering when saved?
-        #atom_dict['molecule_atom_index'] = self._molecule_atom_index
+        # atom_dict['molecule_atom_index'] = self._molecule_atom_index
         return atom_dict
 
     @classmethod
@@ -322,7 +335,7 @@ class Atom(Particle):
             The stereochemistry around this atom, allowed values are "CW", "CCW", or None,
         """
 
-        #if (value != 'CW') and (value != 'CCW') and not(value is None):
+        # if (value != 'CW') and (value != 'CCW') and not(value is None):
         #    raise Exception("Atom stereochemistry setter expected 'CW', 'CCW', or None. Received {} (type {})".format(value, type(value)))
         self._stereochemistry = value
 
@@ -371,8 +384,10 @@ class Atom(Particle):
         """
         if not (type(other) is str):
             raise Exception(
-                "In setting atom name. Expected str, received {} (type {})".
-                format(other, type(other)))
+                "In setting atom name. Expected str, received {} (type {})".format(
+                    other, type(other)
+                )
+            )
         self._name = other
 
     # TODO: How are we keeping track of bonds, angles, etc?
@@ -384,11 +399,11 @@ class Atom(Particle):
 
         """
         return self._bonds
-        #for bond in self._bonds:
+        # for bond in self._bonds:
         #    yield bond
 
     @property
-    #def bonded_to(self):
+    # def bonded_to(self):
     def bonded_atoms(self):
         """
         The list of ``Atom`` objects this atom is involved in bonds with
@@ -414,7 +429,7 @@ class Atom(Particle):
         bool
             Whether this atom is bound to atom2
         """
-        #TODO: Sanity check (check for same molecule?)
+        # TODO: Sanity check (check for same molecule?)
         assert self != atom2
         for bond in self._bonds:
             for bonded_atom in bond.atoms:
@@ -429,7 +444,7 @@ class Atom(Particle):
 
         """
         return self._virtual_sites
-        #for vsite in self._vsites:
+        # for vsite in self._vsites:
         #    yield vsite
 
     @property
@@ -440,7 +455,7 @@ class Atom(Particle):
 
         """
         if self._molecule is None:
-            raise ValueError('This Atom does not belong to a Molecule object')
+            raise ValueError("This Atom does not belong to a Molecule object")
         return self._molecule.atoms.index(self)
 
     @property
@@ -451,7 +466,7 @@ class Atom(Particle):
 
         """
         if self._molecule is None:
-            raise ValueError('This Atom does not belong to a Molecule object')
+            raise ValueError("This Atom does not belong to a Molecule object")
         return self._molecule.particles.index(self)
 
     # ## From Jeff: Not sure if we actually need this
@@ -470,18 +485,18 @@ class Atom(Particle):
 
     def __repr__(self):
         # TODO: Also include particle_index and which molecule this atom belongs to?
-        return "Atom(name={}, atomic number={})".format(
-            self._name, self._atomic_number)
+        return "Atom(name={}, atomic number={})".format(self._name, self._atomic_number)
 
     def __str__(self):
         # TODO: Also include particle_index and which molecule this atom belongs to?
         return "<Atom name='{}' atomic number='{}'>".format(
-            self._name, self._atomic_number)
+            self._name, self._atomic_number
+        )
 
 
-#=============================================================================================
+# =============================================================================================
 # VirtualSite
-#=============================================================================================
+# =============================================================================================
 
 
 class VirtualSite(Particle):
@@ -500,13 +515,15 @@ class VirtualSite(Particle):
 
     """
 
-    def __init__(self,
-                 atoms,
-                 charge_increments=None,
-                 epsilon=None,
-                 sigma=None,
-                 rmin_half=None,
-                 name=None):
+    def __init__(
+        self,
+        atoms,
+        charge_increments=None,
+        epsilon=None,
+        sigma=None,
+        rmin_half=None,
+        name=None,
+    ):
         """
         Base class for VirtualSites
 
@@ -543,28 +560,36 @@ class VirtualSite(Particle):
         if not (charge_increments is None):
             if not (len(charge_increments) == len(atoms)):
                 raise Exception(
-                    "VirtualSite definition must have same number of charge_increments ({}) and atoms({})"
-                    .format(len(charge_increments), len(atoms)))
+                    "VirtualSite definition must have same number of charge_increments ({}) and atoms({})".format(
+                        len(charge_increments), len(atoms)
+                    )
+                )
 
         # VdW parameters can either be epsilon+rmin_half or epsilon+sigma, but not both
         if not (epsilon is None):
-            if ((rmin_half != None) and (sigma != None)):
+            if (rmin_half != None) and (sigma != None):
                 raise Exception(
-                    "VirtualSite constructor given epsilon (value : {}), rmin_half (value : {}), and sigma (value : {}). If epsilon is nonzero, it should receive either rmin_half OR sigma"
-                    .format(epsilon, rmin_half, sigma))
-            if ((rmin_half is None) and (sigma is None)):
+                    "VirtualSite constructor given epsilon (value : {}), rmin_half (value : {}), and sigma (value : {}). If epsilon is nonzero, it should receive either rmin_half OR sigma".format(
+                        epsilon, rmin_half, sigma
+                    )
+                )
+            if (rmin_half is None) and (sigma is None):
                 raise Exception(
-                    "VirtualSite constructor given epsilon (value : {}) but not given rmin_half (value : {}) or sigma (value : {})"
-                    .format(epsilon, rmin_half, sigma))
-            if (sigma is None):
+                    "VirtualSite constructor given epsilon (value : {}) but not given rmin_half (value : {}) or sigma (value : {})".format(
+                        epsilon, rmin_half, sigma
+                    )
+                )
+            if sigma is None:
                 # TODO: Save the 6th root of 2 if this starts being slow.
-                sigma = (2. * rmin_half) / (2.**(1. / 6))
+                sigma = (2.0 * rmin_half) / (2.0 ** (1.0 / 6))
 
         elif epsilon is None:
-            if ((rmin_half != None) or (sigma != None)):
+            if (rmin_half != None) or (sigma != None):
                 raise Exception(
-                    "VirtualSite constructor given rmin_half (value : {}) or sigma (value : {}), but not epsilon (value : {})"
-                    .format(rmin_half, sigma, epsilon))
+                    "VirtualSite constructor given rmin_half (value : {}) or sigma (value : {}), but not epsilon (value : {})".format(
+                        rmin_half, sigma, epsilon
+                    )
+                )
 
         # Perform type-checking
         for atom in atoms:
@@ -576,25 +601,25 @@ class VirtualSite(Particle):
         if sigma is None:
             self._sigma = None
         else:
-            assert hasattr(sigma, 'unit')
+            assert hasattr(sigma, "unit")
             assert unit.angstrom.is_compatible(sigma.unit)
             self._sigma = sigma.in_units_of(unit.angstrom)
 
         if epsilon is None:
             self._epsilon = None
         else:
-            assert hasattr(epsilon, 'unit')
+            assert hasattr(epsilon, "unit")
             assert (unit.kilojoule_per_mole).is_compatible(epsilon.unit)
             self._epsilon = epsilon.in_units_of(unit.kilojoule_per_mole)
 
         if charge_increments is None:
             self._charge_increments = None
         else:
-            assert hasattr(charge_increments, 'unit')
-            assert unit.elementary_charges.is_compatible(
-                charge_increments.unit)
+            assert hasattr(charge_increments, "unit")
+            assert unit.elementary_charges.is_compatible(charge_increments.unit)
             self._charge_increments = charge_increments.in_units_of(
-                unit.elementary_charges)
+                unit.elementary_charges
+            )
 
         self._atoms = list()
         for atom in atoms:
@@ -605,10 +630,10 @@ class VirtualSite(Particle):
         self._name = name
 
         # Subclassing makes _type unnecessary
-        #self._type = None
+        # self._type = None
         # TODO: Validate site types against allowed values
 
-        #self._weights = np.array(weights) # make a copy and convert to array internally
+        # self._weights = np.array(weights) # make a copy and convert to array internally
 
     def to_dict(self):
         """Return a dict representation of the virtual site.
@@ -616,14 +641,13 @@ class VirtualSite(Particle):
 """
         # Each subclass should have its own to_dict
         vsite_dict = OrderedDict()
-        vsite_dict['name'] = self._name
-        vsite_dict['atoms'] = tuple(
-            [i.molecule_atom_index for i in self.atoms])
-        vsite_dict['charge_increments'] = quantity_to_string(self._charge_increments)
+        vsite_dict["name"] = self._name
+        vsite_dict["atoms"] = tuple([i.molecule_atom_index for i in self.atoms])
+        vsite_dict["charge_increments"] = quantity_to_string(self._charge_increments)
 
-        vsite_dict['epsilon'] = quantity_to_string(self._epsilon)
+        vsite_dict["epsilon"] = quantity_to_string(self._epsilon)
 
-        vsite_dict['sigma'] = quantity_to_string(self._sigma)
+        vsite_dict["sigma"] = quantity_to_string(self._sigma)
 
         return vsite_dict
 
@@ -638,11 +662,11 @@ class VirtualSite(Particle):
         vsite_dict_units = deepcopy(vsite_dict)
 
         # Attach units to epsilon term
-        vsite_dict_units['epsilon'] = string_to_quantity(
-            vsite_dict['epsilon'])
-        vsite_dict_units['sigma'] = string_to_quantity(vsite_dict['sigma'])
-        vsite_dict_units['charge_increments'] = string_to_quantity(
-            vsite_dict['charge_increments'])
+        vsite_dict_units["epsilon"] = string_to_quantity(vsite_dict["epsilon"])
+        vsite_dict_units["sigma"] = string_to_quantity(vsite_dict["sigma"])
+        vsite_dict_units["charge_increments"] = string_to_quantity(
+            vsite_dict["charge_increments"]
+        )
 
         return VirtualSite(**vsite_dict_units)
 
@@ -652,7 +676,7 @@ class VirtualSite(Particle):
         The index of this VirtualSite within the list of virtual sites within ``Molecule``
         Note that this can be different from ``particle_index``.
         """
-        #if self._topology is None:
+        # if self._topology is None:
         #    raise ValueError('This VirtualSite does not belong to a Topology object')
         # TODO: This will be slow; can we cache this and update it only when needed?
         #       Deleting atoms/molecules in the Topology would have to invalidate the cached index.
@@ -666,8 +690,7 @@ class VirtualSite(Particle):
 
         """
         if self._molecule is None:
-            raise ValueError(
-                'This VirtualSite does not belong to a Molecule object')
+            raise ValueError("This VirtualSite does not belong to a Molecule object")
         return self._molecule.particles.index(self)
 
     @property
@@ -676,7 +699,7 @@ class VirtualSite(Particle):
         Atoms on whose position this VirtualSite depends.
         """
         return self._atoms
-        #for atom in self._atoms:
+        # for atom in self._atoms:
         #    yield atom
 
     @property
@@ -705,7 +728,7 @@ class VirtualSite(Particle):
         """
         The VdW rmin_half term of this VirtualSite
         """
-        rmin = 2.**(1. / 6) * self._sigma
+        rmin = 2.0 ** (1.0 / 6) * self._sigma
         rmin_half = rmin / 2
         return rmin_half
 
@@ -724,12 +747,14 @@ class VirtualSite(Particle):
     def __repr__(self):
         # TODO: Also include particle_index, which molecule this atom belongs to?
         return "VirtualSite(name={}, type={}, atoms={})".format(
-            self.name, self.type, self.atoms)
+            self.name, self.type, self.atoms
+        )
 
     def __str__(self):
         # TODO: Also include particle_index, which molecule this atom belongs to?
         return "<VirtualSite name={} type={} atoms={}>".format(
-            self.name, self.type, self.atoms)
+            self.name, self.type, self.atoms
+        )
 
 
 class BondChargeVirtualSite(VirtualSite):
@@ -739,15 +764,17 @@ class BondChargeVirtualSite(VirtualSite):
     .. warning :: This API is experimental and subject to change.
     """
 
-    def __init__(self,
-                 atoms,
-                 distance,
-                 charge_increments=None,
-                 weights=None,
-                 epsilon=None,
-                 sigma=None,
-                 rmin_half=None,
-                 name=None):
+    def __init__(
+        self,
+        atoms,
+        distance,
+        charge_increments=None,
+        weights=None,
+        epsilon=None,
+        sigma=None,
+        rmin_half=None,
+        name=None,
+    ):
         """
         Create a bond charge-type virtual site, in which the location of the charge is specified by the position of two atoms. This supports placement of a virtual site S along a vector between two specified atoms, e.g. to allow for a sigma hole for halogens or similar contexts. With positive values of the distance, the virtual site lies outside the first indexed atom.
 
@@ -772,7 +799,7 @@ class BondChargeVirtualSite(VirtualSite):
         name : string or None, default=None
             The name of this virtual site. Default is None.
         """
-        assert hasattr(distance, 'unit')
+        assert hasattr(distance, "unit")
         assert unit.angstrom.is_compatible(distance.unit)
 
         super().__init__(
@@ -781,27 +808,28 @@ class BondChargeVirtualSite(VirtualSite):
             epsilon=epsilon,
             sigma=sigma,
             rmin_half=rmin_half,
-            name=name)
+            name=name,
+        )
         self._distance = distance.in_units_of(unit.angstrom)
 
     def to_dict(self):
         vsite_dict = super().to_dict()
-        vsite_dict['distance'] = quantity_to_string(self._distance)
+        vsite_dict["distance"] = quantity_to_string(self._distance)
 
-        #type = self.type
-        vsite_dict['vsite_type'] = self.type
-        #vsite_dict['vsite_type'] = 'BondChargeVirtualSite'
+        # type = self.type
+        vsite_dict["vsite_type"] = self.type
+        # vsite_dict['vsite_type'] = 'BondChargeVirtualSite'
         return vsite_dict
 
     @classmethod
     def from_dict(cls, vsite_dict):
         base_dict = deepcopy(vsite_dict)
         # Make sure it's the right type of virtual site
-        assert vsite_dict['vsite_type'] == "BondChargeVirtualSite"
-        base_dict.pop('vsite_type')
-        base_dict.pop('distance')
+        assert vsite_dict["vsite_type"] == "BondChargeVirtualSite"
+        base_dict.pop("vsite_type")
+        base_dict.pop("distance")
         vsite = super().from_dict(**base_dict)
-        vsite._distance = string_to_quantity(vsite_dict['distance'])
+        vsite._distance = string_to_quantity(vsite_dict["distance"])
         return vsite
 
     @property
@@ -818,17 +846,15 @@ class _LonePairVirtualSite(VirtualSite):
         base_dict = deepcopy(vsite_dict)
 
         # Make sure it's the right type of virtual site
-        assert vsite_dict['vsite_type'] == cls.__name__
-        base_dict.pop('vsite_type')
-        base_dict.pop('distance')
-        base_dict.pop('out_of_plane_angle')
-        base_dict.pop('in_plane_angle')
+        assert vsite_dict["vsite_type"] == cls.__name__
+        base_dict.pop("vsite_type")
+        base_dict.pop("distance")
+        base_dict.pop("out_of_plane_angle")
+        base_dict.pop("in_plane_angle")
         vsite = super().from_dict(**base_dict)
-        vsite._distance = string_to_quantity(vsite_dict['distance'])
-        vsite._in_plane_angle = string_to_quantity(
-            vsite_dict['in_plane_angle'])
-        vsite._out_of_plane_angle = string_to_quantity(
-            vsite_dict['out_of_plane_angle'])
+        vsite._distance = string_to_quantity(vsite_dict["distance"])
+        vsite._in_plane_angle = string_to_quantity(vsite_dict["in_plane_angle"])
+        vsite._out_of_plane_angle = string_to_quantity(vsite_dict["out_of_plane_angle"])
         return vsite
 
 
@@ -839,17 +865,19 @@ class MonovalentLonePairVirtualSite(VirtualSite):
     .. warning :: This API is experimental and subject to change.
    """
 
-    def __init__(self,
-                 atoms,
-                 distance,
-                 out_of_plane_angle,
-                 in_plane_angle,
-                 charge_increments=None,
-                 weights=None,
-                 epsilon=None,
-                 sigma=None,
-                 rmin_half=None,
-                 name=None):
+    def __init__(
+        self,
+        atoms,
+        distance,
+        out_of_plane_angle,
+        in_plane_angle,
+        charge_increments=None,
+        weights=None,
+        epsilon=None,
+        sigma=None,
+        rmin_half=None,
+        name=None,
+    ):
         """
         Create a bond charge-type virtual site, in which the location of the charge is specified by the position of three atoms.
 
@@ -876,13 +904,13 @@ class MonovalentLonePairVirtualSite(VirtualSite):
 
 
         """
-        #assert isinstance(distance, unit.Quantity)
+        # assert isinstance(distance, unit.Quantity)
         # TODO: Check for proper number of atoms
-        assert hasattr(distance, 'unit')
+        assert hasattr(distance, "unit")
         assert unit.angstrom.is_compatible(distance.unit)
-        assert hasattr(in_plane_angle, 'unit')
+        assert hasattr(in_plane_angle, "unit")
         assert unit.degree.is_compatible(in_plane_angle.unit)
-        assert hasattr(out_of_plane_angle, 'unit')
+        assert hasattr(out_of_plane_angle, "unit")
         assert unit.degree.is_compatible(out_of_plane_angle.unit)
 
         assert len(atoms) == 3
@@ -892,20 +920,20 @@ class MonovalentLonePairVirtualSite(VirtualSite):
             epsilon=epsilon,
             sigma=sigma,
             rmin_half=rmin_half,
-            name=name)
+            name=name,
+        )
         self._distance = distance.in_units_of(unit.angstrom)
         self._out_of_plane_angle = out_of_plane_angle.in_units_of(unit.degree)
         self._in_plane_angle = in_plane_angle.in_units_of(unit.degree)
 
     def to_dict(self):
         vsite_dict = super().to_dict()
-        vsite_dict['distance'] = quantity_to_string(self._distance)
-        vsite_dict['out_of_plane_angle'] = quantity_to_string(
-            self._out_of_plane_angle)
-        vsite_dict['in_plane_angle'] = quantity_to_string(self._in_plane_angle)
-        #vsite_dict['vsite_type'] = self.type.fget()
-        vsite_dict['vsite_type'] = self.type
-        #vsite_dict['vsite_type'] = 'MonovalentLonePairVirtualSite'
+        vsite_dict["distance"] = quantity_to_string(self._distance)
+        vsite_dict["out_of_plane_angle"] = quantity_to_string(self._out_of_plane_angle)
+        vsite_dict["in_plane_angle"] = quantity_to_string(self._in_plane_angle)
+        # vsite_dict['vsite_type'] = self.type.fget()
+        vsite_dict["vsite_type"] = self.type
+        # vsite_dict['vsite_type'] = 'MonovalentLonePairVirtualSite'
         return vsite_dict
 
     @classmethod
@@ -949,17 +977,19 @@ class DivalentLonePairVirtualSite(VirtualSite):
     .. warning :: This API is experimental and subject to change.
     """
 
-    def __init__(self,
-                 atoms,
-                 distance,
-                 out_of_plane_angle,
-                 in_plane_angle,
-                 charge_increments=None,
-                 weights=None,
-                 epsilon=None,
-                 sigma=None,
-                 rmin_half=None,
-                 name=None):
+    def __init__(
+        self,
+        atoms,
+        distance,
+        out_of_plane_angle,
+        in_plane_angle,
+        charge_increments=None,
+        weights=None,
+        epsilon=None,
+        sigma=None,
+        rmin_half=None,
+        name=None,
+    ):
         """
         Create a divalent lone pair-type virtual site, in which the location of the charge is specified by the position of three atoms.
 
@@ -984,12 +1014,12 @@ class DivalentLonePairVirtualSite(VirtualSite):
         name : string or None, default=None
             The name of this virtual site. Default is None.
         """
-        #assert isinstance(distance, unit.Quantity)
-        assert hasattr(distance, 'unit')
+        # assert isinstance(distance, unit.Quantity)
+        assert hasattr(distance, "unit")
         assert unit.angstrom.is_compatible(distance.unit)
-        assert hasattr(in_plane_angle, 'unit')
+        assert hasattr(in_plane_angle, "unit")
         assert unit.degree.is_compatible(in_plane_angle.unit)
-        assert hasattr(out_of_plane_angle, 'unit')
+        assert hasattr(out_of_plane_angle, "unit")
         assert unit.degree.is_compatible(out_of_plane_angle.unit)
         assert len(atoms) == 3
         super().__init__(
@@ -998,18 +1028,18 @@ class DivalentLonePairVirtualSite(VirtualSite):
             epsilon=epsilon,
             sigma=sigma,
             rmin_half=rmin_half,
-            name=name)
+            name=name,
+        )
         self._distance = distance.in_units_of(unit.angstrom)
         self._out_of_plane_angle = out_of_plane_angle.in_units_of(unit.degree)
         self._in_plane_angle = in_plane_angle.in_units_of(unit.degree)
 
     def to_dict(self):
         vsite_dict = super().to_dict()
-        vsite_dict['distance'] = quantity_to_string(self._distance)
-        vsite_dict['out_of_plane_angle'] = quantity_to_string(
-            self._out_of_plane_angle)
-        vsite_dict['in_plane_angle'] = quantity_to_string(self._in_plane_angle)
-        vsite_dict['vsite_type'] = self.type
+        vsite_dict["distance"] = quantity_to_string(self._distance)
+        vsite_dict["out_of_plane_angle"] = quantity_to_string(self._out_of_plane_angle)
+        vsite_dict["in_plane_angle"] = quantity_to_string(self._in_plane_angle)
+        vsite_dict["vsite_type"] = self.type
         return vsite_dict
 
     @classmethod
@@ -1053,17 +1083,19 @@ class TrivalentLonePairVirtualSite(VirtualSite):
     .. warning :: This API is experimental and subject to change.
     """
 
-    def __init__(self,
-                 atoms,
-                 distance,
-                 out_of_plane_angle,
-                 in_plane_angle,
-                 charge_increments=None,
-                 weights=None,
-                 epsilon=None,
-                 sigma=None,
-                 rmin_half=None,
-                 name=None):
+    def __init__(
+        self,
+        atoms,
+        distance,
+        out_of_plane_angle,
+        in_plane_angle,
+        charge_increments=None,
+        weights=None,
+        epsilon=None,
+        sigma=None,
+        rmin_half=None,
+        name=None,
+    ):
         """
         Create a trivalent lone pair-type virtual site, in which the location of the charge is specified by the position of four atoms.
 
@@ -1090,11 +1122,11 @@ class TrivalentLonePairVirtualSite(VirtualSite):
 
         """
         assert len(atoms) == 4
-        assert hasattr(distance, 'unit')
+        assert hasattr(distance, "unit")
         assert unit.angstrom.is_compatible(distance.unit)
-        assert hasattr(in_plane_angle, 'unit')
+        assert hasattr(in_plane_angle, "unit")
         assert unit.degree.is_compatible(in_plane_angle.unit)
-        assert hasattr(out_of_plane_angle, 'unit')
+        assert hasattr(out_of_plane_angle, "unit")
         assert unit.degree.is_compatible(out_of_plane_angle.unit)
 
         super().__init__(
@@ -1103,18 +1135,18 @@ class TrivalentLonePairVirtualSite(VirtualSite):
             epsilon=epsilon,
             sigma=sigma,
             rmin_half=rmin_half,
-            name=name)
+            name=name,
+        )
         self._distance = distance.in_units_of(unit.angstrom)
         self._out_of_plane_angle = out_of_plane_angle.in_units_of(unit.degree)
         self._in_plane_angle = in_plane_angle.in_units_of(unit.degree)
 
     def to_dict(self):
         vsite_dict = super().to_dict()
-        vsite_dict['distance'] = quantity_to_string(self._distance)
-        vsite_dict['out_of_plane_angle'] = quantity_to_string(
-            self._out_of_plane_angle)
-        vsite_dict['in_plane_angle'] = quantity_to_string(self._in_plane_angle)
-        vsite_dict['vsite_type'] = self.type
+        vsite_dict["distance"] = quantity_to_string(self._distance)
+        vsite_dict["out_of_plane_angle"] = quantity_to_string(self._out_of_plane_angle)
+        vsite_dict["in_plane_angle"] = quantity_to_string(self._in_plane_angle)
+        vsite_dict["vsite_type"] = self.type
         return vsite_dict
 
     @classmethod
@@ -1156,11 +1188,11 @@ class TrivalentLonePairVirtualSite(VirtualSite):
 # Bond Stereochemistry
 # =============================================================================================
 
-#class BondStereochemistry(Serializable):
-#"""
-#Bond stereochemistry representation
-#"""
-#def __init__(self, stereo_type, neighbor1, neighbor2):
+# class BondStereochemistry(Serializable):
+# """
+# Bond stereochemistry representation
+# """
+# def __init__(self, stereo_type, neighbor1, neighbor2):
 #    """
 #
 #    Parameters
@@ -1176,38 +1208,38 @@ class TrivalentLonePairVirtualSite(VirtualSite):
 #    self._neighbor1 = neighbor1
 #    self._neighbor2 = neighbor2
 
-#def to_dict(self):
+# def to_dict(self):
 #    bs_dict = OrderedDict()
 #    bs_dict['stereo_type'] = self._stereo_type
 #    bs_dict['neighbor1_index'] = self._neighbor1.molecule_atom_index
 #    bs_dict['neighbor2_index'] = self._neighbor2.molecule_atom_index
 #    return bs_dict
 
-#classmethod
-#def from_dict(cls, molecule, bs_dict):
+# classmethod
+# def from_dict(cls, molecule, bs_dict):
 #    neighbor1 = molecule.atoms[bs_dict['neighbor1_index']]
 #    neighbor2 = molecule.atoms[bs_dict['neighbor2_index']]
 #    return cls.__init__(bs_dict['stereo_type'], neighbor1, neighbor2)
 
-#@property
-#def stereo_type(self):
+# @property
+# def stereo_type(self):
 #    return self._stereo_type
 
-#@stereo_type.setter
-#def stereo_type(self, value):
+# @stereo_type.setter
+# def stereo_type(self, value):
 #    assert (value == 'CIS') or (value == 'TRANS') or (value is None)
 #    self._stereo_type = value
 
-#@property
-#def neighbor1(self):
+# @property
+# def neighbor1(self):
 #    return self._neighbor1
 
-#@property
-#def neighbor2(self):
+# @property
+# def neighbor2(self):
 #    return self._neighbor2
 
-#@property
-#def neighbors(self):
+# @property
+# def neighbors(self):
 #    return (self._neighbor1, self._neighbor2)
 
 # =============================================================================================
@@ -1241,13 +1273,15 @@ class Bond(Serializable):
     .. warning :: This API is experimental and subject to change.
     """
 
-    def __init__(self,
-                 atom1,
-                 atom2,
-                 bond_order,
-                 is_aromatic,
-                 fractional_bond_order=None,
-                 stereochemistry=None):
+    def __init__(
+        self,
+        atom1,
+        atom2,
+        bond_order,
+        is_aromatic,
+        fractional_bond_order=None,
+        stereochemistry=None,
+    ):
         """
         Create a new chemical bond.
 
@@ -1265,7 +1299,7 @@ class Bond(Serializable):
         atom2.add_bond(self)
         # TODO: Check bondtype and fractional_bond_order are valid?
         # TODO: Dative bonds
-        #self._type = bondtype
+        # self._type = bondtype
         self._fractional_bond_order = fractional_bond_order
         self._bond_order = bond_order
         self._is_aromatic = is_aromatic
@@ -1277,21 +1311,21 @@ class Bond(Serializable):
 
         """
         bond_dict = OrderedDict()
-        bond_dict['atom1'] = self.atom1.molecule_atom_index
-        bond_dict['atom2'] = self.atom2.molecule_atom_index
-        bond_dict['bond_order'] = self._bond_order
-        bond_dict['is_aromatic'] = self._is_aromatic
-        bond_dict['stereochemistry'] = self._stereochemistry
-        bond_dict['fractional_bond_order'] = self._fractional_bond_order
+        bond_dict["atom1"] = self.atom1.molecule_atom_index
+        bond_dict["atom2"] = self.atom2.molecule_atom_index
+        bond_dict["bond_order"] = self._bond_order
+        bond_dict["is_aromatic"] = self._is_aromatic
+        bond_dict["stereochemistry"] = self._stereochemistry
+        bond_dict["fractional_bond_order"] = self._fractional_bond_order
         return bond_dict
 
     @classmethod
     def from_dict(cls, molecule, d):
         """Create a Bond from a dict representation."""
         # TODO
-        d['molecule'] = molecule
-        d['atom1'] = molecule.atoms[d['atom1']]
-        d['atom2'] = molecule.atoms[d['atom2']]
+        d["molecule"] = molecule
+        d["atom1"] = molecule.atoms[d["atom1"]]
+        d["atom2"] = molecule.atoms[d["atom2"]]
         return cls(*d)
 
     @property
@@ -1357,19 +1391,21 @@ class Bond(Serializable):
 
         """
         if self._molecule is None:
-            raise ValueError('This Atom does not belong to a Molecule object')
+            raise ValueError("This Atom does not belong to a Molecule object")
         return self._molecule.bonds.index(self)
 
     def __repr__(self):
         return f"Bond(atom1 index={self.atom1_index}, atom2 index={self.atom2_index})"
 
     def __str__(self):
-        return f"<Bond atom1 index='{self.atom1_index}', atom2 index='{self.atom2_index}'>"
+        return (
+            f"<Bond atom1 index='{self.atom1_index}', atom2 index='{self.atom2_index}'>"
+        )
 
 
-#=============================================================================================
+# =============================================================================================
 # Molecule
-#=============================================================================================
+# =============================================================================================
 
 # TODO: How do we automatically trigger invalidation of cached properties if an ``Atom``, ``Bond``, or ``VirtualSite`` is modified,
 #       rather than added/deleted via the API? The simplest resolution is simply to make them immutable.
@@ -1419,11 +1455,13 @@ class FrozenMolecule(Serializable):
 
     """
 
-    def __init__(self,
-                 other=None,
-                 file_format=None,
-                 toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
-                 allow_undefined_stereo=False):
+    def __init__(
+        self,
+        other=None,
+        file_format=None,
+        toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+        allow_undefined_stereo=False,
+    ):
         """
         Create a new FrozenMolecule object
 
@@ -1524,20 +1562,18 @@ class FrozenMolecule(Serializable):
             # if there turned out to be no way to load this input
             value_errors = list()
 
-            if isinstance(
-                    other,
-                    openforcefield.topology.FrozenMolecule) and not (loaded):
+            if isinstance(other, openforcefield.topology.FrozenMolecule) and not (
+                loaded
+            ):
                 self._copy_initializer(other)
                 loaded = True
-            if isinstance(other,
-                          openforcefield.topology.Molecule) and not (loaded):
+            if isinstance(other, openforcefield.topology.Molecule) and not (loaded):
                 # TODO: This will need to be updated once FrozenMolecules and Molecules are significantly different
                 self._copy_initializer(other)
                 loaded = True
             if isinstance(other, OrderedDict) and not (loaded):
                 self.__setstate__(other)
                 loaded = True
-
 
             # Check through the toolkit registry to find a compatible wrapper for loading
             if not loaded:
@@ -1547,10 +1583,12 @@ class FrozenMolecule(Serializable):
                     # return an OFFMol if provided with an RDMol, or raise a ValueError if it is provided
                     # an OEMol (or anything else). This makes the assumption that any non-ValueError errors raised
                     # by the toolkit _really are_ bad and should be raised immediately, which may be a bad assumption.
-                    result = toolkit_registry.call('from_object',
-                                                    other,
-                                                    allow_undefined_stereo=allow_undefined_stereo,
-                                                    raise_exception_types=[UndefinedStereochemistryError])
+                    result = toolkit_registry.call(
+                        "from_object",
+                        other,
+                        allow_undefined_stereo=allow_undefined_stereo,
+                        raise_exception_types=[UndefinedStereochemistryError],
+                    )
                 # NotImplementedError should never be raised... Only from_file and from_file_obj are provided
                 # in the base ToolkitWrapper class and require overwriting, so from_object should be excluded
                 # except NotImplementedError as e:
@@ -1564,17 +1602,17 @@ class FrozenMolecule(Serializable):
                     loaded = True
             # TODO: Make this compatible with file-like objects (I couldn't figure out how to make an oemolistream
             # from a fileIO object)
-            if (isinstance(other, str) or hasattr(other, 'read')) and not (loaded):
+            if (isinstance(other, str) or hasattr(other, "read")) and not (loaded):
                 try:
                     mol = Molecule.from_file(
                         other,
                         file_format=file_format,
                         toolkit_registry=toolkit_registry,
-                        allow_undefined_stereo=allow_undefined_stereo
+                        allow_undefined_stereo=allow_undefined_stereo,
                     )  # returns a list only if multiple molecules are found
                     if type(mol) == list:
                         raise ValueError(
-                            'Specified file or file-like object must contain exactly one molecule'
+                            "Specified file or file-like object must contain exactly one molecule"
                         )
                 except ValueError as e:
                     value_errors.append(e)
@@ -1586,8 +1624,9 @@ class FrozenMolecule(Serializable):
             # errors from the different loading attempts
 
             if not (loaded):
-                msg = 'Cannot construct openforcefield.topology.Molecule from {}\n'.format(
-                    other)
+                msg = "Cannot construct openforcefield.topology.Molecule from {}\n".format(
+                    other
+                )
                 for value_error in value_errors:
                     msg += str(value_error)
                 raise ValueError(msg)
@@ -1607,6 +1646,7 @@ class FrozenMolecule(Serializable):
 
         """
         from collections import defaultdict
+
         element_counts = defaultdict(int)
         for atom in self.atoms:
             symbol = atom.element.symbol
@@ -1621,7 +1661,9 @@ class FrozenMolecule(Serializable):
         if not self.has_unique_atom_names:
             self.generate_unique_atom_names()
 
-    def strip_atom_stereochemistry(self, smarts, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def strip_atom_stereochemistry(
+        self, smarts, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY
+    ):
         """Delete stereochemistry information for certain atoms, if it is present.
         This method can be used to "normalize" molecules imported from different cheminformatics
         toolkits, which differ in which atom centers are considered stereogenic.
@@ -1636,13 +1678,15 @@ class FrozenMolecule(Serializable):
 
         """
         from openforcefield.typing.chemistry.environment import AtomChemicalEnvironment
+
         chem_env = AtomChemicalEnvironment(smarts)
-        matches = self.chemical_environment_matches(chem_env, toolkit_registry=toolkit_registry)
+        matches = self.chemical_environment_matches(
+            chem_env, toolkit_registry=toolkit_registry
+        )
 
         for match in set(matches):
             atom_idx = match[0]
             self.atoms[atom_idx].stereochemistry = None
-
 
     ####################################################################################################
     # Safe serialization
@@ -1664,46 +1708,46 @@ class FrozenMolecule(Serializable):
 
         """
         molecule_dict = OrderedDict()
-        molecule_dict['name'] = self._name
+        molecule_dict["name"] = self._name
         ## From Jeff: If we go the properties-as-dict route, then _properties should, at
         ## the top level, be a dict. Should we go through recursively and ensure all values are dicts too?
-        molecule_dict['atoms'] = [atom.to_dict() for atom in self._atoms]
-        molecule_dict['virtual_sites'] = [
+        molecule_dict["atoms"] = [atom.to_dict() for atom in self._atoms]
+        molecule_dict["virtual_sites"] = [
             vsite.to_dict() for vsite in self._virtual_sites
         ]
-        molecule_dict['bonds'] = [bond.to_dict() for bond in self._bonds]
+        molecule_dict["bonds"] = [bond.to_dict() for bond in self._bonds]
         # TODO: Charges
         # TODO: Properties
         # From Jeff: We could have the onerous requirement that all "properties" have to_dict() functions.
         # Or we could restrict properties to simple stuff (ints, strings, floats, and the like)
         # Or pickle anything unusual
         # Or not allow user-defined properties at all (just use our internal _cached_properties)
-        #molecule_dict['properties'] = dict([(key, value._to_dict()) for key.value in self._properties])
+        # molecule_dict['properties'] = dict([(key, value._to_dict()) for key.value in self._properties])
         # TODO: Assuming "simple stuff" properties right now, figure out a better standard
-        molecule_dict['properties'] = self._properties
-        if hasattr(self, '_cached_properties'):
-            molecule_dict['cached_properties'] = self._cached_properties
+        molecule_dict["properties"] = self._properties
+        if hasattr(self, "_cached_properties"):
+            molecule_dict["cached_properties"] = self._cached_properties
         # TODO: Conformers
         if self._conformers is None:
-            molecule_dict['conformers'] = None
+            molecule_dict["conformers"] = None
         else:
-            molecule_dict['conformers'] = []
+            molecule_dict["conformers"] = []
             molecule_dict[
-                'conformers_unit'] = 'angstrom'  # Have this defined as a class variable?
+                "conformers_unit"
+            ] = "angstrom"  # Have this defined as a class variable?
             for conf in self._conformers:
-                conf_unitless = (conf / unit.angstrom)
+                conf_unitless = conf / unit.angstrom
                 conf_serialized, conf_shape = serialize_numpy((conf_unitless))
-                molecule_dict['conformers'].append(conf_serialized)
+                molecule_dict["conformers"].append(conf_serialized)
         if self._partial_charges is None:
-            molecule_dict['partial_charges'] = None
-            molecule_dict['partial_charges_unit'] = None
+            molecule_dict["partial_charges"] = None
+            molecule_dict["partial_charges_unit"] = None
 
         else:
             charges_unitless = self._partial_charges / unit.elementary_charge
-            charges_serialized, charges_shape = serialize_numpy(
-                charges_unitless)
-            molecule_dict['partial_charges'] = charges_serialized
-            molecule_dict['partial_charges_unit'] = 'elementary_charge'
+            charges_serialized, charges_shape = serialize_numpy(charges_unitless)
+            molecule_dict["partial_charges"] = charges_serialized
+            molecule_dict["partial_charges_unit"] = "elementary_charge"
 
         return molecule_dict
 
@@ -1750,100 +1794,108 @@ class FrozenMolecule(Serializable):
         # TODO: Provide useful exception messages if there are any failures
 
         self._initialize()
-        self.name = molecule_dict['name']
-        for atom_dict in molecule_dict['atoms']:
+        self.name = molecule_dict["name"]
+        for atom_dict in molecule_dict["atoms"]:
             self._add_atom(**atom_dict)
 
         # Handle virtual site unit reattachment and molecule tagging
-        for vsite_dict in molecule_dict['virtual_sites']:
+        for vsite_dict in molecule_dict["virtual_sites"]:
             vsite_dict_units = deepcopy(vsite_dict)
 
             # Attach units to epsilon term
-            vsite_dict_units['epsilon'] = string_to_quantity(
-                vsite_dict['epsilon'])
-            vsite_dict_units['sigma'] = string_to_quantity(
-                vsite_dict['sigma'])
-            vsite_dict_units['charge_increments'] = string_to_quantity(
-                vsite_dict['charge_increments'])
+            vsite_dict_units["epsilon"] = string_to_quantity(vsite_dict["epsilon"])
+            vsite_dict_units["sigma"] = string_to_quantity(vsite_dict["sigma"])
+            vsite_dict_units["charge_increments"] = string_to_quantity(
+                vsite_dict["charge_increments"]
+            )
 
             # Call the correct molecule._add_X_virtual_site function, based on the stated type
-            if vsite_dict_units['vsite_type'] == "BondChargeVirtualSite":
-                del vsite_dict_units['vsite_type']
-                vsite_dict_units['distance'] = string_to_quantity(
-                    vsite_dict['distance'])
+            if vsite_dict_units["vsite_type"] == "BondChargeVirtualSite":
+                del vsite_dict_units["vsite_type"]
+                vsite_dict_units["distance"] = string_to_quantity(
+                    vsite_dict["distance"]
+                )
                 self._add_bond_charge_virtual_site(**vsite_dict_units)
 
-            elif vsite_dict_units[
-                    'vsite_type'] == "MonovalentLonePairVirtualSite":
-                del vsite_dict_units['vsite_type']
-                vsite_dict_units['distance'] = string_to_quantity(
-                    vsite_dict['distance'])
-                vsite_dict_units['in_plane_angle'] = string_to_quantity(
-                    vsite_dict['in_plane_angle'])
-                vsite_dict_units['out_of_plane_angle'] = string_to_quantity(
-                    vsite_dict['out_of_plane_angle'])
+            elif vsite_dict_units["vsite_type"] == "MonovalentLonePairVirtualSite":
+                del vsite_dict_units["vsite_type"]
+                vsite_dict_units["distance"] = string_to_quantity(
+                    vsite_dict["distance"]
+                )
+                vsite_dict_units["in_plane_angle"] = string_to_quantity(
+                    vsite_dict["in_plane_angle"]
+                )
+                vsite_dict_units["out_of_plane_angle"] = string_to_quantity(
+                    vsite_dict["out_of_plane_angle"]
+                )
                 self._add_monovalent_lone_pair_virtual_site(**vsite_dict_units)
 
-            elif vsite_dict_units[
-                    'vsite_type'] == "DivalentLonePairVirtualSite":
-                del vsite_dict_units['vsite_type']
-                vsite_dict_units['distance'] = string_to_quantity(
-                    vsite_dict['distance'])
-                vsite_dict_units['in_plane_angle'] = string_to_quantity(
-                    vsite_dict['in_plane_angle'])
-                vsite_dict_units['out_of_plane_angle'] = string_to_quantity(
-                    vsite_dict['out_of_plane_angle'])
+            elif vsite_dict_units["vsite_type"] == "DivalentLonePairVirtualSite":
+                del vsite_dict_units["vsite_type"]
+                vsite_dict_units["distance"] = string_to_quantity(
+                    vsite_dict["distance"]
+                )
+                vsite_dict_units["in_plane_angle"] = string_to_quantity(
+                    vsite_dict["in_plane_angle"]
+                )
+                vsite_dict_units["out_of_plane_angle"] = string_to_quantity(
+                    vsite_dict["out_of_plane_angle"]
+                )
                 self._add_divalent_lone_pair_virtual_site(**vsite_dict_units)
 
-            elif vsite_dict_units[
-                    'vsite_type'] == "TrivalentLonePairVirtualSite":
-                del vsite_dict_units['vsite_type']
-                vsite_dict_units['distance'] = string_to_quantity(
-                    vsite_dict['distance'])
-                vsite_dict_units['in_plane_angle'] = string_to_quantity(
-                    vsite_dict['in_plane_angle'])
-                vsite_dict_units['out_of_plane_angle'] = string_to_quantity(
-                    vsite_dict['out_of_plane_angle'])
+            elif vsite_dict_units["vsite_type"] == "TrivalentLonePairVirtualSite":
+                del vsite_dict_units["vsite_type"]
+                vsite_dict_units["distance"] = string_to_quantity(
+                    vsite_dict["distance"]
+                )
+                vsite_dict_units["in_plane_angle"] = string_to_quantity(
+                    vsite_dict["in_plane_angle"]
+                )
+                vsite_dict_units["out_of_plane_angle"] = string_to_quantity(
+                    vsite_dict["out_of_plane_angle"]
+                )
                 self._add_trivalent_lone_pair_virtual_site(**vsite_dict_units)
 
             else:
-                raise Exception("Vsite type {} not recognized".format(
-                    vsite_dict['vsite_type']))
+                raise Exception(
+                    "Vsite type {} not recognized".format(vsite_dict["vsite_type"])
+                )
 
-        for bond_dict in molecule_dict['bonds']:
-            bond_dict['atom1'] = int(bond_dict['atom1'])
-            bond_dict['atom2'] = int(bond_dict['atom2'])
+        for bond_dict in molecule_dict["bonds"]:
+            bond_dict["atom1"] = int(bond_dict["atom1"])
+            bond_dict["atom2"] = int(bond_dict["atom2"])
             self._add_bond(**bond_dict)
 
-        if molecule_dict['partial_charges'] is None:
+        if molecule_dict["partial_charges"] is None:
             self._partial_charges = None
         else:
-            charges_shape = (self.n_atoms, )
+            charges_shape = (self.n_atoms,)
             partial_charges_unitless = deserialize_numpy(
-                molecule_dict['partial_charges'], charges_shape)
-            pc_unit = getattr(unit, molecule_dict['partial_charges_unit'])
+                molecule_dict["partial_charges"], charges_shape
+            )
+            pc_unit = getattr(unit, molecule_dict["partial_charges_unit"])
             partial_charges = unit.Quantity(partial_charges_unitless, pc_unit)
             self._partial_charges = partial_charges
 
-        if molecule_dict['conformers'] is None:
+        if molecule_dict["conformers"] is None:
             self._conformers = None
         else:
             self._conformers = list()
-            for ser_conf in molecule_dict['conformers']:
+            for ser_conf in molecule_dict["conformers"]:
                 # TODO: Update to use string_to_quantity
-                conformers_shape = ((self.n_atoms, 3))
-                conformer_unitless = deserialize_numpy(ser_conf,
-                                                       conformers_shape)
-                c_unit = getattr(unit, molecule_dict['conformers_unit'])
+                conformers_shape = (self.n_atoms, 3)
+                conformer_unitless = deserialize_numpy(ser_conf, conformers_shape)
+                c_unit = getattr(unit, molecule_dict["conformers_unit"])
                 conformer = unit.Quantity(conformer_unitless, c_unit)
                 self._conformers.append(conformer)
 
-        self._properties = molecule_dict['properties']
+        self._properties = molecule_dict["properties"]
 
     def __repr__(self):
         """Return the SMILES of this molecule"""
         return "Molecule with name '{}' and SMILES '{}'".format(
-            self.name, self.to_smiles())
+            self.name, self.to_smiles()
+        )
 
     def __getstate__(self):
         return self.to_dict()
@@ -1855,12 +1907,12 @@ class FrozenMolecule(Serializable):
         """
         Clear the contents of the current molecule.
         """
-        self._name = ''
+        self._name = ""
         self._atoms = list()
         self._virtual_sites = list()
         self._bonds = list()  # List of bonds between Atom objects
         self._properties = {}  # Attached properties to be preserved
-        #self._cached_properties = None # Cached properties (such as partial charges) can be recomputed as needed
+        # self._cached_properties = None # Cached properties (such as partial charges) can be recomputed as needed
         self._partial_charges = None
         self._conformers = None  # Optional conformers
 
@@ -1877,7 +1929,7 @@ class FrozenMolecule(Serializable):
             A deep copy is made.
 
         """
-        #assert isinstance(other, type(self)), "can only copy instances of {}".format(type(self))
+        # assert isinstance(other, type(self)), "can only copy instances of {}".format(type(self))
         other_dict = other.to_dict()
         self._initialize_from_dict(other_dict)
 
@@ -1894,7 +1946,13 @@ class FrozenMolecule(Serializable):
         # TODO the doc string did not match the previous function what matching should this method do?
         return Molecule.are_isomorphic(self, other, return_atom_map=False)[0]
 
-    def to_smiles(self, isomeric=True, explicit_hydrogens=True, mapped=False, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def to_smiles(
+        self,
+        isomeric=True,
+        explicit_hydrogens=True,
+        mapped=False,
+        toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+    ):
         """
         Return a canonical isomeric SMILES representation of the current molecule.
         A partially mapped smiles can also be generated for atoms of interest by supplying an `atom_map` to the
@@ -1936,19 +1994,26 @@ class FrozenMolecule(Serializable):
 
         # Figure out which toolkit should be used to create the SMILES
         if isinstance(toolkit_registry, ToolkitRegistry):
-            to_smiles_method = toolkit_registry.resolve('to_smiles')
+            to_smiles_method = toolkit_registry.resolve("to_smiles")
         elif isinstance(toolkit_registry, ToolkitWrapper):
             to_smiles_method = toolkit_registry.to_smiles
         else:
             raise Exception(
-                'Invalid toolkit_registry passed to to_smiles. Expected ToolkitRegistry or ToolkitWrapper. Got  {}'
-                .format(type(toolkit_registry)))
+                "Invalid toolkit_registry passed to to_smiles. Expected ToolkitRegistry or ToolkitWrapper. Got  {}".format(
+                    type(toolkit_registry)
+                )
+            )
 
         # Get a string representation of the function containing the toolkit name so we can check
         # if a SMILES was already cached for this molecule. This will return, for example
         # "RDKitToolkitWrapper.to_smiles"
-        smiles_hash = to_smiles_method.__qualname__ + str(isomeric) + str(explicit_hydrogens) + str(mapped)
-        smiles_hash += str(self._properties.get('atom_map', None))
+        smiles_hash = (
+            to_smiles_method.__qualname__
+            + str(isomeric)
+            + str(explicit_hydrogens)
+            + str(mapped)
+        )
+        smiles_hash += str(self._properties.get("atom_map", None))
         # Check to see if a SMILES for this molecule was already cached using this method
         if smiles_hash in self._cached_smiles:
             return self._cached_smiles[smiles_hash]
@@ -1958,7 +2023,9 @@ class FrozenMolecule(Serializable):
             return smiles
 
     @staticmethod
-    def from_inchi(inchi, allow_undefined_stereo=False, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def from_inchi(
+        inchi, allow_undefined_stereo=False, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY
+    ):
         """
         Construct a Molecule from a InChI representation
 
@@ -1987,17 +2054,20 @@ class FrozenMolecule(Serializable):
         """
 
         if isinstance(toolkit_registry, ToolkitRegistry):
-            molecule = toolkit_registry.call('from_inchi',
-                                             inchi,
-                                             allow_undefined_stereo=allow_undefined_stereo)
+            molecule = toolkit_registry.call(
+                "from_inchi", inchi, allow_undefined_stereo=allow_undefined_stereo
+            )
         elif isinstance(toolkit_registry, ToolkitWrapper):
             toolkit = toolkit_registry
-            molecule = toolkit.from_inchi(inchi,
-                                          allow_undefined_stereo=allow_undefined_stereo)
+            molecule = toolkit.from_inchi(
+                inchi, allow_undefined_stereo=allow_undefined_stereo
+            )
         else:
             raise Exception(
-                'Invalid toolkit_registry passed to from_inchi. Expected ToolkitRegistry or ToolkitWrapper. Got  {}'
-                .format(type(toolkit_registry)))
+                "Invalid toolkit_registry passed to from_inchi. Expected ToolkitRegistry or ToolkitWrapper. Got  {}".format(
+                    type(toolkit_registry)
+                )
+            )
 
         return molecule
 
@@ -2030,21 +2100,24 @@ class FrozenMolecule(Serializable):
         """
 
         if isinstance(toolkit_registry, ToolkitRegistry):
-            inchi = toolkit_registry.call('to_inchi',
-                                          self,
-                                          fixed_hydrogens=fixed_hydrogens)
+            inchi = toolkit_registry.call(
+                "to_inchi", self, fixed_hydrogens=fixed_hydrogens
+            )
         elif isinstance(toolkit_registry, ToolkitWrapper):
             toolkit = toolkit_registry
-            inchi = toolkit.to_inchi(self,
-                                     fixed_hydrogens=fixed_hydrogens)
+            inchi = toolkit.to_inchi(self, fixed_hydrogens=fixed_hydrogens)
         else:
             raise InvalidToolkitError(
-                'Invalid toolkit_registry passed to to_inchi. Expected ToolkitRegistry or ToolkitWrapper. Got  {}'
-                .format(type(toolkit_registry)))
+                "Invalid toolkit_registry passed to to_inchi. Expected ToolkitRegistry or ToolkitWrapper. Got  {}".format(
+                    type(toolkit_registry)
+                )
+            )
 
         return inchi
 
-    def to_inchikey(self, fixed_hydrogens=False, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def to_inchikey(
+        self, fixed_hydrogens=False, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY
+    ):
         """
         Create an InChIKey for the molecule using the requested toolkit backend.
         InChIKey is a standardised representation that does not capture tautomers unless specified using the fixed hydrogen
@@ -2073,25 +2146,28 @@ class FrozenMolecule(Serializable):
         """
 
         if isinstance(toolkit_registry, ToolkitRegistry):
-            inchi_key = toolkit_registry.call('to_inchikey',
-                                              self,
-                                              fixed_hydrogens=fixed_hydrogens)
+            inchi_key = toolkit_registry.call(
+                "to_inchikey", self, fixed_hydrogens=fixed_hydrogens
+            )
         elif isinstance(toolkit_registry, ToolkitWrapper):
             toolkit = toolkit_registry
-            inchi_key = toolkit.to_inchikey(self,
-                                            fixed_hydrogens=fixed_hydrogens)
+            inchi_key = toolkit.to_inchikey(self, fixed_hydrogens=fixed_hydrogens)
         else:
             raise InvalidToolkitError(
-                'Invalid toolkit_registry passed to to_inchikey. Expected ToolkitRegistry or ToolkitWrapper. Got  {}'
-                .format(type(toolkit_registry)))
+                "Invalid toolkit_registry passed to to_inchikey. Expected ToolkitRegistry or ToolkitWrapper. Got  {}".format(
+                    type(toolkit_registry)
+                )
+            )
 
         return inchi_key
 
     @staticmethod
-    def from_smiles(smiles,
-                    hydrogens_are_explicit=False,
-                    toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
-                    allow_undefined_stereo=False):
+    def from_smiles(
+        smiles,
+        hydrogens_are_explicit=False,
+        toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+        allow_undefined_stereo=False,
+    ):
         """
         Construct a Molecule from a SMILES representation
 
@@ -2119,33 +2195,40 @@ class FrozenMolecule(Serializable):
 
         """
         if isinstance(toolkit_registry, ToolkitRegistry):
-            molecule = toolkit_registry.call('from_smiles',
-                                             smiles,
-                                             hydrogens_are_explicit=hydrogens_are_explicit,
-                                             allow_undefined_stereo=allow_undefined_stereo)
+            molecule = toolkit_registry.call(
+                "from_smiles",
+                smiles,
+                hydrogens_are_explicit=hydrogens_are_explicit,
+                allow_undefined_stereo=allow_undefined_stereo,
+            )
         elif isinstance(toolkit_registry, ToolkitWrapper):
             toolkit = toolkit_registry
-            molecule = toolkit.from_smiles(smiles,
-                                           hydrogens_are_explicit=hydrogens_are_explicit,
-                                           allow_undefined_stereo=allow_undefined_stereo
-                                           )
+            molecule = toolkit.from_smiles(
+                smiles,
+                hydrogens_are_explicit=hydrogens_are_explicit,
+                allow_undefined_stereo=allow_undefined_stereo,
+            )
         else:
             raise Exception(
-                'Invalid toolkit_registry passed to from_smiles. Expected ToolkitRegistry or ToolkitWrapper. Got  {}'
-                .format(type(toolkit_registry)))
+                "Invalid toolkit_registry passed to from_smiles. Expected ToolkitRegistry or ToolkitWrapper. Got  {}".format(
+                    type(toolkit_registry)
+                )
+            )
 
         return molecule
 
     @staticmethod
     def are_isomorphic(
-            mol1, mol2, return_atom_map=False,
-            aromatic_matching=True,
-            formal_charge_matching=True,
-            bond_order_matching=True,
-            atom_stereochemistry_matching=True,
-            bond_stereochemistry_matching=True,
-            strip_pyrimidal_n_atom_stereo=True,
-            toolkit_registry=GLOBAL_TOOLKIT_REGISTRY
+        mol1,
+        mol2,
+        return_atom_map=False,
+        aromatic_matching=True,
+        formal_charge_matching=True,
+        bond_order_matching=True,
+        atom_stereochemistry_matching=True,
+        bond_stereochemistry_matching=True,
+        strip_pyrimidal_n_atom_stereo=True,
+        toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
     ):
         """
         Determines whether the two molecules are isomorphic by comparing their graph representations and the chosen
@@ -2208,36 +2291,40 @@ class FrozenMolecule(Serializable):
         # Build the user defined matching functions
         def node_match_func(x, y):
             # always match by atleast atomic number
-            is_equal = (x['atomic_number'] == y['atomic_number'])
+            is_equal = x["atomic_number"] == y["atomic_number"]
             if aromatic_matching:
-                is_equal &= (x['is_aromatic'] == y['is_aromatic'])
+                is_equal &= x["is_aromatic"] == y["is_aromatic"]
             if formal_charge_matching:
-                is_equal &= (x['formal_charge'] == y['formal_charge'])
+                is_equal &= x["formal_charge"] == y["formal_charge"]
             if atom_stereochemistry_matching:
-                is_equal &= (x['stereochemistry'] == y['stereochemistry'])
+                is_equal &= x["stereochemistry"] == y["stereochemistry"]
             return is_equal
 
         # check if we want to do any bond matching if not the function is None
         if aromatic_matching or bond_order_matching or bond_stereochemistry_matching:
+
             def edge_match_func(x, y):
                 # We don't need to check the exact bond order (which is 1 or 2)
                 # if the bond is aromatic. This way we avoid missing a match only
                 # if the alternate bond orders 1 and 2 are assigned differently.
                 if aromatic_matching and bond_order_matching:
-                    is_equal = (x['is_aromatic'] == y['is_aromatic']) or (x['bond_order'] == y['bond_order'])
+                    is_equal = (x["is_aromatic"] == y["is_aromatic"]) or (
+                        x["bond_order"] == y["bond_order"]
+                    )
                 elif aromatic_matching:
-                    is_equal = (x['is_aromatic'] == y['is_aromatic'])
+                    is_equal = x["is_aromatic"] == y["is_aromatic"]
                 elif bond_order_matching:
-                    is_equal = (x['bond_order'] == y['bond_order'])
+                    is_equal = x["bond_order"] == y["bond_order"]
                 else:
                     is_equal = None
                 if bond_stereochemistry_matching:
                     if is_equal is None:
-                        is_equal = (x['stereochemistry'] == y['stereochemistry'])
+                        is_equal = x["stereochemistry"] == y["stereochemistry"]
                     else:
-                        is_equal &= (x['stereochemistry'] == y['stereochemistry'])
+                        is_equal &= x["stereochemistry"] == y["stereochemistry"]
 
                 return is_equal
+
         else:
             edge_match_func = None
 
@@ -2247,38 +2334,42 @@ class FrozenMolecule(Serializable):
             from openforcefield.topology import TopologyMolecule
 
             if strip_pyrimidal_n_atom_stereo:
-                SMARTS = '[N+0X3:1](-[*])(-[*])(-[*])'
+                SMARTS = "[N+0X3:1](-[*])(-[*])(-[*])"
 
             if isinstance(data, FrozenMolecule):
                 # Molecule class instance
                 if strip_pyrimidal_n_atom_stereo:
                     # Make a copy of the molecule so we don't modify the original
                     data = deepcopy(data)
-                    data.strip_atom_stereochemistry(SMARTS, toolkit_registry=toolkit_registry)
+                    data.strip_atom_stereochemistry(
+                        SMARTS, toolkit_registry=toolkit_registry
+                    )
                 return data.to_networkx()
             elif isinstance(data, TopologyMolecule):
                 # TopologyMolecule class instance
                 if strip_pyrimidal_n_atom_stereo:
                     # Make a copy of the molecule so we don't modify the original
                     ref_mol = deepcopy(data.reference_molecule)
-                    ref_mol.strip_atom_stereochemistry(SMARTS, toolkit_registry=toolkit_registry)
+                    ref_mol.strip_atom_stereochemistry(
+                        SMARTS, toolkit_registry=toolkit_registry
+                    )
                 return ref_mol.to_networkx()
             elif isinstance(data, nx.Graph):
                 return data
 
             else:
-                raise NotImplementedError(f'The input type {type(data)} is not supported,'
-                                          f'please supply an openforcefield.topology.molecule.Molecule,'
-                                          f'openforcefield.topology.topology.TopologyMolecule or networkx '
-                                          f'representation of the molecule.')
+                raise NotImplementedError(
+                    f"The input type {type(data)} is not supported,"
+                    f"please supply an openforcefield.topology.molecule.Molecule,"
+                    f"openforcefield.topology.topology.TopologyMolecule or networkx "
+                    f"representation of the molecule."
+                )
 
         mol1_netx = to_networkx(mol1)
         mol2_netx = to_networkx(mol2)
         GM = GraphMatcher(
-            mol1_netx,
-            mol2_netx,
-            node_match=node_match_func,
-            edge_match=edge_match_func)
+            mol1_netx, mol2_netx, node_match=node_match_func, edge_match=edge_match_func
+        )
         isomorphic = GM.is_isomorphic()
 
         if isomorphic and return_atom_map:
@@ -2339,20 +2430,32 @@ class FrozenMolecule(Serializable):
         isomorphic : bool
         """
 
-        return Molecule.are_isomorphic(self, other, return_atom_map=False,
-                                       aromatic_matching=kwargs.get('aromatic_matching', True),
-                                       formal_charge_matching=kwargs.get('formal_charge_matching', True),
-                                       bond_order_matching=kwargs.get('bond_order_matching', True),
-                                       atom_stereochemistry_matching=kwargs.get('atom_stereochemistry_matching', True),
-                                       bond_stereochemistry_matching=kwargs.get('bond_stereochemistry_matching', True),
-                                       strip_pyrimidal_n_atom_stereo=kwargs.get('strip_pyrimidal_n_atom_stereo', True),
-                                       toolkit_registry=kwargs.get('toolkit_registry', GLOBAL_TOOLKIT_REGISTRY))[0]
+        return Molecule.are_isomorphic(
+            self,
+            other,
+            return_atom_map=False,
+            aromatic_matching=kwargs.get("aromatic_matching", True),
+            formal_charge_matching=kwargs.get("formal_charge_matching", True),
+            bond_order_matching=kwargs.get("bond_order_matching", True),
+            atom_stereochemistry_matching=kwargs.get(
+                "atom_stereochemistry_matching", True
+            ),
+            bond_stereochemistry_matching=kwargs.get(
+                "bond_stereochemistry_matching", True
+            ),
+            strip_pyrimidal_n_atom_stereo=kwargs.get(
+                "strip_pyrimidal_n_atom_stereo", True
+            ),
+            toolkit_registry=kwargs.get("toolkit_registry", GLOBAL_TOOLKIT_REGISTRY),
+        )[0]
 
-    def generate_conformers(self,
-                            toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
-                            n_conformers=10,
-                            rms_cutoff=None,
-                            clear_existing=True):
+    def generate_conformers(
+        self,
+        toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+        n_conformers=10,
+        rms_cutoff=None,
+        clear_existing=True,
+    ):
         """
         Generate conformers for this molecule using an underlying toolkit. If n_conformers=0, no toolkit wrapper
         will be called. If n_conformers=0 and clear_existing=True, molecule.conformers will be set to None.
@@ -2389,26 +2492,34 @@ class FrozenMolecule(Serializable):
             return
 
         if isinstance(toolkit_registry, ToolkitRegistry):
-            return toolkit_registry.call('generate_conformers',
-                                         self,
-                                         n_conformers=n_conformers,
-                                         rms_cutoff=rms_cutoff,
-                                         clear_existing=clear_existing)
+            return toolkit_registry.call(
+                "generate_conformers",
+                self,
+                n_conformers=n_conformers,
+                rms_cutoff=rms_cutoff,
+                clear_existing=clear_existing,
+            )
         elif isinstance(toolkit_registry, ToolkitWrapper):
             toolkit = toolkit_registry
-            return toolkit.generate_conformers(self,
-                                               n_conformers=n_conformers,
-                                               rms_cutoff = rms_cutoff,
-                                               clear_existing=clear_existing)
+            return toolkit.generate_conformers(
+                self,
+                n_conformers=n_conformers,
+                rms_cutoff=rms_cutoff,
+                clear_existing=clear_existing,
+            )
         else:
             raise InvalidToolkitError(
-                'Invalid toolkit_registry passed to generate_conformers. Expected ToolkitRegistry or ToolkitWrapper. Got  {}'
-                .format(type(toolkit_registry)))
+                "Invalid toolkit_registry passed to generate_conformers. Expected ToolkitRegistry or ToolkitWrapper. Got  {}".format(
+                    type(toolkit_registry)
+                )
+            )
 
-    def compute_partial_charges_am1bcc(self,
-                                       use_conformers=None,
-                                       strict_n_conformers=False,
-                                       toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def compute_partial_charges_am1bcc(
+        self,
+        use_conformers=None,
+        strict_n_conformers=False,
+        toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+    ):
         """
         Calculate partial atomic charges for this molecule using AM1-BCC run by an underlying toolkit
         and assign them to this molecule's partial_charges attribute.
@@ -2437,17 +2548,20 @@ class FrozenMolecule(Serializable):
             If an invalid object is passed as the toolkit_registry parameter
 
         """
-        self.assign_partial_charges(partial_charge_method='am1bcc',
-                                    use_conformers=use_conformers,
-                                    strict_n_conformers=strict_n_conformers,
-                                    toolkit_registry=toolkit_registry)
+        self.assign_partial_charges(
+            partial_charge_method="am1bcc",
+            use_conformers=use_conformers,
+            strict_n_conformers=strict_n_conformers,
+            toolkit_registry=toolkit_registry,
+        )
 
-
-    def assign_partial_charges(self,
-                               partial_charge_method,
-                               strict_n_conformers=False,
-                               use_conformers=None,
-                               toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def assign_partial_charges(
+        self,
+        partial_charge_method,
+        strict_n_conformers=False,
+        use_conformers=None,
+        toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+    ):
         """
         Calculate partial atomic charges for this molecule using an underlying toolkit, and assign
         the new values to the partial_charges attribute.
@@ -2481,30 +2595,34 @@ class FrozenMolecule(Serializable):
             # that supports the desired partial charge method, so we
             # tell the ToolkitRegistry to continue trying ToolkitWrappers
             # if one raises an error (raise_exception_types=[])
-            toolkit_registry.call('assign_partial_charges',
-                                  self,
-                                  partial_charge_method=partial_charge_method,
-                                  use_conformers=use_conformers,
-                                  strict_n_conformers=strict_n_conformers,
-                                  raise_exception_types=[]
-                                  )
+            toolkit_registry.call(
+                "assign_partial_charges",
+                self,
+                partial_charge_method=partial_charge_method,
+                use_conformers=use_conformers,
+                strict_n_conformers=strict_n_conformers,
+                raise_exception_types=[],
+            )
         elif isinstance(toolkit_registry, ToolkitWrapper):
             toolkit = toolkit_registry
-            toolkit.assign_partial_charges(self,
-                                           partial_charge_method=partial_charge_method,
-                                           use_conformers=use_conformers,
-                                           strict_n_conformers=strict_n_conformers
-                                           )
+            toolkit.assign_partial_charges(
+                self,
+                partial_charge_method=partial_charge_method,
+                use_conformers=use_conformers,
+                strict_n_conformers=strict_n_conformers,
+            )
         else:
             raise InvalidToolkitError(
-                f'Invalid toolkit_registry passed to assign_partial_charges.'
-                f'Expected ToolkitRegistry or ToolkitWrapper. Got  {type(toolkit_registry)}')
+                f"Invalid toolkit_registry passed to assign_partial_charges."
+                f"Expected ToolkitRegistry or ToolkitWrapper. Got  {type(toolkit_registry)}"
+            )
 
-
-    def assign_fractional_bond_orders(self,
-                                      bond_order_model=None,
-                                      toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
-                                      use_conformers=None):
+    def assign_fractional_bond_orders(
+        self,
+        bond_order_model=None,
+        toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+        use_conformers=None,
+    ):
         """
         Update and store list of bond orders this molecule. Bond orders are stored on each
         bond, in the `bond.fractional_bond_order` attribute.
@@ -2535,27 +2653,27 @@ class FrozenMolecule(Serializable):
         """
         if isinstance(toolkit_registry, ToolkitRegistry):
             return toolkit_registry.call(
-                'assign_fractional_bond_orders',
+                "assign_fractional_bond_orders",
                 self,
                 bond_order_model=bond_order_model,
-                use_conformers=use_conformers)
+                use_conformers=use_conformers,
+            )
         elif isinstance(toolkit_registry, ToolkitWrapper):
             toolkit = toolkit_registry
             return toolkit.assign_fractional_bond_orders(
-                self,
-                bond_order_model=bond_order_model,
-                use_conformers=use_conformers)
+                self, bond_order_model=bond_order_model, use_conformers=use_conformers
+            )
         else:
             raise Exception(
-                f'Invalid toolkit_registry passed to assign_fractional_bond_orders. '
-                f'Expected ToolkitRegistry or ToolkitWrapper. Got {type(toolkit_registry)}.')
-
+                f"Invalid toolkit_registry passed to assign_fractional_bond_orders. "
+                f"Expected ToolkitRegistry or ToolkitWrapper. Got {type(toolkit_registry)}."
+            )
 
     def _invalidate_cached_properties(self):
         """
         Indicate that the chemical entity has been altered.
         """
-        #if hasattr(self, '_cached_properties'):
+        # if hasattr(self, '_cached_properties'):
         #    delattr(self, '_cached_properties')
         self._conformers = None
         self._partial_charges = None
@@ -2596,21 +2714,32 @@ class FrozenMolecule(Serializable):
 
         """
         import networkx as nx
+
         G = nx.Graph()
         for atom in self.atoms:
             G.add_node(
-                atom.molecule_atom_index, atomic_number=atom.atomic_number, is_aromatic=atom.is_aromatic,
-                stereochemistry=atom.stereochemistry, formal_charge=atom.formal_charge)
-            #G.add_node(atom.molecule_atom_index, attr_dict={'atomic_number': atom.atomic_number})
+                atom.molecule_atom_index,
+                atomic_number=atom.atomic_number,
+                is_aromatic=atom.is_aromatic,
+                stereochemistry=atom.stereochemistry,
+                formal_charge=atom.formal_charge,
+            )
+            # G.add_node(atom.molecule_atom_index, attr_dict={'atomic_number': atom.atomic_number})
         for bond in self.bonds:
             G.add_edge(
-                bond.atom1_index, bond.atom2_index, bond_order=bond.bond_order, is_aromatic=bond.is_aromatic,
-                stereochemistry=bond.stereochemistry)
-            #G.add_edge(bond.atom1_index, bond.atom2_index, attr_dict={'order':bond.bond_order})
+                bond.atom1_index,
+                bond.atom2_index,
+                bond_order=bond.bond_order,
+                is_aromatic=bond.is_aromatic,
+                stereochemistry=bond.stereochemistry,
+            )
+            # G.add_edge(bond.atom1_index, bond.atom2_index, attr_dict={'order':bond.bond_order})
 
         return G
 
-    def find_rotatable_bonds(self, ignore_functional_groups=None, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def find_rotatable_bonds(
+        self, ignore_functional_groups=None, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY
+    ):
         """
         Find all bonds classed as rotatable ignoring any matched to the ``ignore_functional_groups`` list.
 
@@ -2630,11 +2759,12 @@ class FrozenMolecule(Serializable):
 
         # general rotatable bond smarts taken from RDKit
         # https://github.com/rdkit/rdkit/blob/1bf6ef3d65f5c7b06b56862b3fb9116a3839b229/rdkit/Chem/Lipinski.py#L47%3E
-        rotatable_bond_smarts = '[!$(*#*)&!D1:1]-&!@[!$(*#*)&!D1:2]'
+        rotatable_bond_smarts = "[!$(*#*)&!D1:1]-&!@[!$(*#*)&!D1:2]"
 
         # get all of the general matches
-        general_matches = self.chemical_environment_matches(query=rotatable_bond_smarts,
-                                                            toolkit_registry=toolkit_registry)
+        general_matches = self.chemical_environment_matches(
+            query=rotatable_bond_smarts, toolkit_registry=toolkit_registry
+        )
 
         # this will give all forwards and backwards matches, so condense them down with this function
         def condense_matches(matches):
@@ -2661,8 +2791,9 @@ class FrozenMolecule(Serializable):
             # find the functional groups to remove
             for functional_group in ignore_functional_groups:
                 # note I run the searches through this function so they have to be SMIRKS?
-                ignore_matches = self.chemical_environment_matches(query=functional_group,
-                                                                   toolkit_registry=toolkit_registry)
+                ignore_matches = self.chemical_environment_matches(
+                    query=functional_group, toolkit_registry=toolkit_registry
+                )
                 ignore_matches = condense_matches(ignore_matches)
                 # add the new matches to the matches to ignore
                 matches_to_ignore.update(ignore_matches)
@@ -2679,12 +2810,9 @@ class FrozenMolecule(Serializable):
         rotatable_bonds = [self.get_bond_between(*bond) for bond in general_bonds]
         return rotatable_bonds
 
-    def _add_atom(self,
-                  atomic_number,
-                  formal_charge,
-                  is_aromatic,
-                  stereochemistry=None,
-                  name=None):
+    def _add_atom(
+        self, atomic_number, formal_charge, is_aromatic, stereochemistry=None, name=None
+    ):
         """
         Add an atom
 
@@ -2731,9 +2859,10 @@ class FrozenMolecule(Serializable):
             is_aromatic,
             stereochemistry=stereochemistry,
             name=name,
-            molecule=self)
+            molecule=self,
+        )
         self._atoms.append(atom)
-        #self._particles.append(atom)
+        # self._particles.append(atom)
         self._invalidate_cached_properties()
         return self._atoms.index(atom)
 
@@ -2777,18 +2906,20 @@ class FrozenMolecule(Serializable):
             atom_list = atoms
         else:
             raise Exception(
-                'Invalid inputs to molecule._add_bond_charge_virtual_site.'
-                ' Expected ints or Atoms. Received types {} '.format(
-                    [type(i) for i in atoms]))
+                "Invalid inputs to molecule._add_bond_charge_virtual_site."
+                " Expected ints or Atoms. Received types {} ".format(
+                    [type(i) for i in atoms]
+                )
+            )
         # TODO: Check to make sure bond does not already exist
         vsite = BondChargeVirtualSite(atom_list, distance, **kwargs)
         self._virtual_sites.append(vsite)
         self._invalidate_cached_properties()
         return self._virtual_sites.index(vsite)
 
-    def _add_monovalent_lone_pair_virtual_site(self, atoms, distance,
-                                               out_of_plane_angle,
-                                               in_plane_angle, **kwargs):
+    def _add_monovalent_lone_pair_virtual_site(
+        self, atoms, distance, out_of_plane_angle, in_plane_angle, **kwargs
+    ):
         """
         Create a bond charge-type virtual site, in which the location of the charge is specified by the position of
         three atoms.
@@ -2826,18 +2957,20 @@ class FrozenMolecule(Serializable):
             atom_list = atoms
         else:
             raise Exception(
-                'Invalid inputs to molecule._add_monovalent_lone_pair_virtual_site. Expected ints or Atoms.'
-                ' Received types {} '.format([type(i) for i in atoms]))
+                "Invalid inputs to molecule._add_monovalent_lone_pair_virtual_site. Expected ints or Atoms."
+                " Received types {} ".format([type(i) for i in atoms])
+            )
         # TODO: Check to make sure bond does not already exist
         vsite = MonovalentLonePairVirtualSite(
-            atom_list, distance, out_of_plane_angle, in_plane_angle, **kwargs)
+            atom_list, distance, out_of_plane_angle, in_plane_angle, **kwargs
+        )
         self._virtual_sites.append(vsite)
         self._invalidate_cached_properties()
         return self._virtual_sites.index(vsite)
 
-    def _add_divalent_lone_pair_virtual_site(self, atoms, distance,
-                                             out_of_plane_angle,
-                                             in_plane_angle, **kwargs):
+    def _add_divalent_lone_pair_virtual_site(
+        self, atoms, distance, out_of_plane_angle, in_plane_angle, **kwargs
+    ):
         """
         Create a divalent lone pair-type virtual site, in which the location of the charge is specified by the position
         of three atoms.
@@ -2875,18 +3008,20 @@ class FrozenMolecule(Serializable):
             atom_list = atoms
         else:
             raise Exception(
-                'Invalid inputs to molecule._add_divalent_lone_pair_virtual_site. Expected ints or Atoms. '
-                'Received types {} '.format([type(i) for i in atoms]))
+                "Invalid inputs to molecule._add_divalent_lone_pair_virtual_site. Expected ints or Atoms. "
+                "Received types {} ".format([type(i) for i in atoms])
+            )
         # TODO: Check to make sure bond does not already exist
         vsite = DivalentLonePairVirtualSite(
-            atom_list, distance, out_of_plane_angle, in_plane_angle, **kwargs)
+            atom_list, distance, out_of_plane_angle, in_plane_angle, **kwargs
+        )
         self._virtual_sites.append(vsite)
         self._invalidate_cached_properties()
         return self._virtual_sites.index(vsite)
 
-    def _add_trivalent_lone_pair_virtual_site(self, atoms, distance,
-                                              out_of_plane_angle,
-                                              in_plane_angle, **kwargs):
+    def _add_trivalent_lone_pair_virtual_site(
+        self, atoms, distance, out_of_plane_angle, in_plane_angle, **kwargs
+    ):
         """
         Create a trivalent lone pair-type virtual site, in which the location of the charge is specified by the position
          of four atoms.
@@ -2919,21 +3054,26 @@ class FrozenMolecule(Serializable):
             atom_list = atoms
         else:
             raise Exception(
-                'Invalid inputs to molecule._add_trivalent_lone_pair_virtual_site. Expected ints or Atoms. Received types {} '
-                .format([type(i) for i in atoms]))
+                "Invalid inputs to molecule._add_trivalent_lone_pair_virtual_site. Expected ints or Atoms. Received types {} ".format(
+                    [type(i) for i in atoms]
+                )
+            )
         vsite = TrivalentLonePairVirtualSite(
-            atom_list, distance, out_of_plane_angle, in_plane_angle, **kwargs)
+            atom_list, distance, out_of_plane_angle, in_plane_angle, **kwargs
+        )
         self._virtual_sites.append(vsite)
         self._invalidate_cached_properties()
         return self._virtual_sites.index(vsite)
 
-    def _add_bond(self,
-                  atom1,
-                  atom2,
-                  bond_order,
-                  is_aromatic,
-                  stereochemistry=None,
-                  fractional_bond_order=None):
+    def _add_bond(
+        self,
+        atom1,
+        atom2,
+        bond_order,
+        is_aromatic,
+        stereochemistry=None,
+        fractional_bond_order=None,
+    ):
         """
         Add a bond between two specified atom indices
 
@@ -2965,20 +3105,24 @@ class FrozenMolecule(Serializable):
             atom2_atom = atom2
         else:
             raise Exception(
-                'Invalid inputs to molecule._add_bond. Expected ints or Atoms. '
-                'Received {} (type {}) and {} (type {}) '.format(
-                    atom1, type(atom1), atom2, type(atom2)))
+                "Invalid inputs to molecule._add_bond. Expected ints or Atoms. "
+                "Received {} (type {}) and {} (type {}) ".format(
+                    atom1, type(atom1), atom2, type(atom2)
+                )
+            )
         # TODO: Check to make sure bond does not already exist
         if atom1_atom.is_bonded_to(atom2_atom):
-            raise Exception('Bond already exists between {} and {}'.format(
-                atom1_atom, atom2_atom))
+            raise Exception(
+                "Bond already exists between {} and {}".format(atom1_atom, atom2_atom)
+            )
         bond = Bond(
             atom1_atom,
             atom2_atom,
             bond_order,
             is_aromatic,
             stereochemistry=stereochemistry,
-            fractional_bond_order=fractional_bond_order)
+            fractional_bond_order=fractional_bond_order,
+        )
         self._bonds.append(bond)
         self._invalidate_cached_properties()
         # TODO: This is a bad way to get bond index
@@ -2999,24 +3143,24 @@ class FrozenMolecule(Serializable):
         index: int
             The index of this conformer
         """
-        new_conf = unit.Quantity(
-            np.zeros((self.n_atoms, 3), np.float), unit.angstrom)
+        new_conf = unit.Quantity(np.zeros((self.n_atoms, 3), np.float), unit.angstrom)
         if not (new_conf.shape == coordinates.shape):
             raise Exception(
                 "molecule.add_conformer given input of the wrong shape: "
-                "Given {}, expected {}".format(coordinates.shape,
-                                               new_conf.shape))
+                "Given {}, expected {}".format(coordinates.shape, new_conf.shape)
+            )
 
         try:
             new_conf[:] = coordinates
         except AttributeError as e:
             print(e)
             raise Exception(
-                'Coordinates passed to Molecule._add_conformer without units. Ensure that coordinates are '
-                'of type simtk.units.Quantity')
+                "Coordinates passed to Molecule._add_conformer without units. Ensure that coordinates are "
+                "of type simtk.units.Quantity"
+            )
 
         if self._conformers is None:
-            #TODO should we checking that the exact same conformer is not in the list already?
+            # TODO should we checking that the exact same conformer is not in the list already?
             self._conformers = []
         self._conformers.append(new_conf)
         return len(self._conformers)
@@ -3047,9 +3191,9 @@ class FrozenMolecule(Serializable):
         if charges is None:
             self._partial_charges = None
         else:
-            assert hasattr(charges, 'unit')
+            assert hasattr(charges, "unit")
             assert unit.elementary_charge.is_compatible(charges.unit)
-            assert charges.shape == (self.n_atoms, )
+            assert charges.shape == (self.n_atoms,)
 
             charges_ec = charges.in_units_of(unit.elementary_charge)
             self._partial_charges = charges_ec
@@ -3198,7 +3342,7 @@ class FrozenMolecule(Serializable):
         """
         Return the total charge on the molecule
         """
-        charge_sum = 0. * unit.elementary_charge
+        charge_sum = 0.0 * unit.elementary_charge
         for atom in self.atoms:
             charge_sum += atom.formal_charge
         return charge_sum
@@ -3216,7 +3360,7 @@ class FrozenMolecule(Serializable):
         Set the name of this molecule
         """
         if other is None:
-            self._name = ''
+            self._name = ""
         elif type(other) is str:
             self._name = other
         else:
@@ -3260,7 +3404,9 @@ class FrozenMolecule(Serializable):
         # check for networkx then assuming we have a Molecule or TopologyMolecule instance just try and
         # extract the info. Note we do not type check the TopologyMolecule due to cyclic dependencies
         if isinstance(molecule, nx.Graph):
-            atom_nums = list(dict(molecule.nodes(data='atomic_number', default=1)).values())
+            atom_nums = list(
+                dict(molecule.nodes(data="atomic_number", default=1)).values()
+            )
 
         elif isinstance(molecule, TopologyMolecule):
             atom_nums = [atom.atomic_number for atom in molecule.atoms]
@@ -3269,20 +3415,24 @@ class FrozenMolecule(Serializable):
             atom_nums = [atom.atomic_number for atom in molecule.atoms]
 
         else:
-            raise NotImplementedError(f'The input type {type(molecule)} is not supported,'
-                                      f'please supply an openforcefield.topology.molecule.Molecule,'
-                                      f'openforcefield.topology.topology.TopologyMolecule or networkx representaion '
-                                      f'of the molecule.')
+            raise NotImplementedError(
+                f"The input type {type(molecule)} is not supported,"
+                f"please supply an openforcefield.topology.molecule.Molecule,"
+                f"openforcefield.topology.topology.TopologyMolecule or networkx representaion "
+                f"of the molecule."
+            )
 
         # make a correct hill formula representation following this guide
         # https://en.wikipedia.org/wiki/Chemical_formula#Hill_system
 
         # create the counter dictionary using chemical symbols
-        atom_symbol_counts = Counter(Element.getByAtomicNumber(atom_num).symbol for atom_num in atom_nums)
+        atom_symbol_counts = Counter(
+            Element.getByAtomicNumber(atom_num).symbol for atom_num in atom_nums
+        )
 
         formula = []
         # Check for C and H first, to make a correct hill formula
-        for el in ['C', 'H']:
+        for el in ["C", "H"]:
             if el in atom_symbol_counts:
                 count = atom_symbol_counts.pop(el)
                 formula.append(el)
@@ -3298,9 +3448,9 @@ class FrozenMolecule(Serializable):
 
         return "".join(formula)
 
-    def chemical_environment_matches(self,
-                                     query,
-                                     toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def chemical_environment_matches(
+        self, query, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY
+    ):
         """Retrieve all matches for a given chemical environment query.
 
         Parameters
@@ -3332,20 +3482,18 @@ class FrozenMolecule(Serializable):
         """
         # Resolve to SMIRKS if needed
         # TODO: Update this to use updated ChemicalEnvironment API
-        if hasattr(query, 'smirks'):
+        if hasattr(query, "smirks"):
             smirks = query.smirks
         elif type(query) == str:
             smirks = query
         else:
-            raise ValueError(
-                "'query' must be either a string or a ChemicalEnvironment")
+            raise ValueError("'query' must be either a string or a ChemicalEnvironment")
 
         # Use specified cheminformatics toolkit to determine matches with specified aromaticity model
         # TODO: Simplify this by requiring a toolkit registry for the molecule?
         # TODO: Do we have to pass along an aromaticity model?
         if isinstance(toolkit_registry, ToolkitRegistry):
-            matches = toolkit_registry.call('find_smarts_matches', self,
-                                            smirks)
+            matches = toolkit_registry.call("find_smarts_matches", self, smirks)
         elif isinstance(toolkit_registry, ToolkitWrapper):
             matches = toolkit_registry.find_smarts_matches(self, smirks)
         else:
@@ -3388,13 +3536,13 @@ class FrozenMolecule(Serializable):
 
         """
         from openeye import oechem, oeiupac
+
         oemol = oechem.OEMol()
         oeiupac.OEParseIUPACName(oemol, iupac_name)
         oechem.OETriposAtomNames(oemol)
         result = oechem.OEAddExplicitHydrogens(oemol)
         if result == False:
-            raise Exception(
-                "Addition of explicit hydrogens failed in from_iupac")
+            raise Exception("Addition of explicit hydrogens failed in from_iupac")
         molecule = cls.from_openeye(oemol, **kwargs)
         return molecule
 
@@ -3420,6 +3568,7 @@ class FrozenMolecule(Serializable):
 
         """
         from openeye import oeiupac
+
         return oeiupac.OECreateIUPACName(self.to_openeye())
 
     @staticmethod
@@ -3452,7 +3601,7 @@ class FrozenMolecule(Serializable):
         """
         # TODO: Ensure we are dealing with an openforcefield Topology object
         if topology.n_topology_molecules != 1:
-            raise ValueError('Topology must contain exactly one molecule')
+            raise ValueError("Topology must contain exactly one molecule")
         molecule = [i for i in topology.reference_molecules][0]
         return Molecule(molecule)
 
@@ -3473,13 +3622,16 @@ class FrozenMolecule(Serializable):
 
         """
         from openforcefield.topology import Topology
+
         return Topology.from_molecules(self)
 
     @staticmethod
-    def from_file(file_path,
-                  file_format=None,
-                  toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
-                  allow_undefined_stereo=False):
+    def from_file(
+        file_path,
+        file_format=None,
+        toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+        allow_undefined_stereo=False,
+    ):
         """
         Create one or more molecules from a file
 
@@ -3524,10 +3676,10 @@ class FrozenMolecule(Serializable):
                 )
             # Assume that files ending in ".gz" should use their second-to-last suffix for compatibility check
             # TODO: Will all cheminformatics packages be OK with gzipped files?
-            if file_path[-3:] == '.gz':
-                file_format = file_path.split('.')[-2]
+            if file_path[-3:] == ".gz":
+                file_format = file_path.split(".")[-2]
             else:
-                file_format = file_path.split('.')[-1]
+                file_format = file_path.split(".")[-1]
         file_format = file_format.upper()
 
         # Determine which toolkit to use (highest priority that's compatible with input type)
@@ -3540,35 +3692,45 @@ class FrozenMolecule(Serializable):
                     toolkit = query_toolkit
                     break
                 supported_read_formats[
-                    query_toolkit.
-                    toolkit_name] = query_toolkit.toolkit_file_read_formats
+                    query_toolkit.toolkit_name
+                ] = query_toolkit.toolkit_file_read_formats
             if toolkit is None:
-                msg = f"No toolkits in registry can read file {file_path} (format {file_format}). Supported " \
-                      f"formats in the provided ToolkitRegistry are {supported_read_formats}. "
+                msg = (
+                    f"No toolkits in registry can read file {file_path} (format {file_format}). Supported "
+                    f"formats in the provided ToolkitRegistry are {supported_read_formats}. "
+                )
                 # Per issue #407, not allowing RDKit to read mol2 has confused a lot of people. Here we add text
                 # to the error message that will hopefully reduce this confusion.
-                if file_format == 'MOL2' and RDKitToolkitWrapper.is_available():
-                    msg += f"RDKit does not fully support input of molecules from mol2 format unless they " \
-                           f"have Corina atom types, and this is not common in the simulation community. For this " \
-                           f"reason, the Open Force Field Toolkit does not use " \
-                           f"RDKit to read .mol2. Consider reading from SDF instead. If you would like to attempt " \
-                           f"to use RDKit to read mol2 anyway, you can load the molecule of interest into an RDKit " \
-                           f"molecule and use openforcefield.topology.Molecule.from_rdkit, but we do not recommend this."
-                elif file_format == 'PDB' and RDKitToolkitWrapper.is_available():
-                    msg += "RDKit can not safely read PDBs on their own. Information about bond order and aromaticity " \
-                           "is likely to be lost. PDBs can be used along with a valid smiles string with RDKit using " \
-                           "the constructor Molecule.from_pdb_and_smiles(file_path, smiles)"
+                if file_format == "MOL2" and RDKitToolkitWrapper.is_available():
+                    msg += (
+                        f"RDKit does not fully support input of molecules from mol2 format unless they "
+                        f"have Corina atom types, and this is not common in the simulation community. For this "
+                        f"reason, the Open Force Field Toolkit does not use "
+                        f"RDKit to read .mol2. Consider reading from SDF instead. If you would like to attempt "
+                        f"to use RDKit to read mol2 anyway, you can load the molecule of interest into an RDKit "
+                        f"molecule and use openforcefield.topology.Molecule.from_rdkit, but we do not recommend this."
+                    )
+                elif file_format == "PDB" and RDKitToolkitWrapper.is_available():
+                    msg += (
+                        "RDKit can not safely read PDBs on their own. Information about bond order and aromaticity "
+                        "is likely to be lost. PDBs can be used along with a valid smiles string with RDKit using "
+                        "the constructor Molecule.from_pdb_and_smiles(file_path, smiles)"
+                    )
                 raise NotImplementedError(msg)
 
         elif isinstance(toolkit_registry, ToolkitWrapper):
             # TODO: Encapsulate this logic in ToolkitWrapper?
             toolkit = toolkit_registry
             if file_format not in toolkit.toolkit_file_read_formats:
-                msg = f"Toolkit {toolkit.toolkit_name} can not read file {file_path} (format {file_format}). Supported " \
-                      f"formats for this toolkit are {toolkit.toolkit_file_read_formats}."
-                if toolkit.toolkit_name == 'The RDKit' and file_format == 'PDB':
-                    msg += "RDKit can however read PDBs with a valid smiles string using the " \
-                           "Molecule.from_pdb_and_smiles(file_path, smiles) constructor"
+                msg = (
+                    f"Toolkit {toolkit.toolkit_name} can not read file {file_path} (format {file_format}). Supported "
+                    f"formats for this toolkit are {toolkit.toolkit_file_read_formats}."
+                )
+                if toolkit.toolkit_name == "The RDKit" and file_format == "PDB":
+                    msg += (
+                        "RDKit can however read PDBs with a valid smiles string using the "
+                        "Molecule.from_pdb_and_smiles(file_path, smiles) constructor"
+                    )
                 raise NotImplementedError(msg)
         else:
             raise ValueError(
@@ -3581,17 +3743,18 @@ class FrozenMolecule(Serializable):
             mols = toolkit.from_file(
                 file_path,
                 file_format=file_format,
-                allow_undefined_stereo=allow_undefined_stereo)
-        elif hasattr(file_path, 'read'):
+                allow_undefined_stereo=allow_undefined_stereo,
+            )
+        elif hasattr(file_path, "read"):
             file_obj = file_path
             mols = toolkit.from_file_obj(
                 file_obj,
                 file_format=file_format,
-                allow_undefined_stereo=allow_undefined_stereo)
+                allow_undefined_stereo=allow_undefined_stereo,
+            )
 
         if len(mols) == 0:
-            raise Exception(
-                'Unable to read molecule from file: {}'.format(file_path))
+            raise Exception("Unable to read molecule from file: {}".format(file_path))
         elif len(mols) == 1:
             return mols[0]
 
@@ -3613,30 +3776,38 @@ class FrozenMolecule(Serializable):
 
         # If we do not have a conformer make one with all zeros
         if self.n_conformers == 0:
-            conformers = [unit.Quantity(np.zeros((self.n_atoms, 3), np.float), unit.angstrom)]
+            conformers = [
+                unit.Quantity(np.zeros((self.n_atoms, 3), np.float), unit.angstrom)
+            ]
 
         else:
             conformers = self._conformers
 
         if len(conformers) == 1:
-            end = ''
-            title = lambda frame: f'{self.name if self.name is not "" else self.hill_formula}{frame}\n'
+            end = ""
+            title = (
+                lambda frame: f'{self.name if self.name is not "" else self.hill_formula}{frame}\n'
+            )
         else:
             end = 1
-            title = lambda frame: f'{self.name if self.name is not "" else self.hill_formula} Frame {frame}\n'
+            title = (
+                lambda frame: f'{self.name if self.name is not "" else self.hill_formula} Frame {frame}\n'
+            )
 
         # check if we have a file path or an open file object
         if isinstance(file_path, str):
-            xyz_data = open(file_path, 'w')
+            xyz_data = open(file_path, "w")
         else:
             xyz_data = file_path
 
         # add the data to the xyz_data list
         for i, geometry in enumerate(conformers, 1):
-            xyz_data.write(f'{self.n_atoms}\n'+title(end))
+            xyz_data.write(f"{self.n_atoms}\n" + title(end))
             for j, atom_coords in enumerate(geometry.in_units_of(unit.angstrom)):
                 x, y, z = atom_coords._value
-                xyz_data.write(f'{self.atoms[j].element.symbol}       {x: .10f}   {y: .10f}   {z: .10f}\n')
+                xyz_data.write(
+                    f"{self.atoms[j].element.symbol}       {x: .10f}   {y: .10f}   {z: .10f}\n"
+                )
 
             # now we up the frame count
             end = i + 1
@@ -3644,10 +3815,7 @@ class FrozenMolecule(Serializable):
         # now close the file
         xyz_data.close()
 
-    def to_file(self,
-                file_path,
-                file_format,
-                toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def to_file(self, file_path, file_format, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
         """Write the current molecule to a file or file-like object
 
         Parameters
@@ -3690,7 +3858,7 @@ class FrozenMolecule(Serializable):
 
         file_format = file_format.upper()
         # check if xyz, use the toolkit independent method.
-        if file_format == 'XYZ':
+        if file_format == "XYZ":
             return self._to_xyz_file(file_path=file_path)
 
         # Take the first toolkit that can write the desired output format
@@ -3705,11 +3873,12 @@ class FrozenMolecule(Serializable):
             supported_formats = {}
             for toolkit in toolkit_registry.registered_toolkits:
                 supported_formats[
-                    toolkit.toolkit_name] = toolkit.toolkit_file_write_formats
+                    toolkit.toolkit_name
+                ] = toolkit.toolkit_file_write_formats
             raise ValueError(
-                'The requested file format ({}) is not available from any of the installed toolkits '
-                '(supported formats: {})'.format(file_format,
-                                                 supported_formats))
+                "The requested file format ({}) is not available from any of the installed toolkits "
+                "(supported formats: {})".format(file_format, supported_formats)
+            )
 
         # Write file
         if type(file_path) == str:
@@ -3718,7 +3887,9 @@ class FrozenMolecule(Serializable):
         else:
             toolkit.to_file_obj(self, file_path, file_format)
 
-    def enumerate_tautomers(self, max_states=20, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def enumerate_tautomers(
+        self, max_states=20, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY
+    ):
         """
         Enumerate the possible tautomers of the current molecule
 
@@ -3738,13 +3909,14 @@ class FrozenMolecule(Serializable):
         """
 
         if isinstance(toolkit_registry, ToolkitRegistry):
-            molecules = toolkit_registry.call('enumerate_tautomers',
-                                              molecule=self,
-                                              max_states=max_states)
+            molecules = toolkit_registry.call(
+                "enumerate_tautomers", molecule=self, max_states=max_states
+            )
 
         elif isinstance(toolkit_registry, ToolkitWrapper):
-            molecules = toolkit_registry.enumerate_tautomers(self,
-                                                             max_states=max_states)
+            molecules = toolkit_registry.enumerate_tautomers(
+                self, max_states=max_states
+            )
 
         else:
             raise ValueError(
@@ -3753,10 +3925,13 @@ class FrozenMolecule(Serializable):
 
         return molecules
 
-    def enumerate_stereoisomers(self, undefined_only=False,
-                                max_isomers=20,
-                                rationalise=True,
-                                toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def enumerate_stereoisomers(
+        self,
+        undefined_only=False,
+        max_isomers=20,
+        rationalise=True,
+        toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+    ):
         """
         Enumerate the stereocenters and bonds of the current molecule.
 
@@ -3783,17 +3958,21 @@ class FrozenMolecule(Serializable):
         """
 
         if isinstance(toolkit_registry, ToolkitRegistry):
-            molecules = toolkit_registry.call('enumerate_stereoisomers',
-                                              molecule=self,
-                                              undefined_only=undefined_only,
-                                              max_isomers=max_isomers,
-                                              rationalise=rationalise)
+            molecules = toolkit_registry.call(
+                "enumerate_stereoisomers",
+                molecule=self,
+                undefined_only=undefined_only,
+                max_isomers=max_isomers,
+                rationalise=rationalise,
+            )
 
         elif isinstance(toolkit_registry, ToolkitWrapper):
-            molecules = toolkit_registry.enumerate_stereoisomers(self,
-                                                                 undefined_only=undefined_only,
-                                                                 max_isomers=max_isomers,
-                                                                 rationalise=rationalise)
+            molecules = toolkit_registry.enumerate_stereoisomers(
+                self,
+                undefined_only=undefined_only,
+                max_isomers=max_isomers,
+                rationalise=rationalise,
+            )
 
         else:
             raise ValueError(
@@ -3856,7 +4035,8 @@ class FrozenMolecule(Serializable):
         """
         toolkit = RDKitToolkitWrapper()
         molecule = toolkit.from_rdkit(
-            rdmol, allow_undefined_stereo=allow_undefined_stereo)
+            rdmol, allow_undefined_stereo=allow_undefined_stereo
+        )
         return molecule
 
     @RDKitToolkitWrapper.requires_toolkit()
@@ -3924,7 +4104,8 @@ class FrozenMolecule(Serializable):
         """
         toolkit = OpenEyeToolkitWrapper()
         molecule = toolkit.from_openeye(
-            oemol, allow_undefined_stereo=allow_undefined_stereo)
+            oemol, allow_undefined_stereo=allow_undefined_stereo
+        )
         return molecule
 
     def to_qcschema(self, multiplicity=1, conformer=0, extras=None):
@@ -3972,28 +4153,47 @@ class FrozenMolecule(Serializable):
         try:
             import qcelemental as qcel
         except ImportError:
-            raise ImportError('Please install QCElemental via conda install -c conda-forge qcelemental '
-                              'to validate the schema')
+            raise ImportError(
+                "Please install QCElemental via conda install -c conda-forge qcelemental "
+                "to validate the schema"
+            )
 
         # get/ check the geometry
         try:
             geometry = self.conformers[conformer].in_units_of(unit.bohr)
         except (IndexError, TypeError):
-            raise InvalidConformerError('The molecule must have a conformation to produce a valid qcschema; '
-                                        f'no conformer was found at index {conformer}.')
+            raise InvalidConformerError(
+                "The molecule must have a conformation to produce a valid qcschema; "
+                f"no conformer was found at index {conformer}."
+            )
 
         # Gather the required qcschema data
         charge = self.total_charge / unit.elementary_charge
-        connectivity = [(bond.atom1_index, bond.atom2_index, bond.bond_order) for bond in self.bonds]
-        symbols = [Element.getByAtomicNumber(atom.atomic_number).symbol for atom in self.atoms]
+        connectivity = [
+            (bond.atom1_index, bond.atom2_index, bond.bond_order) for bond in self.bonds
+        ]
+        symbols = [
+            Element.getByAtomicNumber(atom.atomic_number).symbol for atom in self.atoms
+        ]
 
-        schema_dict = {'symbols': symbols, 'geometry': geometry, 'connectivity': connectivity,
-                       'molecular_charge': charge, 'molecular_multiplicity': multiplicity, "extras": extras}
+        schema_dict = {
+            "symbols": symbols,
+            "geometry": geometry,
+            "connectivity": connectivity,
+            "molecular_charge": charge,
+            "molecular_multiplicity": multiplicity,
+            "extras": extras,
+        }
 
         return qcel.models.Molecule.from_data(schema_dict, validate=True)
 
     @classmethod
-    def from_mapped_smiles(cls, mapped_smiles, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY, allow_undefined_stereo=False):
+    def from_mapped_smiles(
+        cls,
+        mapped_smiles,
+        toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+        allow_undefined_stereo=False,
+    ):
         """
         Create an openforcefield.topology.molecule.Molecule from a mapped SMILES made with cmiles.
         The molecule will be in the order of the indexing in the mapped smiles string.
@@ -4023,18 +4223,26 @@ class FrozenMolecule(Serializable):
 
         # create the molecule from the smiles and check we have the right number of indexes
         # in the mapped SMILES
-        offmol = cls.from_smiles(mapped_smiles, hydrogens_are_explicit=True, toolkit_registry=toolkit_registry,
-                                 allow_undefined_stereo=allow_undefined_stereo)
+        offmol = cls.from_smiles(
+            mapped_smiles,
+            hydrogens_are_explicit=True,
+            toolkit_registry=toolkit_registry,
+            allow_undefined_stereo=allow_undefined_stereo,
+        )
 
         # check we found some mapping and remove it as we do not want to expose atom maps
         try:
-            mapping = offmol._properties.pop('atom_map')
+            mapping = offmol._properties.pop("atom_map")
         except KeyError:
-            raise SmilesParsingError('The given SMILES has no indexing, please generate a valid explicit hydrogen '
-                                     'mapped SMILES using cmiles.')
+            raise SmilesParsingError(
+                "The given SMILES has no indexing, please generate a valid explicit hydrogen "
+                "mapped SMILES using cmiles."
+            )
 
         if len(mapping) != offmol.n_atoms:
-            raise SmilesParsingError('The mapped smiles does not contain enough indexes to remap the molecule.')
+            raise SmilesParsingError(
+                "The mapped smiles does not contain enough indexes to remap the molecule."
+            )
 
         # remap the molecule using the atom map found in the smiles
         # the order is mapping = Dict[current_index: new_index]
@@ -4044,7 +4252,13 @@ class FrozenMolecule(Serializable):
         return offmol.remap(adjusted_mapping, current_to_new=True)
 
     @classmethod
-    def from_qcschema(cls, qca_record, client=None, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY, allow_undefined_stereo=False):
+    def from_qcschema(
+        cls,
+        qca_record,
+        client=None,
+        toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+        allow_undefined_stereo=False,
+    ):
         """
         Create a Molecule from  a QCArchive entry based on the cmiles information.
 
@@ -4083,41 +4297,56 @@ class FrozenMolecule(Serializable):
         # lets get it all in the dict rep
         if not isinstance(qca_record, dict):
             try:
-                qca_record = qca_record.dict(encoding='json')
+                qca_record = qca_record.dict(encoding="json")
             except AttributeError:
-                raise AttributeError('The object passed could not be converted to a dict with json encoding')
+                raise AttributeError(
+                    "The object passed could not be converted to a dict with json encoding"
+                )
 
         try:
-            mapped_smiles = qca_record['attributes']['canonical_isomeric_explicit_hydrogen_mapped_smiles']
+            mapped_smiles = qca_record["attributes"][
+                "canonical_isomeric_explicit_hydrogen_mapped_smiles"
+            ]
         except KeyError:
-            raise KeyError('The record must contain the hydrogen mapped smiles to be safely made from the archive.')
+            raise KeyError(
+                "The record must contain the hydrogen mapped smiles to be safely made from the archive."
+            )
 
         # make a new molecule that has been reordered to match the cmiles mapping
-        offmol = cls.from_mapped_smiles(mapped_smiles, toolkit_registry=toolkit_registry,
-                                        allow_undefined_stereo=allow_undefined_stereo)
+        offmol = cls.from_mapped_smiles(
+            mapped_smiles,
+            toolkit_registry=toolkit_registry,
+            allow_undefined_stereo=allow_undefined_stereo,
+        )
 
         if client is not None:
             # try and find the initial molecule conformations and attach them
             # collect the input molecules
             try:
-                input_mols = client.query_molecules(id=qca_record['initial_molecules'])
+                input_mols = client.query_molecules(id=qca_record["initial_molecules"])
             except KeyError:
                 # this must be an optimisation record
-                input_mols = client.query_molecules(id=qca_record['initial_molecule'])
+                input_mols = client.query_molecules(id=qca_record["initial_molecule"])
             except AttributeError:
-                raise AttributeError('The provided client can not query molecules, make sure it is an instance of'
-                                     'qcportal.client.FractalClient() with the correct address.')
+                raise AttributeError(
+                    "The provided client can not query molecules, make sure it is an instance of"
+                    "qcportal.client.FractalClient() with the correct address."
+                )
             initial_ids = {}
             # now for each molecule convert and attach the input geometry
             for molecule in input_mols:
-                geometry = unit.Quantity(np.array(molecule.geometry, np.float), unit.bohr)
+                geometry = unit.Quantity(
+                    np.array(molecule.geometry, np.float), unit.bohr
+                )
                 try:
                     offmol.add_conformer(geometry.in_units_of(unit.angstrom))
                     initial_ids[molecule.id] = offmol.n_conformers - 1
                 except InvalidConformerError:
-                    print('Invalid conformer for this molecule, the geometry could not be attached.')
+                    print(
+                        "Invalid conformer for this molecule, the geometry could not be attached."
+                    )
             # attach a dict that has the initial molecule ids and the number of the conformer it is stored in
-            offmol._properties['initial_molecules'] = initial_ids
+            offmol._properties["initial_molecules"] = initial_ids
 
         return offmol
 
@@ -4177,15 +4406,16 @@ class FrozenMolecule(Serializable):
         """
 
         if isinstance(toolkit_registry, ToolkitRegistry):
-            return toolkit_registry.call('canonical_order_atoms',
-                                         self)
+            return toolkit_registry.call("canonical_order_atoms", self)
         elif isinstance(toolkit_registry, ToolkitWrapper):
             toolkit = toolkit_registry
             return toolkit.canonical_order_atoms(self)
         else:
             raise Exception(
-                'Invalid toolkit_registry passed to from_smiles. Expected ToolkitRegistry or ToolkitWrapper. Got  {}'
-                .format(type(toolkit_registry)))
+                "Invalid toolkit_registry passed to from_smiles. Expected ToolkitRegistry or ToolkitWrapper. Got  {}".format(
+                    type(toolkit_registry)
+                )
+            )
 
     def remap(self, mapping_dict, current_to_new=True):
         """
@@ -4207,12 +4437,14 @@ class FrozenMolecule(Serializable):
         """
 
         if self.n_virtual_sites != 0:
-            raise NotImplementedError('We can not remap virtual sites yet!')
+            raise NotImplementedError("We can not remap virtual sites yet!")
 
         # make sure the size of the mapping matches the current molecule
         if len(mapping_dict) != self.n_atoms:
-            raise ValueError(f'The number of mapping indices({len(mapping_dict)}) does not match the number of'
-                             f'atoms in this molecule({self.n_atoms})')
+            raise ValueError(
+                f"The number of mapping indices({len(mapping_dict)}) does not match the number of"
+                f"atoms in this molecule({self.n_atoms})"
+            )
 
         # make two mapping dicts we need new to old for atoms
         # and old to new for bonds
@@ -4235,25 +4467,31 @@ class FrozenMolecule(Serializable):
         # this is the first time we access the mapping; catch an index error here corresponding to mapping that starts
         # from 0 or higher
         except (KeyError, IndexError):
-            raise IndexError(f'The mapping supplied is missing a relation corresponding to atom({i})')
+            raise IndexError(
+                f"The mapping supplied is missing a relation corresponding to atom({i})"
+            )
 
         # add the bonds but with atom indexes in a sorted ascending order
         for bond in self._bonds:
             atoms = sorted([cur_to_new[bond.atom1_index], cur_to_new[bond.atom2_index]])
             bond_dict = bond.to_dict()
-            bond_dict['atom1'] = atoms[0]
-            bond_dict['atom2'] = atoms[1]
+            bond_dict["atom1"] = atoms[0]
+            bond_dict["atom2"] = atoms[1]
             new_molecule.add_bond(**bond_dict)
 
         # we can now resort the bonds
-        sorted_bonds = sorted(new_molecule.bonds, key=operator.attrgetter('atom1_index', 'atom2_index'))
+        sorted_bonds = sorted(
+            new_molecule.bonds, key=operator.attrgetter("atom1_index", "atom2_index")
+        )
         new_molecule._bonds = sorted_bonds
 
         # remap the charges
         if self.partial_charges is not None:
             new_charges = np.zeros(self.n_atoms)
             for i in range(self.n_atoms):
-                new_charges[i] = self.partial_charges[new_to_cur[i]].value_in_unit(unit.elementary_charge)
+                new_charges[i] = self.partial_charges[new_to_cur[i]].value_in_unit(
+                    unit.elementary_charge
+                )
             new_molecule.partial_charges = new_charges * unit.elementary_charge
 
         # remap the conformers there can be more than one
@@ -4261,7 +4499,9 @@ class FrozenMolecule(Serializable):
             for conformer in self.conformers:
                 new_conformer = np.zeros((self.n_atoms, 3))
                 for i in range(self.n_atoms):
-                    new_conformer[i] = conformer[new_to_cur[i]].value_in_unit(unit.angstrom)
+                    new_conformer[i] = conformer[new_to_cur[i]].value_in_unit(
+                        unit.angstrom
+                    )
                 new_molecule.add_conformer(new_conformer * unit.angstrom)
 
         # move any properties across
@@ -4308,7 +4548,7 @@ class FrozenMolecule(Serializable):
         Get an iterator over all i-j-k angles.
         """
         # TODO: Build Angle objects instead of tuple of atoms.
-        if not hasattr(self, '_angles'):
+        if not hasattr(self, "_angles"):
             self._construct_bonded_atoms_list()
             self._angles = set()
             for atom1 in self._atoms:
@@ -4327,10 +4567,10 @@ class FrozenMolecule(Serializable):
         Construct sets containing the atoms improper and proper torsions
         """
         # TODO: Build Proper/ImproperTorsion objects instead of tuple of atoms.
-        if not hasattr(self, '_torsions'):
+        if not hasattr(self, "_torsions"):
             self._construct_bonded_atoms_list()
 
-            #self._torsions = set()
+            # self._torsions = set()
             self._propers = set()
             self._impropers = set()
             for atom1 in self._atoms:
@@ -4362,7 +4602,7 @@ class FrozenMolecule(Serializable):
                             self._impropers.add(improper)
 
             self._torsions = self._propers | self._impropers
-        #return iter(self._torsions)
+        # return iter(self._torsions)
 
     def _construct_bonded_atoms_list(self):
         """
@@ -4370,8 +4610,8 @@ class FrozenMolecule(Serializable):
 
         """
         # TODO: Add this to cached_properties
-        if not hasattr(self, '_bondedAtoms'):
-            #self._atoms = [ atom for atom in self.atoms() ]
+        if not hasattr(self, "_bondedAtoms"):
+            # self._atoms = [ atom for atom in self.atoms() ]
             self._bondedAtoms = dict()
             for atom in self._atoms:
                 self._bondedAtoms[atom] = set()
@@ -4425,7 +4665,8 @@ class FrozenMolecule(Serializable):
         else:
             raise TypeError(
                 "Invalid input passed to is_bonded(). Expected ints or Atoms, "
-                "got {} and {}".format(i, j))
+                "got {} and {}".format(i, j)
+            )
 
         for bond in atom_i.bonds:
 
@@ -4438,7 +4679,8 @@ class FrozenMolecule(Serializable):
                     return bond
 
         from openforcefield.topology import NotBondedError
-        raise NotBondedError('No bond between atom {} and {}'.format(i, j))
+
+        raise NotBondedError("No bond between atom {} and {}".format(i, j))
 
 
 class Molecule(FrozenMolecule):
@@ -4552,16 +4794,13 @@ class Molecule(FrozenMolecule):
            * Should we also support SMILES strings or IUPAC names for ``other``?
 
         """
-        #super(self, Molecule).__init__(*args, **kwargs)
+        # super(self, Molecule).__init__(*args, **kwargs)
         super(Molecule, self).__init__(*args, **kwargs)
 
     # TODO: Change this to add_atom(Atom) to improve encapsulation and extensibility?
-    def add_atom(self,
-                 atomic_number,
-                 formal_charge,
-                 is_aromatic,
-                 stereochemistry=None,
-                 name=None):
+    def add_atom(
+        self, atomic_number, formal_charge, is_aromatic, stereochemistry=None, name=None
+    ):
         """
         Add an atom
 
@@ -4606,18 +4845,21 @@ class Molecule(FrozenMolecule):
             formal_charge,
             is_aromatic,
             stereochemistry=stereochemistry,
-            name=name)
+            name=name,
+        )
         return atom_index
 
-    def add_bond_charge_virtual_site(self,
-                                     atoms,
-                                     distance,
-                                     charge_increments=None,
-                                     weights=None,
-                                     epsilon=None,
-                                     sigma=None,
-                                     rmin_half=None,
-                                     name=''):
+    def add_bond_charge_virtual_site(
+        self,
+        atoms,
+        distance,
+        charge_increments=None,
+        weights=None,
+        epsilon=None,
+        sigma=None,
+        rmin_half=None,
+        name="",
+    ):
         """
         Create a bond charge-type virtual site, in which the location of the charge is specified by the position of two atoms. This supports placement of a virtual site S along a vector between two specified atoms, e.g. to allow for a sigma hole for halogens or similar contexts. With positive values of the distance, the virtual site lies outside the first indexed atom.
         Parameters
@@ -4654,12 +4896,13 @@ class Molecule(FrozenMolecule):
             epsilon=epsilon,
             sigma=sigma,
             rmin_half=rmin_half,
-            name=name)
+            name=name,
+        )
         return vsite_index
 
-    def add_monovalent_lone_pair_virtual_site(self, atoms, distance,
-                                              out_of_plane_angle,
-                                              in_plane_angle, **kwargs):
+    def add_monovalent_lone_pair_virtual_site(
+        self, atoms, distance, out_of_plane_angle, in_plane_angle, **kwargs
+    ):
         """
         Create a bond charge-type virtual site, in which the location of the charge is specified by the position of three atoms.
 
@@ -4692,15 +4935,16 @@ class Molecule(FrozenMolecule):
 
         """
 
-        #vsite_index = self._add_monovalent_lone_pair_virtual_site(self, atoms, distance, out_of_plane_angle, in_plane_angle, charge_increments=charge_increments, weights=weights, epsilon=epsilon, sigma=sigma, rmin_half=rmin_half, name=name)
+        # vsite_index = self._add_monovalent_lone_pair_virtual_site(self, atoms, distance, out_of_plane_angle, in_plane_angle, charge_increments=charge_increments, weights=weights, epsilon=epsilon, sigma=sigma, rmin_half=rmin_half, name=name)
         vsite_index = self._add_monovalent_lone_pair_virtual_site(
-            atoms, distance, out_of_plane_angle, in_plane_angle, **kwargs)
+            atoms, distance, out_of_plane_angle, in_plane_angle, **kwargs
+        )
         return vsite_index
 
-    #def add_divalent_lone_pair_virtual_site(self, atoms, distance, out_of_plane_angle, in_plane_angle, charge_increments=None, weights=None, epsilon=None, sigma=None, rmin_half=None, name=None):
-    def add_divalent_lone_pair_virtual_site(self, atoms, distance,
-                                            out_of_plane_angle, in_plane_angle,
-                                            **kwargs):
+    # def add_divalent_lone_pair_virtual_site(self, atoms, distance, out_of_plane_angle, in_plane_angle, charge_increments=None, weights=None, epsilon=None, sigma=None, rmin_half=None, name=None):
+    def add_divalent_lone_pair_virtual_site(
+        self, atoms, distance, out_of_plane_angle, in_plane_angle, **kwargs
+    ):
         """
         Create a divalent lone pair-type virtual site, in which the location of the charge is specified by the position of three atoms.
 
@@ -4731,14 +4975,15 @@ class Molecule(FrozenMolecule):
             The index of the newly-added virtual site in the molecule
 
         """
-        #vsite_index = self._add_divalent_lone_pair_virtual_site(self, atoms, distance, out_of_plane_angle, in_plane_angle, charge_increments=charge_increments, weights=weights, epsilon=epsilon, sigma=sigma, rmin_half=rmin_half, name=name)
+        # vsite_index = self._add_divalent_lone_pair_virtual_site(self, atoms, distance, out_of_plane_angle, in_plane_angle, charge_increments=charge_increments, weights=weights, epsilon=epsilon, sigma=sigma, rmin_half=rmin_half, name=name)
         vsite_index = self._add_divalent_lone_pair_virtual_site(
-            atoms, distance, out_of_plane_angle, in_plane_angle, **kwargs)
+            atoms, distance, out_of_plane_angle, in_plane_angle, **kwargs
+        )
         return vsite_index
 
-    def add_trivalent_lone_pair_virtual_site(self, atoms, distance,
-                                             out_of_plane_angle,
-                                             in_plane_angle, **kwargs):
+    def add_trivalent_lone_pair_virtual_site(
+        self, atoms, distance, out_of_plane_angle, in_plane_angle, **kwargs
+    ):
         """
         Create a trivalent lone pair-type virtual site, in which the location of the charge is specified by the position of four atoms.
 
@@ -4770,16 +5015,19 @@ class Molecule(FrozenMolecule):
 
         """
         vsite_index = self._add_trivalent_lone_pair_virtual_site(
-            atoms, distance, out_of_plane_angle, in_plane_angle, **kwargs)
+            atoms, distance, out_of_plane_angle, in_plane_angle, **kwargs
+        )
         return vsite_index
 
-    def add_bond(self,
-                 atom1,
-                 atom2,
-                 bond_order,
-                 is_aromatic,
-                 stereochemistry=None,
-                 fractional_bond_order=None):
+    def add_bond(
+        self,
+        atom1,
+        atom2,
+        bond_order,
+        is_aromatic,
+        stereochemistry=None,
+        fractional_bond_order=None,
+    ):
         """
         Add a bond between two specified atom indices
 
@@ -4811,7 +5059,8 @@ class Molecule(FrozenMolecule):
             bond_order,
             is_aromatic,
             stereochemistry=stereochemistry,
-            fractional_bond_order=fractional_bond_order)
+            fractional_bond_order=fractional_bond_order,
+        )
         return bond_index
 
     def add_conformer(self, coordinates):
@@ -4835,7 +5084,7 @@ class Molecule(FrozenMolecule):
 
         return self._add_conformer(coordinates)
 
-    def visualize(self, backend='rdkit', width=500, height=300):
+    def visualize(self, backend="rdkit", width=500, height=300):
         """
         Render a visualization of the molecule in Jupyter
         
@@ -4864,13 +5113,13 @@ class Molecule(FrozenMolecule):
 
         backend = backend.lower()
 
-        if backend == 'nglview':
+        if backend == "nglview":
             try:
                 import nglview as nv
             except ImportError:
                 raise ValueError(
-                    'Attempted to visualize with NGLview but did not find it '
-                    'installed. Try conda install -c conda-forge nglview.'
+                    "Attempted to visualize with NGLview but did not find it "
+                    "installed. Try conda install -c conda-forge nglview."
                 )
             if self.conformers:
                 trajectory_like = _OFFTrajectoryNGLView(self)
@@ -4878,28 +5127,31 @@ class Molecule(FrozenMolecule):
                 return widget
             else:
                 raise ValueError(
-                    'Visualizing with NGLview requires that the molecule has '
-                    'conformers.'
+                    "Visualizing with NGLview requires that the molecule has "
+                    "conformers."
                 )
-        if backend == 'rdkit':
+        if backend == "rdkit":
             if RDKIT_AVAILABLE:
                 from rdkit.Chem.Draw import IPythonConsole
+
                 return self.to_rdkit()
             else:
                 warnings.warn(
-                    'RDKit was requested as a visualization backend but '
-                    'it was not found to be installed. Falling back to '
-                    'trying to using OpenEye for visualization.'
+                    "RDKit was requested as a visualization backend but "
+                    "it was not found to be installed. Falling back to "
+                    "trying to using OpenEye for visualization."
                 )
-                backend = 'openeye'
-        if backend == 'openeye':
+                backend = "openeye"
+        if backend == "openeye":
             if OPENEYE_AVAILABLE:
                 from openeye import oedepict
                 from IPython.display import Image
 
                 oemol = self.to_openeye()
 
-                opts = oedepict.OE2DMolDisplayOptions(width, height, oedepict.OEScale_AutoScale)
+                opts = oedepict.OE2DMolDisplayOptions(
+                    width, height, oedepict.OEScale_AutoScale
+                )
 
                 oedepict.OEPrepareDepiction(oemol)
                 img = oedepict.OEImage(width, height)
@@ -4908,22 +5160,23 @@ class Molecule(FrozenMolecule):
                 png = oedepict.OEWriteImageToString("png", img)
                 return Image(png)
 
-        raise ValueError('Could not find an appropriate backend')
+        raise ValueError("Could not find an appropriate backend")
 
     def _ipython_display_(self):
         from IPython.display import display
+
         try:
-            return display(self.visualize(backend='nglview'))
+            return display(self.visualize(backend="nglview"))
         except (ImportError, ValueError):
             pass
 
         try:
-            return display(self.visualize(backend='rdkit'))
+            return display(self.visualize(backend="rdkit"))
         except ValueError:
             pass
 
         try:
-            return display(self.visualize(backend='openeye'))
+            return display(self.visualize(backend="openeye"))
         except ValueError:
             pass
 
@@ -4944,6 +5197,7 @@ class _OFFTrajectoryNGLView(_NGLViewTrajectory):
     molecule : openforcefield.topology.Molecule
         The molecule (with conformers) to visualize
     """
+
     def __init__(self, molecule):
         self.molecule = molecule
         self.ext = "pdb"
@@ -4963,7 +5217,7 @@ class _OFFTrajectoryNGLView(_NGLViewTrajectory):
         memfile.seek(0)
         block = memfile.getvalue()
         # FIXME: Prevent multi-model PDB export with a keyword in molecule.to_file()?
-        models = block.split('END\n', 1)
+        models = block.split("END\n", 1)
         return models[0]
 
 
@@ -4973,6 +5227,7 @@ class InvalidConformerError(Exception):
     has a different connectivity to that already defined.
     or anyother conformer related issues.
     """
+
     pass
 
 
@@ -4980,4 +5235,5 @@ class SmilesParsingError(Exception):
     """
     This error is rasied when parsing a smiles string results in an error.
     """
+
     pass

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#=============================================================================================
+# =============================================================================================
 # MODULE DOCSTRING
-#=============================================================================================
+# =============================================================================================
 """
 Class definitions to represent a molecular system and its chemical components
 
@@ -17,9 +17,9 @@ Class definitions to represent a molecular system and its chemical components
 
 """
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import itertools
 
@@ -31,33 +31,40 @@ from simtk.openmm import app
 
 from openforcefield.typing.chemistry import ChemicalEnvironment
 from openforcefield.utils.toolkits import (
-    DEFAULT_AROMATICITY_MODEL, ALLOWED_AROMATICITY_MODELS, ALLOWED_FRACTIONAL_BOND_ORDER_MODELS,
-    GLOBAL_TOOLKIT_REGISTRY, ALLOWED_CHARGE_MODELS
+    DEFAULT_AROMATICITY_MODEL,
+    ALLOWED_AROMATICITY_MODELS,
+    ALLOWED_FRACTIONAL_BOND_ORDER_MODELS,
+    GLOBAL_TOOLKIT_REGISTRY,
+    ALLOWED_CHARGE_MODELS,
 )
 from openforcefield.utils.serialization import Serializable
 from openforcefield.utils import MessageException
 
-#=============================================================================================
+# =============================================================================================
 # Exceptions
-#=============================================================================================
+# =============================================================================================
 
 
 class DuplicateUniqueMoleculeError(MessageException):
     """
     Exception for when the user provides indistinguishable unique molecules when trying to identify atoms from a PDB
     """
+
     pass
+
 
 class NotBondedError(MessageException):
     """
     Exception for when a function requires a bond between two atoms, but none is present
     """
+
     pass
 
 
-#=============================================================================================
+# =============================================================================================
 # PRIVATE SUBROUTINES
-#=============================================================================================
+# =============================================================================================
+
 
 class _TransformedDict(MutableMapping):
     """A dictionary that transform and sort keys.
@@ -96,6 +103,7 @@ class _TransformedDict(MutableMapping):
     def __sortfunc__(key):
         return key
 
+
 # TODO: Encapsulate this atom ordering logic directly into Atom/Bond/Angle/Torsion classes?
 class ValenceDict(_TransformedDict):
     """Enforce uniqueness in atom indices."""
@@ -109,6 +117,7 @@ class ValenceDict(_TransformedDict):
             key = tuple(reversed(key))
         return key
 
+
 class SortedDict(_TransformedDict):
     """Enforce uniqueness of atom index tuples, without any restrictions on atom reordering."""
 
@@ -118,6 +127,7 @@ class SortedDict(_TransformedDict):
         key = tuple(sorted(key))
         # Reverse the key if the first element is bigger than the last.
         return key
+
 
 class ImproperDict(_TransformedDict):
     """Symmetrize improper torsions."""
@@ -131,14 +141,13 @@ class ImproperDict(_TransformedDict):
         # Sort connected atoms
         connectedatoms.sort()
         # Re-store connected atoms
-        key = tuple(
-            [connectedatoms[0], key[1], connectedatoms[1], connectedatoms[2]])
-        return (key)
+        key = tuple([connectedatoms[0], key[1], connectedatoms[1], connectedatoms[2]])
+        return key
 
 
-#=============================================================================================
+# =============================================================================================
 # TOPOLOGY OBJECTS
-#=============================================================================================
+# =============================================================================================
 
 # =============================================================================================
 # TopologyAtom
@@ -228,8 +237,13 @@ class TopologyAtom(Serializable):
         int
             The index of this atom in its parent topology.
         """
-        mapped_molecule_atom_index = self._topology_molecule._ref_to_top_index[self._atom.molecule_atom_index]
-        return self._topology_molecule.atom_start_topology_index + mapped_molecule_atom_index
+        mapped_molecule_atom_index = self._topology_molecule._ref_to_top_index[
+            self._atom.molecule_atom_index
+        ]
+        return (
+            self._topology_molecule.atom_start_topology_index
+            + mapped_molecule_atom_index
+        )
 
     @property
     def topology_particle_index(self):
@@ -260,12 +274,14 @@ class TopologyAtom(Serializable):
             yield self._topology_molecule.bond(reference_mol_bond_index)
 
     def __eq__(self, other):
-        return ((self._atom == other._atom)
-                and (self._topology_molecule == other._topology_molecule))
+        return (self._atom == other._atom) and (
+            self._topology_molecule == other._topology_molecule
+        )
 
     def __repr__(self):
         return "TopologyAtom {} with reference atom {} and parent TopologyMolecule {}".format(
-            self.topology_atom_index, self._atom, self._topology_molecule)
+            self.topology_atom_index, self._atom, self._topology_molecule
+        )
 
     def to_dict(self):
         """Convert to dictionary representation."""
@@ -278,8 +294,8 @@ class TopologyAtom(Serializable):
         # Implement abstract method Serializable.to_dict()
         raise NotImplementedError()  # TODO
 
-    #@property
-    #def bonds(self):
+    # @property
+    # def bonds(self):
     #    """
     #    Get the Bonds connected to this TopologyAtom.
     #
@@ -293,9 +309,9 @@ class TopologyAtom(Serializable):
     # TODO: Add all atom properties here? Or just make people use TopologyAtom.atom for that?
 
 
-#=============================================================================================
+# =============================================================================================
 # TopologyBond
-#=============================================================================================
+# =============================================================================================
 
 
 class TopologyBond(Serializable):
@@ -358,7 +374,10 @@ class TopologyBond(Serializable):
         int
             The index of this bond in its parent topology.
         """
-        return self._topology_molecule.bond_start_topology_index + self._bond.molecule_bond_index
+        return (
+            self._topology_molecule.bond_start_topology_index
+            + self._bond.molecule_bond_index
+        )
 
     @property
     def molecule(self):
@@ -406,9 +425,9 @@ class TopologyBond(Serializable):
         raise NotImplementedError()  # TODO
 
 
-#=============================================================================================
+# =============================================================================================
 # TopologyVirtualSite
-#=============================================================================================
+# =============================================================================================
 
 
 class TopologyVirtualSite(Serializable):
@@ -453,8 +472,7 @@ class TopologyVirtualSite(Serializable):
         TopologyAtom
 
         """
-        return TopologyAtom(self._virtual_site.atoms[index],
-                            self.topology_molecule)
+        return TopologyAtom(self._virtual_site.atoms[index], self.topology_molecule)
 
     @property
     def atoms(self):
@@ -500,7 +518,10 @@ class TopologyVirtualSite(Serializable):
         int
             The index of this virtual site in its parent topology.
         """
-        return self._topology_molecule.virtual_site_start_topology_index + self._virtual_site.molecule_virtual_site_index
+        return (
+            self._topology_molecule.virtual_site_start_topology_index
+            + self._virtual_site.molecule_virtual_site_index
+        )
 
     @property
     def topology_particle_index(self):
@@ -541,8 +562,9 @@ class TopologyVirtualSite(Serializable):
         return self._virtual_site.type
 
     def __eq__(self, other):
-        return ((self._virtual_site == other._virtual_site)
-                and (self._topology_molecule == other._topology_molecule))
+        return (self._virtual_site == other._virtual_site) and (
+            self._topology_molecule == other._topology_molecule
+        )
 
     def to_dict(self):
         """Convert to dictionary representation."""
@@ -570,10 +592,9 @@ class TopologyMolecule:
 
     """
 
-    def __init__(self,
-                 reference_molecule,
-                 topology,
-                 local_topology_to_reference_index=None):
+    def __init__(
+        self, reference_molecule, topology, local_topology_to_reference_index=None
+    ):
         """
         Create a new TopologyMolecule.
 
@@ -592,23 +613,23 @@ class TopologyMolecule:
         self._topology = topology
         if local_topology_to_reference_index is None:
             local_topology_to_reference_index = dict(
-                [(i, i) for i in range(reference_molecule.n_atoms)])
+                [(i, i) for i in range(reference_molecule.n_atoms)]
+            )
         self._top_to_ref_index = local_topology_to_reference_index
         self._ref_to_top_index = dict(
-            (k, j) for j, k in local_topology_to_reference_index.items())
+            (k, j) for j, k in local_topology_to_reference_index.items()
+        )
 
         # Initialize cached data
         self._atom_start_topology_index = None
         self._bond_start_topology_index = None
         self._virtual_site_start_topology_index = None
 
-
     def _invalidate_cached_data(self):
         """Unset all cached data, in response to an appropriate change"""
         self._atom_start_topology_index = None
         self._bond_start_topology_index = None
         self._virtual_site_start_topology_index = None
-
 
     @property
     def topology(self):
@@ -657,8 +678,7 @@ class TopologyMolecule:
         an openforcefield.topology.TopologyAtom
         """
         ref_mol_atom_index = self._top_to_ref_index[index]
-        return TopologyAtom(self._reference_molecule.atoms[ref_mol_atom_index],
-                            self)
+        return TopologyAtom(self._reference_molecule.atoms[ref_mol_atom_index], self)
 
     @property
     def atoms(self):
@@ -673,7 +693,7 @@ class TopologyMolecule:
         # Sort by topology index
         iterate_order.sort(key=lambda x: x[0])
         for top_index, ref_index in iterate_order:
-            #self._reference_molecule.atoms:
+            # self._reference_molecule.atoms:
             yield TopologyAtom(self._reference_molecule.atoms[ref_index], self)
 
     @property
@@ -794,7 +814,6 @@ class TopologyMolecule:
         """
         return self._reference_molecule.n_particles
 
-
     def virtual_site(self, index):
         """
         Get the TopologyVirtualSite with a given reference molecule index in this TopologyMolecule
@@ -808,8 +827,7 @@ class TopologyMolecule:
         -------
         an openforcefield.topology.TopologyVirtualSite
         """
-        return TopologyVirtualSite(
-            self.reference_molecule.virtual_sites[index], self)
+        return TopologyVirtualSite(self.reference_molecule.virtual_sites[index], self)
 
     @property
     def virtual_sites(self):
@@ -872,7 +890,9 @@ class TopologyMolecule:
             virtual_site_start_topology_index = 0
             for topology_molecule in self._topology.topology_molecules:
                 if self == topology_molecule:
-                    self._virtual_site_start_topology_index = virtual_site_start_topology_index
+                    self._virtual_site_start_topology_index = (
+                        virtual_site_start_topology_index
+                    )
                 virtual_site_start_topology_index += topology_molecule.n_virtual_sites
         # Return cached value
         return self._virtual_site_start_topology_index
@@ -891,7 +911,9 @@ class TopologyMolecule:
     def _convert_to_topology_atom_tuples(self, molecule_atom_tuples):
         for atom_tuple in molecule_atom_tuples:
             mol_atom_indices = (a.molecule_atom_index for a in atom_tuple)
-            top_mol_atom_indices = (self._ref_to_top_index[mol_idx] for mol_idx in mol_atom_indices)
+            top_mol_atom_indices = (
+                self._ref_to_top_index[mol_idx] for mol_idx in mol_atom_indices
+            )
             yield tuple(self.atom(i) for i in top_mol_atom_indices)
 
 
@@ -963,8 +985,8 @@ class Topology(Serializable):
         # Assign cheminformatics models
         model = DEFAULT_AROMATICITY_MODEL
         self._aromaticity_model = model
-        #self._fractional_bond_order_model = DEFAULT_FRACTIONAL_BOND_ORDER_MODEL
-        #self._charge_model = DEFAULT_CHARGE_MODEL
+        # self._fractional_bond_order_model = DEFAULT_FRACTIONAL_BOND_ORDER_MODEL
+        # self._charge_model = DEFAULT_CHARGE_MODEL
 
         # Initialize storage
         self._initialize()
@@ -984,8 +1006,8 @@ class Topology(Serializable):
         self._aromaticity_model = DEFAULT_AROMATICITY_MODEL
         self._constrained_atom_pairs = dict()
         self._box_vectors = None
-        #self._is_periodic = False
-        #self._reference_molecule_dicts = set()
+        # self._is_periodic = False
+        # self._reference_molecule_dicts = set()
         # TODO: Look into weakref and what it does. Having multiple topologies might cause a memory leak.
         self._reference_molecule_to_topology_molecules = OrderedDict()
         self._topology_molecules = list()
@@ -1045,12 +1067,12 @@ class Topology(Serializable):
             atom1 = self.atom(atom1)
             atom2 = self.atom(atom2)
 
-        #else:
+        # else:
         if not (self.is_bonded(atom1, atom2)):
             # TODO: Raise more specific exception.
             raise Exception(
-                'Atoms {} and {} are not bonded in topology'.format(
-                    atom1, atom2))
+                "Atoms {} and {} are not bonded in topology".format(atom1, atom2)
+            )
 
     @property
     def aromaticity_model(self):
@@ -1077,7 +1099,8 @@ class Topology(Serializable):
 
         if not aromaticity_model in ALLOWED_AROMATICITY_MODELS:
             msg = "Aromaticity model must be one of {}; specified '{}'".format(
-                ALLOWED_AROMATICITY_MODELS, aromaticity_model)
+                ALLOWED_AROMATICITY_MODELS, aromaticity_model
+            )
             raise ValueError(msg)
         self._aromaticity_model = aromaticity_model
 
@@ -1105,15 +1128,15 @@ class Topology(Serializable):
         if box_vectors is None:
             self._box_vectors = None
             return
-        if not hasattr(box_vectors, 'unit'):
+        if not hasattr(box_vectors, "unit"):
             raise ValueError("Given unitless box vectors")
         if not (unit.angstrom.is_compatible(box_vectors.unit)):
             raise ValueError(
                 "Attempting to set box vectors in units that are incompatible with simtk.unit.Angstrom"
             )
 
-        if hasattr(box_vectors, 'shape'):
-            assert box_vectors.shape == (3, )
+        if hasattr(box_vectors, "shape"):
+            assert box_vectors.shape == (3,)
         else:
             assert len(box_vectors) == 3
         self._box_vectors = box_vectors
@@ -1146,7 +1169,9 @@ class Topology(Serializable):
         if not charge_model in ALLOWED_CHARGE_MODELS:
             raise ValueError(
                 "Charge model must be one of {}; specified '{}'".format(
-                    ALLOWED_CHARGE_MODELS, charge_model))
+                    ALLOWED_CHARGE_MODELS, charge_model
+                )
+            )
         self._charge_model = charge_model
 
     @property
@@ -1186,9 +1211,10 @@ class Topology(Serializable):
         """
         if not fractional_bond_order_model in ALLOWED_FRACTIONAL_BOND_ORDER_MODELS:
             raise ValueError(
-                "Fractional bond order model must be one of {}; specified '{}'"
-                .format(ALLOWED_FRACTIONAL_BOND_ORDER_MODELS,
-                        fractional_bond_order_model))
+                "Fractional bond order model must be one of {}; specified '{}'".format(
+                    ALLOWED_FRACTIONAL_BOND_ORDER_MODELS, fractional_bond_order_model
+                )
+            )
         self._fractional_bond_order_model = fractional_bond_order_model
 
     @property
@@ -1239,8 +1265,8 @@ class Topology(Serializable):
         for reference_molecule in self.reference_molecules:
             n_atoms_per_topology_molecule = reference_molecule.n_atoms
             n_instances_of_topology_molecule = len(
-                self.
-                _reference_molecule_to_topology_molecules[reference_molecule])
+                self._reference_molecule_to_topology_molecules[reference_molecule]
+            )
             n_atoms += n_atoms_per_topology_molecule * n_instances_of_topology_molecule
         return n_atoms
 
@@ -1270,8 +1296,8 @@ class Topology(Serializable):
         for reference_molecule in self.reference_molecules:
             n_bonds_per_topology_molecule = reference_molecule.n_bonds
             n_instances_of_topology_molecule = len(
-                self.
-                _reference_molecule_to_topology_molecules[reference_molecule])
+                self._reference_molecule_to_topology_molecules[reference_molecule]
+            )
             n_bonds += n_bonds_per_topology_molecule * n_instances_of_topology_molecule
         return n_bonds
 
@@ -1300,9 +1326,11 @@ class Topology(Serializable):
         for reference_molecule in self.reference_molecules:
             n_particles_per_topology_molecule = reference_molecule.n_particles
             n_instances_of_topology_molecule = len(
-                self.
-                _reference_molecule_to_topology_molecules[reference_molecule])
-            n_particles += n_particles_per_topology_molecule * n_instances_of_topology_molecule
+                self._reference_molecule_to_topology_molecules[reference_molecule]
+            )
+            n_particles += (
+                n_particles_per_topology_molecule * n_instances_of_topology_molecule
+            )
         return n_particles
 
     @property
@@ -1322,7 +1350,6 @@ class Topology(Serializable):
             for vs in topology_molecule.virtual_sites:
                 yield vs
 
-
     @property
     def n_topology_virtual_sites(self):
         """
@@ -1336,9 +1363,11 @@ class Topology(Serializable):
         for reference_molecule in self.reference_molecules:
             n_virtual_sites_per_topology_molecule = reference_molecule.n_virtual_sites
             n_instances_of_topology_molecule = len(
-                self.
-                _reference_molecule_to_topology_molecules[reference_molecule])
-            n_virtual_sites += n_virtual_sites_per_topology_molecule * n_instances_of_topology_molecule
+                self._reference_molecule_to_topology_molecules[reference_molecule]
+            )
+            n_virtual_sites += (
+                n_virtual_sites_per_topology_molecule * n_instances_of_topology_molecule
+            )
         return n_virtual_sites
 
     @property
@@ -1410,7 +1439,9 @@ class Topology(Serializable):
             """tuple of int: The matched topology atom indices."""
             return self._topology_atom_indices
 
-        def __init__(self, reference_atom_indices, reference_molecule, topology_atom_indices):
+        def __init__(
+            self, reference_atom_indices, reference_molecule, topology_atom_indices
+        ):
             """Constructs a new _ChemicalEnvironmentMatch object
 
             Parameters
@@ -1430,10 +1461,9 @@ class Topology(Serializable):
 
             self._topology_atom_indices = topology_atom_indices
 
-    def chemical_environment_matches(self,
-                                     query,
-                                     aromaticity_model='MDL',
-                                     toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def chemical_environment_matches(
+        self, query, aromaticity_model="MDL", toolkit_registry=GLOBAL_TOOLKIT_REGISTRY
+    ):
         """
         Retrieve all matches for a given chemical environment query.
 
@@ -1463,7 +1493,9 @@ class Topology(Serializable):
         elif type(query) is ChemicalEnvironment:
             smarts = query.as_smarts()
         else:
-            raise ValueError(f"Don't know how to convert query '{query}' into SMARTS string")
+            raise ValueError(
+                f"Don't know how to convert query '{query}' into SMARTS string"
+            )
 
         # Perform matching on each unique molecule, unrolling the matches to all matching copies
         # of that molecule in the Topology object.
@@ -1474,13 +1506,17 @@ class Topology(Serializable):
             # Find all atomsets that match this definition in the reference molecule
             # This will automatically attempt to match chemically identical atoms in
             # a canonical order within the Topology
-            ref_mol_matches = ref_mol.chemical_environment_matches(smarts, toolkit_registry=toolkit_registry)
+            ref_mol_matches = ref_mol.chemical_environment_matches(
+                smarts, toolkit_registry=toolkit_registry
+            )
 
             if len(ref_mol_matches) == 0:
                 continue
 
             # Unroll corresponding atom indices over all instances of this molecule.
-            for topology_molecule in self._reference_molecule_to_topology_molecules[ref_mol]:
+            for topology_molecule in self._reference_molecule_to_topology_molecules[
+                ref_mol
+            ]:
 
                 # topology_molecule_start_index = topology_molecule.atom_start_topology_index
 
@@ -1490,14 +1526,17 @@ class Topology(Serializable):
                     # Collect indices of matching TopologyAtoms.
                     topology_atom_indices = []
                     for reference_molecule_atom_index in reference_match:
-                        reference_atom = topology_molecule.reference_molecule.atoms[reference_molecule_atom_index]
+                        reference_atom = topology_molecule.reference_molecule.atoms[
+                            reference_molecule_atom_index
+                        ]
                         topology_atom = TopologyAtom(reference_atom, topology_molecule)
-                        topology_atom_indices.append(topology_atom.topology_particle_index)
+                        topology_atom_indices.append(
+                            topology_atom.topology_particle_index
+                        )
 
                     environment_match = Topology._ChemicalEnvironmentMatch(
-                        tuple(reference_match),
-                        ref_mol,
-                        tuple(topology_atom_indices))
+                        tuple(reference_match), ref_mol, tuple(topology_atom_indices)
+                    )
 
                     matches.append(environment_match)
         return matches
@@ -1536,7 +1575,7 @@ class Topology(Serializable):
         # Make a flat list of all atomic numbers in the molecule
         atom_nums = []
         for idx in mol_graph.nodes:
-            atom_nums.append(mol_graph.nodes[idx]['atomic_number'])
+            atom_nums.append(mol_graph.nodes[idx]["atomic_number"])
 
         # Count the number of instances of each atomic number
         at_num_to_counts = dict([(unq, atom_nums.count(unq)) for unq in atom_nums])
@@ -1544,24 +1583,25 @@ class Topology(Serializable):
         symbol_to_counts = {}
         # Check for C and H first, to make a correct hill formula (remember dicts in python 3.6+ are ordered)
         if 6 in at_num_to_counts:
-            symbol_to_counts['C'] = at_num_to_counts[6]
+            symbol_to_counts["C"] = at_num_to_counts[6]
             del at_num_to_counts[6]
 
         if 1 in at_num_to_counts:
-            symbol_to_counts['H'] = at_num_to_counts[1]
+            symbol_to_counts["H"] = at_num_to_counts[1]
             del at_num_to_counts[1]
 
         # Now count instances of all elements other than C and H, in order of ascending atomic number
         sorted_atom_nums = sorted(at_num_to_counts.keys())
         for atom_num in sorted_atom_nums:
-            symbol_to_counts[Element.getByAtomicNumber(atom_num).symbol] = at_num_to_counts[atom_num]
+            symbol_to_counts[
+                Element.getByAtomicNumber(atom_num).symbol
+            ] = at_num_to_counts[atom_num]
 
         # Finally format the formula as string
-        formula = ''
+        formula = ""
         for ele, count in symbol_to_counts.items():
-            formula += f'{ele}{count}'
-        return(formula)
-
+            formula += f"{ele}{count}"
+        return formula
 
     @classmethod
     def from_openmm(cls, openmm_topology, unique_molecules=None):
@@ -1600,16 +1640,22 @@ class Topology(Serializable):
         for unq_mol in unique_molecules:
             unq_mol_graph = unq_mol.to_networkx()
             for existing_graph in graph_to_unq_mol.keys():
-                if Molecule.are_isomorphic(existing_graph,
-                                           unq_mol_graph,
-                                           return_atom_map=False,
-                                           aromatic_matching=False,
-                                           formal_charge_matching=False,
-                                           bond_order_matching=omm_has_bond_orders,
-                                           atom_stereochemistry_matching=False,
-                                           bond_stereochemistry_matching=False)[0]:
-                    msg = "Error: Two unique molecules have indistinguishable " \
-                          "graphs: {} and {}".format(unq_mol, graph_to_unq_mol[existing_graph])
+                if Molecule.are_isomorphic(
+                    existing_graph,
+                    unq_mol_graph,
+                    return_atom_map=False,
+                    aromatic_matching=False,
+                    formal_charge_matching=False,
+                    bond_order_matching=omm_has_bond_orders,
+                    atom_stereochemistry_matching=False,
+                    bond_stereochemistry_matching=False,
+                )[0]:
+                    msg = (
+                        "Error: Two unique molecules have indistinguishable "
+                        "graphs: {} and {}".format(
+                            unq_mol, graph_to_unq_mol[existing_graph]
+                        )
+                    )
                     raise DuplicateUniqueMoleculeError(msg)
             graph_to_unq_mol[unq_mol_graph] = unq_mol
 
@@ -1617,46 +1663,64 @@ class Topology(Serializable):
         omm_topology_G = nx.Graph()
         for atom in openmm_topology.atoms():
             omm_topology_G.add_node(
-                atom.index, atomic_number=atom.element.atomic_number)
+                atom.index, atomic_number=atom.element.atomic_number
+            )
         for bond in openmm_topology.bonds():
             omm_topology_G.add_edge(
-                bond.atom1.index, bond.atom2.index, bond_order=bond.order)
+                bond.atom1.index, bond.atom2.index, bond_order=bond.order
+            )
 
         # For each connected subgraph (molecule) in the topology, find its match in unique_molecules
         topology_molecules_to_add = list()
-        for omm_mol_G in (omm_topology_G.subgraph(c).copy()
-                          for c in nx.connected_components(omm_topology_G)):
+        for omm_mol_G in (
+            omm_topology_G.subgraph(c).copy()
+            for c in nx.connected_components(omm_topology_G)
+        ):
             match_found = False
             for unq_mol_G in graph_to_unq_mol.keys():
-                isomorphic, mapping = Molecule.are_isomorphic(omm_mol_G,
-                                                              unq_mol_G,
-                                                              return_atom_map=True,
-                                                              aromatic_matching=False,
-                                                              formal_charge_matching=False,
-                                                              bond_order_matching=omm_has_bond_orders,
-                                                              atom_stereochemistry_matching=False,
-                                                              bond_stereochemistry_matching=False)
+                isomorphic, mapping = Molecule.are_isomorphic(
+                    omm_mol_G,
+                    unq_mol_G,
+                    return_atom_map=True,
+                    aromatic_matching=False,
+                    formal_charge_matching=False,
+                    bond_order_matching=omm_has_bond_orders,
+                    atom_stereochemistry_matching=False,
+                    bond_stereochemistry_matching=False,
+                )
                 if isomorphic:
                     # Take the first valid atom indexing map
                     first_topology_atom_index = min(mapping.keys())
                     topology_molecules_to_add.append(
-                        (first_topology_atom_index, unq_mol_G,
-                         mapping.items()))
+                        (first_topology_atom_index, unq_mol_G, mapping.items())
+                    )
                     match_found = True
                     break
             if match_found is False:
                 hill_formula = Molecule.to_hill_formula(omm_mol_G)
-                msg = f'No match found for molecule {hill_formula}. '
-                probably_missing_conect = ['C', 'H', 'O', 'N', 'P', 'S', 'F', 'Cl', 'Br']
+                msg = f"No match found for molecule {hill_formula}. "
+                probably_missing_conect = [
+                    "C",
+                    "H",
+                    "O",
+                    "N",
+                    "P",
+                    "S",
+                    "F",
+                    "Cl",
+                    "Br",
+                ]
                 if hill_formula in probably_missing_conect:
-                    msg += ('This would be a very unusual molecule to try and parameterize, '
-                            'and it is likely that the data source it was read from does not '
-                            'contain connectivity information. If this molecule is coming from '
-                            'PDB, please ensure that the file contains CONECT records. The PDB '
-                            'format documentation (https://www.wwpdb.org/documentation/'
-                            'file-format-content/format33/sect10.html) states "CONECT records '
-                            'are mandatory for HET groups (excluding water) and for other bonds '
-                            'not specified in the standard residue connectivity table."')
+                    msg += (
+                        "This would be a very unusual molecule to try and parameterize, "
+                        "and it is likely that the data source it was read from does not "
+                        "contain connectivity information. If this molecule is coming from "
+                        "PDB, please ensure that the file contains CONECT records. The PDB "
+                        "format documentation (https://www.wwpdb.org/documentation/"
+                        'file-format-content/format33/sect10.html) states "CONECT records '
+                        "are mandatory for HET groups (excluding water) and for other bonds "
+                        'not specified in the standard residue connectivity table."'
+                    )
                 raise ValueError(msg)
 
         # The connected_component_subgraph function above may have scrambled the molecule order, so sort molecules
@@ -1664,11 +1728,15 @@ class Topology(Serializable):
         topology_molecules_to_add.sort(key=lambda x: x[0])
         for first_index, unq_mol_G, top_to_ref_index in topology_molecules_to_add:
             local_top_to_ref_index = dict(
-                [(top_index - first_index, ref_index)
-                 for top_index, ref_index in top_to_ref_index])
+                [
+                    (top_index - first_index, ref_index)
+                    for top_index, ref_index in top_to_ref_index
+                ]
+            )
             topology.add_molecule(
                 graph_to_unq_mol[unq_mol_G],
-                local_topology_to_reference_index=local_top_to_ref_index)
+                local_topology_to_reference_index=local_top_to_ref_index,
+            )
 
         topology.box_vectors = openmm_topology.getPeriodicBoxVectors()
         # TODO: How can we preserve metadata from the openMM topology when creating the OFF topology?
@@ -1699,7 +1767,6 @@ class Topology(Serializable):
         from simtk.openmm.app import Single, Double, Triple, Aromatic
         from simtk.openmm.app.element import Element as OMMElement
 
-
         omm_topology = OMMTopology()
 
         # Create unique atom names
@@ -1720,7 +1787,9 @@ class Topology(Serializable):
         for topology_molecule in self.topology_molecules:
             for atom in topology_molecule.atoms:
                 reference_molecule = topology_molecule.reference_molecule
-                n_molecules = len(self._reference_molecule_to_topology_molecules[reference_molecule])
+                n_molecules = len(
+                    self._reference_molecule_to_topology_molecules[reference_molecule]
+                )
 
                 # Add 1 chain per molecule unless there are more than 5 copies,
                 # in which case we add a single chain for all of them.
@@ -1750,21 +1819,23 @@ class Topology(Serializable):
                 omm_atom = omm_topology.addAtom(atom.atom.name, element, residue)
 
                 # Make sure that OpenFF and OpenMM Topology atoms have the same indices.
-                assert atom.topology_atom_index == int(omm_atom.id)-1
+                assert atom.topology_atom_index == int(omm_atom.id) - 1
                 omm_atoms.append(omm_atom)
 
         # Add all bonds.
-        bond_types = {
-            1: Single,
-            2: Double,
-            3: Triple
-        }
+        bond_types = {1: Single, 2: Double, 3: Triple}
         for bond in self.topology_bonds:
             atom1, atom2 = bond.atoms
             atom1_idx, atom2_idx = atom1.topology_atom_index, atom2.topology_atom_index
-            bond_type = Aromatic if bond.bond.is_aromatic else bond_types[bond.bond_order]
-            omm_topology.addBond(omm_atoms[atom1_idx], omm_atoms[atom2_idx],
-                                 type=bond_type, order=bond.bond_order)
+            bond_type = (
+                Aromatic if bond.bond.is_aromatic else bond_types[bond.bond_order]
+            )
+            omm_topology.addBond(
+                omm_atoms[atom1_idx],
+                omm_atoms[atom2_idx],
+                type=bond_type,
+                order=bond.bond_order,
+            )
 
         if self.box_vectors is not None:
             omm_topology.setPeriodicBoxVectors(self.box_vectors)
@@ -1793,7 +1864,8 @@ class Topology(Serializable):
             An openforcefield Topology object
         """
         return Topology.from_openmm(
-            mdtraj_topology.to_openmm(), unique_molecules=unique_molecules)
+            mdtraj_topology.to_openmm(), unique_molecules=unique_molecules
+        )
 
     # TODO: Jeff prepended an underscore on this before 0.2.0 release to remove it from the API.
     #       Before exposing this, we should look carefully at the information that is preserved/lost during this
@@ -1811,6 +1883,7 @@ class Topology(Serializable):
             An MDTraj Topology object
         # """
         import mdtraj as md
+
         return md.Topology.from_openmm(self.to_openmm())
 
     @staticmethod
@@ -1839,6 +1912,7 @@ class Topology(Serializable):
             An openforcefield Topology object
         """
         import parmed
+
         # TODO: Implement functionality
         raise NotImplementedError
 
@@ -1855,6 +1929,7 @@ class Topology(Serializable):
             A ParmEd Structure objecft
         """
         import parmed
+
         # TODO: Implement functionality
         raise NotImplementedError
 
@@ -1885,8 +1960,11 @@ class Topology(Serializable):
         # TODO: Convert this to cls.from_molecules(Molecule.from_openeye())?
         # OE Hierarchical molecule view
         hv = oechem.OEHierView(
-            oemol, oechem.OEAssumption_BondedResidue +
-            oechem.OEAssumption_ResPerceived + oechem.OEAssumption_PDBOrder)
+            oemol,
+            oechem.OEAssumption_BondedResidue
+            + oechem.OEAssumption_ResPerceived
+            + oechem.OEAssumption_PDBOrder,
+        )
 
         # Create empty OpenMM Topology
         topology = app.Topology()
@@ -1906,16 +1984,17 @@ class Topology(Serializable):
                     # Get OE residue
                     oe_res = hres.GetOEResidue()
                     # Create OpenMM residue
-                    openmm_res = topology.addResidue(oe_res.GetName(),
-                                                     openmm_chain)
+                    openmm_res = topology.addResidue(oe_res.GetName(), openmm_chain)
 
                     for oe_at in hres.GetAtoms():
                         # Select atom element based on the atomic number
                         element = app.element.Element.getByAtomicNumber(
-                            oe_at.GetAtomicNum())
+                            oe_at.GetAtomicNum()
+                        )
                         # Add atom OpenMM atom to the topology
-                        openmm_at = topology.addAtom(oe_at.GetName(), element,
-                                                     openmm_res)
+                        openmm_at = topology.addAtom(
+                            oe_at.GetName(), element, openmm_res
+                        )
                         openmm_at.index = oe_at.GetIdx()
                         # Add atom to the mapping dictionary
                         oe_atom_to_openmm_at[oe_at] = openmm_at
@@ -1923,8 +2002,10 @@ class Topology(Serializable):
         if topology.getNumAtoms() != mol.NumAtoms():
             oechem.OEThrow.Error(
                 "OpenMM topology and OEMol number of atoms mismatching: "
-                "OpenMM = {} vs OEMol  = {}".format(topology.getNumAtoms(),
-                                                    mol.NumAtoms()))
+                "OpenMM = {} vs OEMol  = {}".format(
+                    topology.getNumAtoms(), mol.NumAtoms()
+                )
+            )
 
         # Count the number of bonds in the openmm topology
         omm_bond_count = 0
@@ -1947,8 +2028,11 @@ class Topology(Serializable):
             atomE = oe_bond.GetEnd()
 
             # The amide bond is made by Carbon and Nitrogen atoms
-            if not (atomB.IsCarbon() and atomE.IsNitrogen() or
-                    (atomB.IsNitrogen() and atomE.IsCarbon())):
+            if not (
+                atomB.IsCarbon()
+                and atomE.IsNitrogen()
+                or (atomB.IsNitrogen() and atomE.IsCarbon())
+            ):
                 return False
 
             # Select Carbon and Nitrogen atoms
@@ -1968,15 +2052,17 @@ class Topology(Serializable):
 
             for bond in C_atom.GetBonds():
                 # The C-O bond can be single or double.
-                if (bond.GetBgn() == C_atom and bond.GetEnd().IsOxygen()) or \
-                        (bond.GetBgn().IsOxygen() and bond.GetEnd() == C_atom):
+                if (bond.GetBgn() == C_atom and bond.GetEnd().IsOxygen()) or (
+                    bond.GetBgn().IsOxygen() and bond.GetEnd() == C_atom
+                ):
                     if bond.GetOrder() == 2:
                         double_bonds += 1
                     if bond.GetOrder() == 1:
                         single_bonds += 1
                 # The CA-C bond is single
-                if (bond.GetBgn() == C_atom and bond.GetEnd().IsCarbon()) or \
-                        (bond.GetBgn().IsCarbon() and bond.GetEnd() == C_atom):
+                if (bond.GetBgn() == C_atom and bond.GetEnd().IsCarbon()) or (
+                    bond.GetBgn().IsCarbon() and bond.GetEnd() == C_atom
+                ):
                     if bond.GetOrder() == 1:
                         single_bonds += 1
             # Just one double and one single bonds are connected to C
@@ -1991,7 +2077,11 @@ class Topology(Serializable):
             # Set the bond type
             if oe_bond.GetType() is not "":
                 if oe_bond.GetType() in [
-                        'Single', 'Double', 'Triple', 'Aromatic', 'Amide'
+                    "Single",
+                    "Double",
+                    "Triple",
+                    "Aromatic",
+                    "Amide",
                 ]:
                     off_bondtype = oe_bond.GetType()
                 else:
@@ -2019,17 +2109,17 @@ class Topology(Serializable):
                 oe_atom_to_openmm_at[oe_bond.GetBgn()],
                 oe_atom_to_openmm_at[oe_bond.GetEnd()],
                 type=off_bondtype,
-                order=oe_bond.GetOrder())
+                order=oe_bond.GetOrder(),
+            )
 
         if molecule.n_bondsphe != mol.NumBonds():
             oechem.OEThrow.Error(
                 "OpenMM topology and OEMol number of bonds mismatching: "
-                "OpenMM = {} vs OEMol  = {}".format(omm_bond_count,
-                                                    mol.NumBonds()))
+                "OpenMM = {} vs OEMol  = {}".format(omm_bond_count, mol.NumBonds())
+            )
 
         dic = mol.GetCoords()
-        positions = [Vec3(v[0], v[1], v[2])
-                     for k, v in dic.items()] * unit.angstrom
+        positions = [Vec3(v[0], v[1], v[2]) for k, v in dic.items()] * unit.angstrom
 
         return topology, positions
 
@@ -2039,9 +2129,7 @@ class Topology(Serializable):
     #       It also expects Topology to be organized by chain, which is not currently the case.
     #       Bringing this function back would require non-trivial engineering and testing, and we
     #       would want to discuss what "guarantee" of correctness it could offer.
-    def _to_openeye(self,
-                   positions=None,
-                   aromaticity_model=DEFAULT_AROMATICITY_MODEL):
+    def _to_openeye(self, positions=None, aromaticity_model=DEFAULT_AROMATICITY_MODEL):
         """
         Create an OpenEye OEMol from the topology
 
@@ -2098,14 +2186,15 @@ class Topology(Serializable):
             raise Exception(
                 "OEMol has an unexpected number of atoms: "
                 "Molecule has {} atoms, while OEMol has {} atoms".format(
-                    topology.n_atom, oe_mol.NumAtoms()))
+                    topology.n_atom, oe_mol.NumAtoms()
+                )
+            )
 
         # Create bonds
         for off_bond in self.topology_bonds():
-            oe_mol.NewBond(oe_atoms[bond.atom1], oe_atoms[bond.atom2],
-                           bond.bond_order)
+            oe_mol.NewBond(oe_atoms[bond.atom1], oe_atoms[bond.atom2], bond.bond_order)
             if off_bond.type:
-                if off_bond.type == 'Aromatic':
+                if off_bond.type == "Aromatic":
                     oe_atom0.SetAromatic(True)
                     oe_atom1.SetAromatic(True)
                     oe_bond.SetAromatic(True)
@@ -2119,7 +2208,9 @@ class Topology(Serializable):
             oechem.OEThrow.Erorr(
                 "OEMol has an unexpected number of bonds:: "
                 "Molecule has {} bonds, while OEMol has {} bonds".format(
-                    self.n_bond, oe_mol.NumBonds()))
+                    self.n_bond, oe_mol.NumBonds()
+                )
+            )
 
         if positions is not None:
             # Set the OEMol positions
@@ -2156,7 +2247,8 @@ class Topology(Serializable):
         else:
             raise Exception(
                 "Invalid input passed to is_bonded(). Expected ints or TopologyAtoms, "
-                "got {} and {}".format(i, j))
+                "got {} and {}".format(i, j)
+            )
 
         for top_bond in atomi.topology_bonds:
             for top_atom in top_bond.atoms:
@@ -2165,8 +2257,7 @@ class Topology(Serializable):
                 if top_atom == atomj:
                     return top_bond
 
-        raise NotBondedError('No bond between atom {} and {}'.format(i, j))
-
+        raise NotBondedError("No bond between atom {} and {}".format(i, j))
 
     def is_bonded(self, i, j):
         """Returns True if the two atoms are bonded
@@ -2305,7 +2396,9 @@ class Topology(Serializable):
         from openforcefield.topology.molecule import Molecule, FrozenMolecule
 
         if local_topology_to_reference_index is None:
-            local_topology_to_reference_index = dict((i, i) for i in range(molecule.n_atoms))
+            local_topology_to_reference_index = dict(
+                (i, i) for i in range(molecule.n_atoms)
+            )
 
         mol_smiles = molecule.to_smiles()
         reference_molecule = None
@@ -2317,26 +2410,29 @@ class Topology(Serializable):
 
                 # Graph-match this molecule to see if it's in the same order
                 # Default settings use full matching
-                _, atom_map = Molecule.are_isomorphic(molecule, reference_molecule, return_atom_map=True)
+                _, atom_map = Molecule.are_isomorphic(
+                    molecule, reference_molecule, return_atom_map=True
+                )
                 if atom_map is None:
                     raise Exception(1)
                 new_mapping = {}
                 for local_top_idx, ref_idx in local_topology_to_reference_index.items():
                     new_mapping[local_top_idx] = atom_map[ref_idx]
                 local_topology_to_reference_index = new_mapping
-                #raise Exception(local_topology_to_reference_index)
+                # raise Exception(local_topology_to_reference_index)
                 break
         if reference_molecule is None:
             # If it's a new unique molecule, make and store an immutable copy of it
             reference_molecule = FrozenMolecule(molecule)
-            self._reference_molecule_to_topology_molecules[
-                reference_molecule] = list()
+            self._reference_molecule_to_topology_molecules[reference_molecule] = list()
 
         topology_molecule = TopologyMolecule(
-            reference_molecule, self, local_topology_to_reference_index)
+            reference_molecule, self, local_topology_to_reference_index
+        )
         self._topology_molecules.append(topology_molecule)
-        self._reference_molecule_to_topology_molecules[
-            reference_molecule].append(self._topology_molecules[-1])
+        self._reference_molecule_to_topology_molecules[reference_molecule].append(
+            self._topology_molecules[-1]
+        )
 
         index = len(self._topology_molecules) - 1
         return index
@@ -2362,9 +2458,13 @@ class Topology(Serializable):
         if (iatom, jatom) in self._constrained_atom_pairs:
             existing_distance = self._constrained_atom_pairs[(iatom, jatom)]
             if unit.is_quantity(existing_distance) and (distance is True):
-                raise Exception(f"Atoms ({iatom},{jatom}) already constrained with distance {existing_distance} but attempting to override with unspecified distance")
+                raise Exception(
+                    f"Atoms ({iatom},{jatom}) already constrained with distance {existing_distance} but attempting to override with unspecified distance"
+                )
             if (existing_distance is True) and (distance is True):
-                raise Exception(f"Atoms ({iatom},{jatom}) already constrained with unspecified distance but attempting to override with unspecified distance")
+                raise Exception(
+                    f"Atoms ({iatom},{jatom}) already constrained with unspecified distance but attempting to override with unspecified distance"
+                )
             if distance is False:
                 del self._constrained_atom_pairs[(iatom, jatom)]
                 del self._constrained_atom_pairs[(jatom, iatom)]

--- a/openforcefield/typing/chemistry/environment.py
+++ b/openforcefield/typing/chemistry/environment.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#==============================================================================
+# ==============================================================================
 # MODULE DOCSTRING
-#==============================================================================
+# ==============================================================================
 
 """
 environment.py
@@ -19,22 +19,26 @@ and David Mobley, UC Irvine.
 """
 
 __all__ = [
-    'SMIRKSMismatchError',
-    'SMIRKSParsingError',
-    'ChemicalEnvironment',
-    'AtomChemicalEnvironment',
-    'BondChemicalEnvironment',
-    'AngleChemicalEnvironment',
-    'TorsionChemicalEnvironment',
-    'ImproperChemicalEnvironment'
+    "SMIRKSMismatchError",
+    "SMIRKSParsingError",
+    "ChemicalEnvironment",
+    "AtomChemicalEnvironment",
+    "BondChemicalEnvironment",
+    "AngleChemicalEnvironment",
+    "TorsionChemicalEnvironment",
+    "ImproperChemicalEnvironment",
 ]
 
 
-#==============================================================================
+# ==============================================================================
 # GLOBAL IMPORTS
-#==============================================================================
+# ==============================================================================
 
-from openforcefield.utils.toolkits import GLOBAL_TOOLKIT_REGISTRY, ToolkitWrapper, MessageException
+from openforcefield.utils.toolkits import (
+    GLOBAL_TOOLKIT_REGISTRY,
+    ToolkitWrapper,
+    MessageException,
+)
 
 
 class SMIRKSMismatchError(MessageException):
@@ -42,6 +46,7 @@ class SMIRKSMismatchError(MessageException):
     Exception for cases where smirks are inappropriate
     for the environment type they are being parsed into
     """
+
     pass
 
 
@@ -49,6 +54,7 @@ class SMIRKSParsingError(MessageException):
     """
     Exception for when SMIRKS are not parseable for any environment
     """
+
     pass
 
 
@@ -58,8 +64,14 @@ class ChemicalEnvironment:
 
     _expected_type = None
 
-    def __init__(self, smirks=None, label=None, validate_parsable=True, validate_valence_type=True,
-                 toolkit_registry=None):
+    def __init__(
+        self,
+        smirks=None,
+        label=None,
+        validate_parsable=True,
+        validate_valence_type=True,
+        toolkit_registry=None,
+    ):
         """Initialize a chemical environment abstract base class.
 
         smirks = string, optional
@@ -87,17 +99,22 @@ class ChemicalEnvironment:
             and validate_valence_type=True
         """
         # Support string input for toolkit names for legacy reasons
-        if toolkit_registry == 'openeye':
+        if toolkit_registry == "openeye":
             from openforcefield.utils.toolkits import OpenEyeToolkitWrapper
+
             toolkit_registry = OpenEyeToolkitWrapper()
-        elif toolkit_registry == 'rdkit':
+        elif toolkit_registry == "rdkit":
             from openforcefield.utils.toolkits import RDKitToolkitWrapper
+
             toolkit_registry = RDKitToolkitWrapper()
 
         self.smirks = smirks
         self.label = label
         if validate_parsable or validate_valence_type:
-            self.validate(validate_valence_type=validate_valence_type, toolkit_registry=toolkit_registry)
+            self.validate(
+                validate_valence_type=validate_valence_type,
+                toolkit_registry=toolkit_registry,
+            )
 
     def validate(self, validate_valence_type=True, toolkit_registry=None):
         """
@@ -121,12 +138,24 @@ class ChemicalEnvironment:
             and validate_valence_type=True
         """
         perceived_type = self.get_type(toolkit_registry=toolkit_registry)
-        if (perceived_type != self._expected_type) and validate_valence_type and not(self._expected_type is None):
-            raise SMIRKSMismatchError(f"{self.__class__} expected '{self._expected_type}' chemical environment, but "
-                                      f"smirks was set to '{self.smirks}', which is type '{perceived_type}'")
+        if (
+            (perceived_type != self._expected_type)
+            and validate_valence_type
+            and not (self._expected_type is None)
+        ):
+            raise SMIRKSMismatchError(
+                f"{self.__class__} expected '{self._expected_type}' chemical environment, but "
+                f"smirks was set to '{self.smirks}', which is type '{perceived_type}'"
+            )
 
     @classmethod
-    def validate_smirks(cls, smirks, validate_parsable=True, validate_valence_type=True, toolkit_registry=None):
+    def validate_smirks(
+        cls,
+        smirks,
+        validate_parsable=True,
+        validate_valence_type=True,
+        toolkit_registry=None,
+    ):
         """
         Check the provided SMIRKS string is valid, and if requested, tags atoms appropriate to the
         specified valence type.
@@ -153,10 +182,12 @@ class ChemicalEnvironment:
             if smirks did not have expected connectivity between tagged atoms
             and validate_valence_type=True
         """
-        cls(smirks,
+        cls(
+            smirks,
             validate_parsable=validate_parsable,
             validate_valence_type=validate_valence_type,
-            toolkit_registry=toolkit_registry)
+            toolkit_registry=toolkit_registry,
+        )
 
     def get_type(self, toolkit_registry=None):
         """
@@ -184,30 +215,37 @@ class ChemicalEnvironment:
             toolkit_registry = GLOBAL_TOOLKIT_REGISTRY
 
         if isinstance(toolkit_registry, ToolkitWrapper):
-            unique_tags, connectivity = toolkit_registry.get_tagged_smarts_connectivity(self.smirks)
+            unique_tags, connectivity = toolkit_registry.get_tagged_smarts_connectivity(
+                self.smirks
+            )
         else:
-            unique_tags, connectivity = toolkit_registry.call('get_tagged_smarts_connectivity', self.smirks)
+            unique_tags, connectivity = toolkit_registry.call(
+                "get_tagged_smarts_connectivity", self.smirks
+            )
 
         if unique_tags == (1,) and len(connectivity) == 0:
             return "Atom"
         if unique_tags == (1, 2) and (1, 2) in connectivity:
             return "Bond"
-        elif (unique_tags == (1, 2, 3) and
-              (1, 2) in connectivity and
-              (2, 3) in connectivity
-              ):
+        elif (
+            unique_tags == (1, 2, 3)
+            and (1, 2) in connectivity
+            and (2, 3) in connectivity
+        ):
             return "Angle"
-        elif (unique_tags == (1, 2, 3, 4) and
-              (1, 2) in connectivity and
-              (2, 3) in connectivity and
-              (3, 4) in connectivity
-              ):
+        elif (
+            unique_tags == (1, 2, 3, 4)
+            and (1, 2) in connectivity
+            and (2, 3) in connectivity
+            and (3, 4) in connectivity
+        ):
             return "ProperTorsion"
-        elif (unique_tags == (1, 2, 3, 4) and
-              (1, 2) in connectivity and
-              (2, 3) in connectivity and
-              (2, 4) in connectivity
-              ):
+        elif (
+            unique_tags == (1, 2, 3, 4)
+            and (1, 2) in connectivity
+            and (2, 3) in connectivity
+            and (2, 4) in connectivity
+        ):
             return "ImproperTorsion"
         else:
             return None
@@ -216,28 +254,33 @@ class ChemicalEnvironment:
 class AtomChemicalEnvironment(ChemicalEnvironment):
     """Chemical environment matching one labeled atom.
     """
-    _expected_type = 'Atom'
+
+    _expected_type = "Atom"
 
 
 class BondChemicalEnvironment(ChemicalEnvironment):
     """Chemical environment matching two labeled atoms (or a bond).
     """
-    _expected_type = 'Bond'
+
+    _expected_type = "Bond"
 
 
 class AngleChemicalEnvironment(ChemicalEnvironment):
     """Chemical environment matching three marked atoms (angle).
     """
-    _expected_type = 'Angle'
+
+    _expected_type = "Angle"
 
 
 class TorsionChemicalEnvironment(ChemicalEnvironment):
     """Chemical environment matching four marked atoms (torsion).
     """
+
     _expected_type = "ProperTorsion"
 
 
 class ImproperChemicalEnvironment(ChemicalEnvironment):
     """Chemical environment matching four marked atoms (improper).
     """
+
     _expected_type = "ImproperTorsion"

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#=============================================================================================
+# =============================================================================================
 # MODULE DOCSTRING
-#=============================================================================================
+# =============================================================================================
 """
 Parameter assignment tools for the SMIRNOFF (SMIRKS Native Open Force Field) format.
 
@@ -17,19 +17,19 @@ Parameter assignment tools for the SMIRNOFF (SMIRKS Native Open Force Field) for
 """
 
 __all__ = [
-    'get_available_force_fields',
-    'MAX_SUPPORTED_VERSION',
-    'ParameterHandlerRegistrationError',
-    'SMIRNOFFVersionError',
-    'SMIRNOFFAromaticityError',
-    'ParseError',
-    'ForceField',
+    "get_available_force_fields",
+    "MAX_SUPPORTED_VERSION",
+    "ParameterHandlerRegistrationError",
+    "SMIRNOFFVersionError",
+    "SMIRNOFFAromaticityError",
+    "ParseError",
+    "ForceField",
 ]
 
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import copy
 import logging
@@ -40,27 +40,33 @@ from collections import OrderedDict
 
 from simtk import openmm, unit
 
-from openforcefield.utils import all_subclasses, MessageException, \
-    convert_all_quantities_to_string, convert_all_strings_to_quantity, \
-    convert_0_1_smirnoff_to_0_2, convert_0_2_smirnoff_to_0_3
+from openforcefield.utils import (
+    all_subclasses,
+    MessageException,
+    convert_all_quantities_to_string,
+    convert_all_strings_to_quantity,
+    convert_0_1_smirnoff_to_0_2,
+    convert_0_2_smirnoff_to_0_3,
+)
 from openforcefield.topology.molecule import DEFAULT_AROMATICITY_MODEL
 from openforcefield.typing.engines.smirnoff.parameters import ParameterHandler
 from openforcefield.typing.engines.smirnoff.plugins import load_handler_plugins
 from openforcefield.typing.engines.smirnoff.io import ParameterIOHandler
 
 
-#=============================================================================================
+# =============================================================================================
 # CONFIGURE LOGGER
-#=============================================================================================
+# =============================================================================================
 
 logger = logging.getLogger(__name__)
 
-#=============================================================================================
+# =============================================================================================
 # PRIVATE METHODS
-#=============================================================================================
+# =============================================================================================
 
 # Directory paths used by ForceField to discover offxml files.
 _installed_offxml_dir_paths = []
+
 
 def _get_installed_offxml_dir_paths():
     """Return the list of directory paths where to search for offxml files.
@@ -80,9 +86,12 @@ def _get_installed_offxml_dir_paths():
     global _installed_offxml_dir_paths
     if len(_installed_offxml_dir_paths) == 0:
         from pkg_resources import iter_entry_points
+
         # Find all registered entry points that should return a list of
         # paths to directories where to search for offxml files.
-        for entry_point in iter_entry_points(group='openforcefield.smirnoff_forcefield_directory'):
+        for entry_point in iter_entry_points(
+            group="openforcefield.smirnoff_forcefield_directory"
+        ):
             _installed_offxml_dir_paths.extend(entry_point.load()())
     return _installed_offxml_dir_paths
 
@@ -111,7 +120,7 @@ def get_available_force_fields(full_paths=False):
     installed_paths = _get_installed_offxml_dir_paths()
     available_force_fields = []
     for installed_path in installed_paths:
-        for globbed in pathlib.Path(installed_path).rglob('*.offxml'):
+        for globbed in pathlib.Path(installed_path).rglob("*.offxml"):
             if full_paths:
                 available_force_fields.append(globbed.as_posix())
             else:
@@ -120,39 +129,46 @@ def get_available_force_fields(full_paths=False):
 
 
 # TODO: Instead of having a global version number, alow each Force to have a separate version number
-MAX_SUPPORTED_VERSION = '1.0'  # maximum version of the SMIRNOFF spec supported by this SMIRNOFF forcefield
+MAX_SUPPORTED_VERSION = (
+    "1.0"  # maximum version of the SMIRNOFF spec supported by this SMIRNOFF forcefield
+)
 
 
 class ParameterHandlerRegistrationError(MessageException):
     """
     Exception for errors in ParameterHandler registration
     """
+
     pass
+
 
 class SMIRNOFFVersionError(MessageException):
     """
     Exception thrown when an incompatible SMIRNOFF version data structure in attempted to be read.
     """
+
     pass
+
 
 class SMIRNOFFAromaticityError(MessageException):
     """
     Exception thrown when an incompatible SMIRNOFF aromaticity model is checked for compatibility.
     """
+
     pass
+
 
 class ParseError(MessageException):
     """
     Error for when a SMIRNOFF data structure is not parseable by a ForceField
     """
+
     pass
 
 
-
-
-#=============================================================================================
+# =============================================================================================
 # FORCEFIELD
-#=============================================================================================
+# =============================================================================================
 
 # QUESTION: How should we document private object fields?
 
@@ -250,13 +266,15 @@ class ForceField:
 
     """
 
-    def __init__(self,
-                 *sources,
-                 parameter_handler_classes=None,
-                 parameter_io_handler_classes=None,
-                 disable_version_check=False,
-                 allow_cosmetic_attributes=False,
-                 load_plugins=False):
+    def __init__(
+        self,
+        *sources,
+        parameter_handler_classes=None,
+        parameter_io_handler_classes=None,
+        disable_version_check=False,
+        allow_cosmetic_attributes=False,
+        load_plugins=False,
+    ):
         """Create a new :class:`ForceField` object from one or more SMIRNOFF parameter definition files.
 
         Parameters
@@ -331,8 +349,7 @@ class ForceField:
         if parameter_io_handler_classes is None:
             parameter_io_handler_classes = all_subclasses(ParameterIOHandler)
 
-        self._register_parameter_io_handler_classes(
-            parameter_io_handler_classes)
+        self._register_parameter_io_handler_classes(parameter_io_handler_classes)
 
         # Parse all sources containing SMIRNOFF parameter definitions
         self.parse_sources(sources, allow_cosmetic_attributes=allow_cosmetic_attributes)
@@ -343,16 +360,25 @@ class ForceField:
         """
         self._MIN_SUPPORTED_SMIRNOFF_VERSION = 0.1
         self._MAX_SUPPORTED_SMIRNOFF_VERSION = 0.3
-        self._disable_version_check = False  # if True, will disable checking compatibility version
+        self._disable_version_check = (
+            False  # if True, will disable checking compatibility version
+        )
         self._aromaticity_model = DEFAULT_AROMATICITY_MODEL  # aromaticity model
-        self._parameter_handler_classes = OrderedDict()  # Parameter handler classes that _can_ be initialized if needed
-        self._parameter_handlers = OrderedDict()  # ParameterHandler classes to be instantiated for each parameter type
-        self._parameter_io_handler_classes = OrderedDict()  # ParameterIOHandler classes that _can_ be initialiazed if needed
-        self._parameter_io_handlers = OrderedDict()  # ParameterIO classes to be used for each file type
+        self._parameter_handler_classes = (
+            OrderedDict()
+        )  # Parameter handler classes that _can_ be initialized if needed
+        self._parameter_handlers = (
+            OrderedDict()
+        )  # ParameterHandler classes to be instantiated for each parameter type
+        self._parameter_io_handler_classes = (
+            OrderedDict()
+        )  # ParameterIOHandler classes that _can_ be initialiazed if needed
+        self._parameter_io_handlers = (
+            OrderedDict()
+        )  # ParameterIO classes to be used for each file type
         self._aromaticity_model = None
         self._author = None
         self._date = None
-
 
     def _check_smirnoff_version_compatibility(self, version):
         """
@@ -369,23 +395,26 @@ class ForceField:
 
         """
         import packaging.version
+
         # Use PEP-440 compliant version number comparison, if requested
         if (not self.disable_version_check) and (
-                (
-                        packaging.version.parse(str(version)) >
-                packaging.version.parse(str(self._MAX_SUPPORTED_SMIRNOFF_VERSION))
-
-                ) or (
-                packaging.version.parse(str(version)) <
-                packaging.version.parse(str(self._MIN_SUPPORTED_SMIRNOFF_VERSION))
-                )
-              ):
+            (
+                packaging.version.parse(str(version))
+                > packaging.version.parse(str(self._MAX_SUPPORTED_SMIRNOFF_VERSION))
+            )
+            or (
+                packaging.version.parse(str(version))
+                < packaging.version.parse(str(self._MIN_SUPPORTED_SMIRNOFF_VERSION))
+            )
+        ):
             raise SMIRNOFFVersionError(
-                'SMIRNOFF offxml file was written with version {}, but this version of ForceField only supports '
-                'version {} to version {}'.format(version,
-                                                  self._MIN_SUPPORTED_SMIRNOFF_VERSION,
-                                                  self._MAX_SUPPORTED_SMIRNOFF_VERSION))
-
+                "SMIRNOFF offxml file was written with version {}, but this version of ForceField only supports "
+                "version {} to version {}".format(
+                    version,
+                    self._MIN_SUPPORTED_SMIRNOFF_VERSION,
+                    self._MAX_SUPPORTED_SMIRNOFF_VERSION,
+                )
+            )
 
     def _set_aromaticity_model(self, aromaticity_model):
         """
@@ -406,9 +435,11 @@ class ForceField:
 
         """
         # Implement better logic here if we ever support another aromaticity model
-        if aromaticity_model != 'OEAroModel_MDL':
-            raise SMIRNOFFAromaticityError("Read aromaticity model {}. Currently only "
-                                           "OEAroModel_MDL is supported.".format(aromaticity_model))
+        if aromaticity_model != "OEAroModel_MDL":
+            raise SMIRNOFFAromaticityError(
+                "Read aromaticity model {}. Currently only "
+                "OEAroModel_MDL is supported.".format(aromaticity_model)
+            )
 
         self._aromaticity_model = aromaticity_model
 
@@ -436,8 +467,7 @@ class ForceField:
         if self._author is None:
             self._author = author
         else:
-            self._author += ' AND ' + author
-
+            self._author += " AND " + author
 
     def _add_date(self, date):
         """
@@ -452,7 +482,7 @@ class ForceField:
         if self._date is None:
             self._date = date
         else:
-            self._date += ' AND ' + date
+            self._date += " AND " + date
 
     @property
     def author(self):
@@ -465,7 +495,6 @@ class ForceField:
         """
         return self._author
 
-
     @author.setter
     def author(self, author):
         """Set the author data for this ForceField object. If not defined in any loaded files, this will be None.
@@ -477,7 +506,6 @@ class ForceField:
         """
         self._author = author
 
-
     @property
     def date(self):
         """Returns the date data for this ForceField object. If not defined in any loaded files, this will be None.
@@ -488,7 +516,6 @@ class ForceField:
             The date data for this forcefield.
         """
         return self._date
-
 
     @date.setter
     def date(self, date):
@@ -519,13 +546,14 @@ class ForceField:
                     raise Exception(
                         "Attempting to register ParameterHandler {}, which provides a parser for tag"
                         " '{}', but ParameterHandler {} has already been registered to handle that tag.".format(
-                        parameter_handler_class, tagname,
-                        self._parameter_handler_classes[tagname])
+                            parameter_handler_class,
+                            tagname,
+                            self._parameter_handler_classes[tagname],
+                        )
                     )
                 self._parameter_handler_classes[tagname] = parameter_handler_class
 
-    def _register_parameter_io_handler_classes(self,
-                                               parameter_io_handler_classes):
+    def _register_parameter_io_handler_classes(self, parameter_io_handler_classes):
         """
         Register multiple ParameterIOHandler classes, ensuring they specify unique suffixes
 
@@ -545,17 +573,18 @@ class ForceField:
         for parameter_io_handler_class in parameter_io_handler_classes:
             serialization_format = parameter_io_handler_class._FORMAT
             if serialization_format is not None:
-                if serialization_format in self._parameter_io_handler_classes.keys(
-                ):
+                if serialization_format in self._parameter_io_handler_classes.keys():
                     raise Exception(
                         "Attempting to register ParameterIOHandler {}, which provides a IO parser for format "
                         "'{}', but ParameterIOHandler {} has already been registered to handle that tag.".format(
-                        parameter_io_handler_class, serialization_format,
-                        self._parameter_io_handler_classes[
-                        serialization_format])
+                            parameter_io_handler_class,
+                            serialization_format,
+                            self._parameter_io_handler_classes[serialization_format],
+                        )
                     )
                 self._parameter_io_handler_classes[
-                    serialization_format] = parameter_io_handler_class
+                    serialization_format
+                ] = parameter_io_handler_class
 
     def register_parameter_handler(self, parameter_handler):
         """
@@ -576,8 +605,9 @@ class ForceField:
             raise ParameterHandlerRegistrationError(
                 "Tried to register parameter handler '{}' for tag '{}', but "
                 "tag is already registered to {}".format(
-                    parameter_handler, tagname,
-                    self._parameter_handlers[tagname]))
+                    parameter_handler, tagname, self._parameter_handlers[tagname]
+                )
+            )
 
         self._parameter_handlers[parameter_handler._TAGNAME] = parameter_handler
 
@@ -599,8 +629,11 @@ class ForceField:
             raise ParameterHandlerRegistrationError(
                 "Tried to register parameter IO handler '{}' for tag '{}', but "
                 "tag is already registered to {}".format(
-                    parameter_io_handler, io_format,
-                    self._parameter_io_handlers[io_format]))
+                    parameter_io_handler,
+                    io_format,
+                    self._parameter_io_handlers[io_format],
+                )
+            )
         self._parameter_io_handlers[io_format] = parameter_io_handler
 
     @property
@@ -620,8 +653,9 @@ class ForceField:
     # TODO: Do we want to make this optional?
 
     @staticmethod
-    def _check_for_missing_valence_terms(name, topology, assigned_terms,
-                                         topological_terms):
+    def _check_for_missing_valence_terms(
+        name, topology, assigned_terms, topological_terms
+    ):
         """
         Check to ensure there are no missing valence terms in the given topology, identifying potential gaps in
         parameter coverage.
@@ -652,14 +686,18 @@ class ForceField:
                 return tuple(reversed(atoms))
 
         try:
-            topology_set = set([
-                ordered_tuple(atom.index for atom in atomset)
-                for atomset in topological_terms
-            ])
-            assigned_set = set([
-                ordered_tuple(index for index in atomset)
-                for atomset in assigned_terms
-            ])
+            topology_set = set(
+                [
+                    ordered_tuple(atom.index for atom in atomset)
+                    for atomset in topological_terms
+                ]
+            )
+            assigned_set = set(
+                [
+                    ordered_tuple(index for index in atomset)
+                    for atomset in assigned_terms
+                ]
+            )
         except TypeError as te:
             topology_set = set([atom.index for atom in topological_terms])
             assigned_set = set([atomset[0] for atomset in assigned_terms])
@@ -667,36 +705,41 @@ class ForceField:
         def render_atoms(atomsets):
             msg = ""
             for atomset in atomsets:
-                msg += f'{atomset:30} :'
+                msg += f"{atomset:30} :"
                 try:
                     for atom_index in atomset:
                         atom = atoms[atom_index]
-                        msg += f' {atom.residue.index:5} {atom.residue.name:3} {atom.name:3}'
+                        msg += f" {atom.residue.index:5} {atom.residue.name:3} {atom.name:3}"
                 except TypeError as te:
                     atom = atoms[atomset]
-                    msg += f' {atom.residue.index:5} {atom.residue.name:3} {atom.name:3}'
+                    msg += (
+                        f" {atom.residue.index:5} {atom.residue.name:3} {atom.name:3}"
+                    )
 
-                msg += '\n'
+                msg += "\n"
             return msg
 
         if set(assigned_set) != set(topology_set):
             # Form informative error message
-            msg = f'{name}: Mismatch between valence terms added and topological terms expected.\n'
+            msg = f"{name}: Mismatch between valence terms added and topological terms expected.\n"
             atoms = [atom for atom in topology.topology_atoms]
             if len(assigned_set.difference(topology_set)) > 0:
-                msg += 'Valence terms created that are not present in Topology:\n'
+                msg += "Valence terms created that are not present in Topology:\n"
                 msg += render_atoms(assigned_set.difference(topology_set))
             if len(topology_set.difference(assigned_set)) > 0:
-                msg += 'Topological atom sets not assigned parameters:\n'
+                msg += "Topological atom sets not assigned parameters:\n"
                 msg += render_atoms(topology_set.difference(assigned_set))
-            msg += 'topology_set:\n'
-            msg += str(topology_set) + '\n'
-            msg += 'assigned_set:\n'
-            msg += str(assigned_set) + '\n'
+            msg += "topology_set:\n"
+            msg += str(topology_set) + "\n"
+            msg += "assigned_set:\n"
+            msg += str(assigned_set) + "\n"
             raise Exception(
-                msg)  # TODO: Should we raise a more specific exception here?
+                msg
+            )  # TODO: Should we raise a more specific exception here?
 
-    def get_parameter_handler(self, tagname, handler_kwargs=None, allow_cosmetic_attributes=False):
+    def get_parameter_handler(
+        self, tagname, handler_kwargs=None, allow_cosmetic_attributes=False
+    ):
         """Retrieve the parameter handlers associated with the provided tagname.
 
         If the parameter handler has not yet been instantiated, it will be created and returned.
@@ -739,17 +782,21 @@ class ForceField:
             # If no handler kwargs were provided, skip the compatibility check
             if handler_kwargs != {}:
                 # Initialize a new instance of this parameter handler class with the given kwargs
-                new_handler = ph_class(**handler_kwargs,
-                                       allow_cosmetic_attributes=allow_cosmetic_attributes,
-                                       skip_version_check=skip_version_check)
+                new_handler = ph_class(
+                    **handler_kwargs,
+                    allow_cosmetic_attributes=allow_cosmetic_attributes,
+                    skip_version_check=skip_version_check,
+                )
                 old_handler.check_handler_compatibility(new_handler)
             return_handler = old_handler
         elif tagname in self._parameter_handler_classes:
             # Otherwise, register this handler in the forcefield
             # Initialize a new instance of this parameter handler class with the given kwargs
-            new_handler = ph_class(**handler_kwargs,
-                                   allow_cosmetic_attributes=allow_cosmetic_attributes,
-                                   skip_version_check=skip_version_check)
+            new_handler = ph_class(
+                **handler_kwargs,
+                allow_cosmetic_attributes=allow_cosmetic_attributes,
+                skip_version_check=skip_version_check,
+            )
             self.register_parameter_handler(new_handler)
             return_handler = new_handler
 
@@ -776,7 +823,7 @@ class ForceField:
         io_format = io_format.upper()
 
         # Remove "." (ParameterIOHandler tags do not include it)
-        io_format = io_format.strip('.')
+        io_format = io_format.strip(".")
 
         # Find or initialize ParameterIOHandler for this format
         io_handler = None
@@ -788,13 +835,14 @@ class ForceField:
             self.register_parameter_io_handler(io_handler)
         if io_handler is None:
             msg = "Cannot find a registered parameter IO handler for format '{}'\n".format(
-                io_format)
+                io_format
+            )
             msg += "Registered parameter IO handlers: {}\n".format(
-                self._parameter_io_handlers.keys())
+                self._parameter_io_handlers.keys()
+            )
             raise KeyError(msg)
 
         return io_handler
-
 
     def parse_sources(self, sources, allow_cosmetic_attributes=True):
         """Parse a SMIRNOFF force field definition.
@@ -828,9 +876,9 @@ class ForceField:
         # TODO: If a non-first source fails here, the forcefield might be partially modified
         for source in sources:
             smirnoff_data = self.parse_smirnoff_from_source(source)
-            self._load_smirnoff_data(smirnoff_data,
-                                     allow_cosmetic_attributes=allow_cosmetic_attributes)
-
+            self._load_smirnoff_data(
+                smirnoff_data, allow_cosmetic_attributes=allow_cosmetic_attributes
+            )
 
     def _to_smirnoff_data(self, discard_cosmetic_attributes=False):
         """
@@ -848,25 +896,27 @@ class ForceField:
         l1_dict = OrderedDict()
 
         # Assume we will write out SMIRNOFF data in compliance with the max supported spec version
-        l1_dict['version'] = self._MAX_SUPPORTED_SMIRNOFF_VERSION
+        l1_dict["version"] = self._MAX_SUPPORTED_SMIRNOFF_VERSION
 
         # Write out the aromaticity model used
-        l1_dict['aromaticity_model'] = self._aromaticity_model
+        l1_dict["aromaticity_model"] = self._aromaticity_model
 
         # Write out author and date (if they have been set)
         if not (self._author is None):
-            l1_dict['Author'] = self._author
+            l1_dict["Author"] = self._author
 
         # Write out author and date (if they have been set)
         if not (self._date is None):
-            l1_dict['Date'] = self._date
+            l1_dict["Date"] = self._date
 
         for handler_format, parameter_handler in self._parameter_handlers.items():
             handler_tag = parameter_handler._TAGNAME
-            l1_dict[handler_tag] = parameter_handler.to_dict(discard_cosmetic_attributes=discard_cosmetic_attributes)
+            l1_dict[handler_tag] = parameter_handler.to_dict(
+                discard_cosmetic_attributes=discard_cosmetic_attributes
+            )
 
         smirnoff_dict = OrderedDict()
-        smirnoff_dict['SMIRNOFF'] = l1_dict
+        smirnoff_dict["SMIRNOFF"] = l1_dict
         smirnoff_dict = convert_all_quantities_to_string(smirnoff_dict)
         return smirnoff_dict
 
@@ -886,11 +936,10 @@ class ForceField:
 
         # Check that the SMIRNOFF version of this data structure is supported by this ForceField implementation
 
-
         if "SMIRNOFF" in smirnoff_data:
-            version = smirnoff_data['SMIRNOFF']['version']
+            version = smirnoff_data["SMIRNOFF"]["version"]
         elif "SMIRFF" in smirnoff_data:
-            version = smirnoff_data['SMIRFF']['version']
+            version = smirnoff_data["SMIRFF"]["version"]
         else:
             raise ParseError("'version' attribute must be specified in SMIRNOFF tag")
 
@@ -908,24 +957,28 @@ class ForceField:
             smirnoff_data = convert_0_2_smirnoff_to_0_3(smirnoff_data)
 
         # Ensure that SMIRNOFF is a top-level key of the dict
-        if not('SMIRNOFF' in smirnoff_data):
-            raise ParseError("'SMIRNOFF' must be a top-level key in the SMIRNOFF object model")
+        if not ("SMIRNOFF" in smirnoff_data):
+            raise ParseError(
+                "'SMIRNOFF' must be a top-level key in the SMIRNOFF object model"
+            )
 
         # Check that the aromaticity model required by this parameter set is compatible with
         # others loaded by this ForceField
-        if 'aromaticity_model' in smirnoff_data['SMIRNOFF']:
-            aromaticity_model = smirnoff_data['SMIRNOFF']['aromaticity_model']
+        if "aromaticity_model" in smirnoff_data["SMIRNOFF"]:
+            aromaticity_model = smirnoff_data["SMIRNOFF"]["aromaticity_model"]
             self._set_aromaticity_model(aromaticity_model)
 
         elif self._aromaticity_model is None:
-            raise ParseError("'aromaticity_model' attribute must be specified in SMIRNOFF "
-                             "tag, or contained in a previously-loaded SMIRNOFF data source")
+            raise ParseError(
+                "'aromaticity_model' attribute must be specified in SMIRNOFF "
+                "tag, or contained in a previously-loaded SMIRNOFF data source"
+            )
 
-        if 'Author' in smirnoff_data['SMIRNOFF']:
-            self._add_author(smirnoff_data['SMIRNOFF']['Author'])
+        if "Author" in smirnoff_data["SMIRNOFF"]:
+            self._add_author(smirnoff_data["SMIRNOFF"]["Author"])
 
-        if 'Date' in smirnoff_data['SMIRNOFF']:
-            self._add_date(smirnoff_data['SMIRNOFF']['Date'])
+        if "Date" in smirnoff_data["SMIRNOFF"]:
+            self._add_date(smirnoff_data["SMIRNOFF"]["Date"])
 
         # Go through the whole SMIRNOFF data structure, trying to convert all strings to Quantity
         smirnoff_data = convert_all_strings_to_quantity(smirnoff_data)
@@ -933,21 +986,21 @@ class ForceField:
         # Go through the subsections, delegating each to the proper ParameterHandler
 
         # Define keys which are expected from the spec, but are not parameter sections
-        l1_spec_keys = ['Author', 'Date', 'version', 'aromaticity_model']
+        l1_spec_keys = ["Author", "Date", "version", "aromaticity_model"]
         # TODO: Throw SMIRNOFFSpecError for unrecognized keywords
 
-        for parameter_name in smirnoff_data['SMIRNOFF']:
+        for parameter_name in smirnoff_data["SMIRNOFF"]:
             # Skip (for now) cosmetic l1 items. They're handled above
             if parameter_name in l1_spec_keys:
                 continue
             # Handle cases where a parameter name has no info (eg. ToolkitAM1BCC)
-            if smirnoff_data['SMIRNOFF'][parameter_name] is None:
+            if smirnoff_data["SMIRNOFF"][parameter_name] is None:
                 # "get"ting the parameter handler here will also initialize it.
                 _ = self.get_parameter_handler(parameter_name, {})
                 continue
 
             # Otherwise, we expect this l1_key to correspond to a ParameterHandler
-            section_dict = smirnoff_data['SMIRNOFF'][parameter_name]
+            section_dict = smirnoff_data["SMIRNOFF"][parameter_name]
 
             # TODO: Implement a ParameterHandler.from_dict() that knows how to deserialize itself for extensibility.
             #       We could let it load the ParameterTypes from the dict and append them to the existing handler
@@ -971,11 +1024,14 @@ class ForceField:
 
             # Retrieve or create parameter handler, passing in section_dict to check for
             # compatibility if a handler for this parameter name already exists
-            handler = self.get_parameter_handler(parameter_name,
-                                                 section_dict,
-                                                 allow_cosmetic_attributes=allow_cosmetic_attributes)
-            handler._add_parameters(parameter_list_dict,
-                                    allow_cosmetic_attributes=allow_cosmetic_attributes)
+            handler = self.get_parameter_handler(
+                parameter_name,
+                section_dict,
+                allow_cosmetic_attributes=allow_cosmetic_attributes,
+            )
+            handler._add_parameters(
+                parameter_list_dict, allow_cosmetic_attributes=allow_cosmetic_attributes
+            )
 
     def parse_smirnoff_from_source(self, source):
         """
@@ -1002,12 +1058,12 @@ class ForceField:
         # file handler or a simple XML string.
         if isinstance(source, str):
             # Try first the simple path.
-            searched_dirs_paths = ['']
+            searched_dirs_paths = [""]
             # Then try a relative file path w.r.t. an installed directory.
-            searched_dirs_paths.extend( _get_installed_offxml_dir_paths())
+            searched_dirs_paths.extend(_get_installed_offxml_dir_paths())
             # Finally, search in openforcefield/data/.
             # TODO: Remove this when smirnoff99Frosst 1.0.9 will be released.
-            searched_dirs_paths.append(get_data_file_path(''))
+            searched_dirs_paths.append(get_data_file_path(""))
 
             # Determine the actual path of the file.
             # TODO: What is desired toolkit behavior if two files with the desired name are available?
@@ -1041,8 +1097,7 @@ class ForceField:
 
         # If we haven't returned by now, the parsing was unsuccessful
         valid_formats = [
-            input_format
-            for input_format in self._parameter_io_handlers.keys()
+            input_format for input_format in self._parameter_io_handlers.keys()
         ]
         msg = f"Source {source} could not be read. If this is a file, ensure that the path is correct.\n"
         msg += "If the file is present, ensure it is in a known SMIRNOFF encoding.\n"
@@ -1050,8 +1105,7 @@ class ForceField:
         msg += f"Parsing failed with the following error:\n{exception_msg}\n"
         raise IOError(msg)
 
-
-    def to_string(self, io_format='XML', discard_cosmetic_attributes=False):
+    def to_string(self, io_format="XML", discard_cosmetic_attributes=False):
         """
         Write this Forcefield and all its associated parameters to a string in a given format which
         complies with the SMIRNOFF spec.
@@ -1075,7 +1129,9 @@ class ForceField:
         else:
             io_handler = self.get_parameter_io_handler(io_format)
 
-        smirnoff_data = self._to_smirnoff_data(discard_cosmetic_attributes=discard_cosmetic_attributes)
+        smirnoff_data = self._to_smirnoff_data(
+            discard_cosmetic_attributes=discard_cosmetic_attributes
+        )
         string_data = io_handler.to_string(smirnoff_data)
         return string_data
 
@@ -1103,22 +1159,20 @@ class ForceField:
         if io_format is None:
             basename, io_format = os.path.splitext(filename)
 
-
-
         # Resolve which IO handler to use
         if isinstance(io_format, ParameterIOHandler):
             io_handler = io_format
         else:
             # Handle the fact that .offxml is the same as .xml
-            if io_format.lower() == 'offxml' or io_format.lower() == '.offxml':
-                io_format = 'xml'
+            if io_format.lower() == "offxml" or io_format.lower() == ".offxml":
+                io_format = "xml"
             io_handler = self.get_parameter_io_handler(io_format)
 
-
         # Write out the SMIRNOFF data to the IOHandler
-        smirnoff_data = self._to_smirnoff_data(discard_cosmetic_attributes=discard_cosmetic_attributes)
+        smirnoff_data = self._to_smirnoff_data(
+            discard_cosmetic_attributes=discard_cosmetic_attributes
+        )
         io_handler.to_file(filename, smirnoff_data)
-
 
     def _resolve_parameter_handler_order(self):
         """Resolve the order in which ParameterHandler objects should execute to satisfy constraints.
@@ -1131,6 +1185,7 @@ class ForceField:
 
         # Create a DAG expressing dependencies
         import networkx as nx
+
         G = nx.DiGraph()
         for tagname, parameter_handler in self._parameter_handlers.items():
             G.add_node(tagname)
@@ -1140,15 +1195,16 @@ class ForceField:
                     G.add_edge(dependency._TAGNAME, parameter_handler._TAGNAME)
 
         # Ensure there are no loops in handler order
-        if not(nx.is_directed_acyclic_graph(G)):
-            raise RuntimeError("Unable to resolve order in which to run ParameterHandlers. Dependencies do not form "
-                               "a directed acyclic graph.")
+        if not (nx.is_directed_acyclic_graph(G)):
+            raise RuntimeError(
+                "Unable to resolve order in which to run ParameterHandlers. Dependencies do not form "
+                "a directed acyclic graph."
+            )
         # Resolve order
         ordered_parameter_handlers = list()
         for tagname in nx.topological_sort(G):
             if tagname in self._parameter_handlers:
-                ordered_parameter_handlers.append(
-                    self._parameter_handlers[tagname])
+                ordered_parameter_handlers.append(self._parameter_handlers[tagname])
         return ordered_parameter_handlers
 
     # TODO: Should we add convenience methods to parameterize a Topology and export directly to AMBER, gromacs, CHARMM, etc.?
@@ -1160,11 +1216,7 @@ class ForceField:
     # TODO: How do we know if the system is periodic or not?
     # TODO: Should we also accept a Molecule as an alternative to a Topology?
 
-
-
-    def create_openmm_system(self,
-                             topology,
-                             **kwargs):
+    def create_openmm_system(self, topology, **kwargs):
         """Create an OpenMM System representing the interactions for the specified Topology with the current force field
 
         Parameters
@@ -1197,7 +1249,7 @@ class ForceField:
             during parameterization.
 
         """
-        return_topology = kwargs.pop('return_topology', False)
+        return_topology = kwargs.pop("return_topology", False)
 
         # Make a deep copy of the topology so we don't accidentally modify it
         topology = copy.deepcopy(topology)
@@ -1209,7 +1261,7 @@ class ForceField:
 
         # Set the topology aromaticity model to that used by the current forcefield
         # TODO: See openforcefield issue #206 for proposed implementation of aromaticity
-        #topology.set_aromaticity_model(self._aromaticity_model)
+        # topology.set_aromaticity_model(self._aromaticity_model)
 
         # Create an empty OpenMM System
         system = openmm.System()
@@ -1233,7 +1285,8 @@ class ForceField:
         unknown_kwargs = set(kwargs.keys()).difference(known_kwargs)
         if len(unknown_kwargs) > 0:
             msg = "The following keyword arguments to create_openmm_system() are not used by any registered force Handler: {}\n".format(
-                unknown_kwargs)
+                unknown_kwargs
+            )
             msg += "Known keyword arguments: {}".format(known_kwargs)
             raise ValueError(msg)
 
@@ -1250,10 +1303,7 @@ class ForceField:
         else:
             return system
 
-    def create_parmed_structure(self,
-                                topology,
-                                positions,
-                                **kwargs):
+    def create_parmed_structure(self, topology, positions, **kwargs):
         """Create a ParmEd Structure object representing the interactions for the specified Topology with the current force field
 
         This method creates a `ParmEd <http://github.com/parmed/parmed>`_ ``Structure`` object containing a topology, positions, and parameters.
@@ -1272,18 +1322,18 @@ class ForceField:
 
         """
         raise NotImplementedError
-        #import parmed
+        # import parmed
         # TODO: Automagically handle expansion of virtual sites? Or is Topology supposed to do that?
 
         # Create OpenMM System
-        #system = self.create_openmm_system(
+        # system = self.create_openmm_system(
         #    topology, **kwargs)
 
         # Create a ParmEd Structure object
-        #structure = parmed.openmm.topsystem.load_topology(
+        # structure = parmed.openmm.topsystem.load_topology(
         #    topology.to_openmm(), system, positions)
         #
-        #return structure
+        # return structure
 
     def label_molecules(self, topology):
         """Return labels for a list of molecules corresponding to parameters from this force field.
@@ -1313,6 +1363,7 @@ class ForceField:
 
         """
         from openforcefield.topology import Topology
+
         # Loop over molecules and label
         molecule_labels = list()
         for molecule_idx, molecule in enumerate(topology.reference_molecules):
@@ -1349,8 +1400,11 @@ class ForceField:
             ph_class = self._parameter_handler_classes[tagname]
         except KeyError:
             msg = "Cannot find a registered parameter handler class for tag '{}'\n".format(
-                tagname)
-            msg += "Known parameter handler class tags are {}".format(self._parameter_handler_classes.keys())
+                tagname
+            )
+            msg += "Known parameter handler class tags are {}".format(
+                self._parameter_handler_classes.keys()
+            )
             raise KeyError(msg)
         return ph_class
 

--- a/openforcefield/typing/engines/smirnoff/io.py
+++ b/openforcefield/typing/engines/smirnoff/io.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#=============================================================================================
+# =============================================================================================
 # MODULE DOCSTRING
-#=============================================================================================
+# =============================================================================================
 """
 XML I/O parser for the SMIRNOFF (SMIRKS Native Open Force Field) format.
 
@@ -13,14 +13,14 @@ XML I/O parser for the SMIRNOFF (SMIRKS Native Open Force Field) format.
 """
 
 __all__ = [
-    'ParameterIOHandler',
-    'XMLParameterIOHandler',
+    "ParameterIOHandler",
+    "XMLParameterIOHandler",
 ]
 
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import logging
 
@@ -28,16 +28,17 @@ import xmltodict
 from simtk import unit
 
 
-#=============================================================================================
+# =============================================================================================
 # CONFIGURE LOGGER
-#=============================================================================================
+# =============================================================================================
 
 logger = logging.getLogger(__name__)
 
 
-#=============================================================================================
+# =============================================================================================
 # QUANTITY PARSING UTILITIES
-#=============================================================================================
+# =============================================================================================
+
 
 def _ast_unit_eval(node):
     """
@@ -49,35 +50,44 @@ def _ast_unit_eval(node):
     import ast
     import operator as op
 
-    operators = {ast.Add: op.add, ast.Sub: op.sub, ast.Mult: op.mul,
-        ast.Div: op.truediv, ast.Pow: op.pow, ast.BitXor: op.xor,
-        ast.USub: op.neg}
+    operators = {
+        ast.Add: op.add,
+        ast.Sub: op.sub,
+        ast.Mult: op.mul,
+        ast.Div: op.truediv,
+        ast.Pow: op.pow,
+        ast.BitXor: op.xor,
+        ast.USub: op.neg,
+    }
 
     if isinstance(node, ast.Num):  # <number>
         return node.n
     elif isinstance(node, ast.BinOp):  # <left> <operator> <right>
-        return operators[type(node.op)](_ast_unit_eval(node.left), _ast_unit_eval(node.right))
+        return operators[type(node.op)](
+            _ast_unit_eval(node.left), _ast_unit_eval(node.right)
+        )
     elif isinstance(node, ast.UnaryOp):  # <operator>( <operand> ) e.g., -1
         return operators[type(node.op)](_ast_unit_eval(node.operand))
     elif isinstance(node, ast.Name):
         # Check if this is a simtk unit.
         u = getattr(unit, node.id)
         if not isinstance(u, unit.Unit):
-            raise ValueError('No unit named {} found in simtk.unit.'.format(node.id))
+            raise ValueError("No unit named {} found in simtk.unit.".format(node.id))
         return u
     else:
         raise TypeError(node)
 
 
-#=============================================================================================
+# =============================================================================================
 # Base ParameterIOHandler
-#=============================================================================================
+# =============================================================================================
 
 
 class ParameterIOHandler:
     """
     Base class for handling serialization/deserialization of SMIRNOFF ForceField objects
     """
+
     _FORMAT = None
 
     def __init__(self):
@@ -147,16 +157,18 @@ class ParameterIOHandler:
         pass
 
 
-#=============================================================================================
+# =============================================================================================
 # XML I/O
-#=============================================================================================
+# =============================================================================================
+
 
 class XMLParameterIOHandler(ParameterIOHandler):
     """
     Handles serialization/deserialization of SMIRNOFF ForceField objects from OFFXML format.
     """
+
     # TODO: Come up with a better keyword for format
-    _FORMAT = 'XML'
+    _FORMAT = "XML"
 
     def parse_file(self, source):
         """Parse a SMIRNOFF force field definition in XML format, read from a file.
@@ -201,7 +213,7 @@ class XMLParameterIOHandler(ParameterIOHandler):
 
         # Parse XML file
         try:
-            smirnoff_data = xmltodict.parse(data, attr_prefix='')
+            smirnoff_data = xmltodict.parse(data, attr_prefix="")
             return smirnoff_data
         except ExpatError as e:
             raise ParseError(str(e))
@@ -219,7 +231,7 @@ class XMLParameterIOHandler(ParameterIOHandler):
 
         """
         xml_string = self.to_string(smirnoff_data)
-        with open(file_path, 'w') as of:
+        with open(file_path, "w") as of:
             of.write(xml_string)
 
     def to_string(self, smirnoff_data):
@@ -237,7 +249,8 @@ class XMLParameterIOHandler(ParameterIOHandler):
             XML String representation of this forcefield.
 
         """
-        def prepend_all_keys(d, char='@', ignore_keys=frozenset()):
+
+        def prepend_all_keys(d, char="@", ignore_keys=frozenset()):
             """
             Modify a dictionary in-place, prepending a specified string to each key
             that doesn't refer to a value that is list or dict.
@@ -269,16 +282,14 @@ class XMLParameterIOHandler(ParameterIOHandler):
 
         # the "xmltodict" library defaults to print out all element attributes on separate lines
         # unless they're prepended by "@"
-        prepend_all_keys(smirnoff_data['SMIRNOFF'], ignore_keys=['Author', 'Date'])
+        prepend_all_keys(smirnoff_data["SMIRNOFF"], ignore_keys=["Author", "Date"])
 
         # Reorder parameter sections to put Author and Date at the top (this is the only
         # way to change the order of items in a dict, as far as I can tell)
-        for key, value in list(smirnoff_data['SMIRNOFF'].items()):
-            if key in ['Author', 'Date']:
+        for key, value in list(smirnoff_data["SMIRNOFF"].items()):
+            if key in ["Author", "Date"]:
                 continue
-            del smirnoff_data['SMIRNOFF'][key]
-            smirnoff_data['SMIRNOFF'][key] = value
+            del smirnoff_data["SMIRNOFF"][key]
+            smirnoff_data["SMIRNOFF"][key] = value
 
         return xmltodict.unparse(smirnoff_data, pretty=True)
-
-

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#=============================================================================================
+# =============================================================================================
 # MODULE DOCSTRING
-#=============================================================================================
+# =============================================================================================
 """
 Parameter handlers for the SMIRNOFF force field engine
 
@@ -13,31 +13,31 @@ New pluggable handlers can be created by creating subclasses of :class:`Paramete
 """
 
 __all__ = [
-    'SMIRNOFFSpecError',
-    'IncompatibleParameterError',
-    'UnassignedValenceParameterException',
-    'UnassignedBondParameterException',
-    'UnassignedAngleParameterException',
-    'NonbondedMethod',
-    'ParameterList',
-    'ParameterType',
-    'ParameterHandler',
-    'ParameterAttribute',
-    'IndexedParameterAttribute',
-    'IndexedMappedParameterAttribute',
-    'ConstraintHandler',
-    'BondHandler',
-    'AngleHandler',
-    'ProperTorsionHandler',
-    'ImproperTorsionHandler',
-    'vdWHandler',
-    'GBSAHandler'
+    "SMIRNOFFSpecError",
+    "IncompatibleParameterError",
+    "UnassignedValenceParameterException",
+    "UnassignedBondParameterException",
+    "UnassignedAngleParameterException",
+    "NonbondedMethod",
+    "ParameterList",
+    "ParameterType",
+    "ParameterHandler",
+    "ParameterAttribute",
+    "IndexedParameterAttribute",
+    "IndexedMappedParameterAttribute",
+    "ConstraintHandler",
+    "BondHandler",
+    "AngleHandler",
+    "ProperTorsionHandler",
+    "ImproperTorsionHandler",
+    "vdWHandler",
+    "GBSAHandler",
 ]
 
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import copy
 from collections import OrderedDict, defaultdict
@@ -49,9 +49,13 @@ import re
 
 from simtk import openmm, unit
 
-from openforcefield.utils import attach_units,  \
-    extract_serialized_units_from_dict, MessageException, \
-    object_to_quantity, GLOBAL_TOOLKIT_REGISTRY
+from openforcefield.utils import (
+    attach_units,
+    extract_serialized_units_from_dict,
+    MessageException,
+    object_to_quantity,
+    GLOBAL_TOOLKIT_REGISTRY,
+)
 from openforcefield.topology import ValenceDict, ImproperDict, SortedDict
 from openforcefield.topology.molecule import Molecule
 from openforcefield.typing.chemistry import ChemicalEnvironment
@@ -59,21 +63,23 @@ from openforcefield.utils import IncompatibleUnitError
 from openforcefield.utils.collections import ValidatedList, ValidatedDict
 
 
-#=============================================================================================
+# =============================================================================================
 # CONFIGURE LOGGER
-#=============================================================================================
+# =============================================================================================
 
 logger = logging.getLogger(__name__)
 
 
-#======================================================================
+# ======================================================================
 # CUSTOM EXCEPTIONS
-#======================================================================
+# ======================================================================
+
 
 class SMIRNOFFSpecError(MessageException):
     """
     Exception for when data is noncompliant with the SMIRNOFF data specification.
     """
+
     pass
 
 
@@ -81,36 +87,43 @@ class IncompatibleParameterError(MessageException):
     """
     Exception for when a set of parameters is scientifically/technically incompatible with another
     """
+
     pass
 
 
 class UnassignedValenceParameterException(Exception):
     """Exception raised when there are valence terms for which a ParameterHandler can't find parameters."""
+
     pass
 
 
 class UnassignedBondParameterException(UnassignedValenceParameterException):
     """Exception raised when there are bond terms for which a ParameterHandler can't find parameters."""
+
     pass
 
 
 class UnassignedAngleParameterException(UnassignedValenceParameterException):
     """Exception raised when there are angle terms for which a ParameterHandler can't find parameters."""
+
     pass
 
 
 class UnassignedProperTorsionParameterException(UnassignedValenceParameterException):
     """Exception raised when there are proper torsion terms for which a ParameterHandler can't find parameters."""
+
     pass
 
 
 class UnassignedMoleculeChargeException(Exception):
     """Exception raised when no charge method is able to assign charges to a molecule."""
+
     pass
 
 
 class NonintegralMoleculeChargeException(Exception):
     """Exception raised when the partial charges on a molecule do not sum up to its formal charge."""
+
     pass
 
 
@@ -118,14 +131,16 @@ class DuplicateParameterError(MessageException):
     """Exception raised when trying to add a ParameterType that already exists"""
 
 
-#======================================================================
+# ======================================================================
 # ENUM TYPES
-#======================================================================
+# ======================================================================
+
 
 class NonbondedMethod(Enum):
     """
     An enumeration of the nonbonded methods
     """
+
     NoCutoff = 0
     CutoffPeriodic = 1
     CutoffNonPeriodic = 2
@@ -133,9 +148,9 @@ class NonbondedMethod(Enum):
     PME = 4
 
 
-#======================================================================
+# ======================================================================
 # PARAMETER ATTRIBUTES
-#======================================================================
+# ======================================================================
 
 # TODO: Think about adding attrs to the dependencies and inherit from attr.ib
 class ParameterAttribute:
@@ -252,6 +267,7 @@ class ParameterAttribute:
 
     class UNDEFINED:
         """Custom type used by ``ParameterAttribute`` to differentiate between ``None`` and undeclared default."""
+
         pass
 
     def __init__(self, default=UNDEFINED, unit=None, converter=None):
@@ -260,7 +276,7 @@ class ParameterAttribute:
         self._converter = converter
 
     def __set_name__(self, owner, name):
-        self._name = '_' + name
+        self._name = "_" + name
 
     @property
     def name(self):
@@ -305,7 +321,9 @@ class ParameterAttribute:
 
     def _is_valid_default(self, value):
         """Return True if this is a defined default value."""
-        return self.default is not ParameterAttribute.UNDEFINED and value == self.default
+        return (
+            self.default is not ParameterAttribute.UNDEFINED and value == self.default
+        )
 
     def _validate_units(self, value):
         """Convert strings expressions to Quantity and validate the units if requested."""
@@ -316,10 +334,14 @@ class ParameterAttribute:
             # Check if units are compatible.
             try:
                 if not self._unit.is_compatible(value.unit):
-                    raise IncompatibleUnitError(f'{self.name}={value} should have units of {self._unit}')
+                    raise IncompatibleUnitError(
+                        f"{self.name}={value} should have units of {self._unit}"
+                    )
             except AttributeError:
                 # This is not a Quantity object.
-                raise IncompatibleUnitError(f'{self.name}={value} should have units of {self._unit}')
+                raise IncompatibleUnitError(
+                    f"{self.name}={value} should have units of {self._unit}"
+                )
         return value
 
     def _call_converter(self, value, instance):
@@ -398,6 +420,7 @@ class IndexedParameterAttribute(ParameterAttribute):
     [1.0, 1.0, 0.01, 4.0]
 
     """
+
     def _convert_and_validate(self, instance, value):
         """Overwrite ParameterAttribute._convert_and_validate to make the value a ValidatedList."""
         # The default value is always allowed.
@@ -483,6 +506,7 @@ class IndexedMappedParameterAttribute(ParameterAttribute):
     [{1: 1.0}, {2: 1.0, 3: 0.01}, {4: 4.0}]
 
     """
+
     def _convert_and_validate(self, instance, value):
         """Overwrite ParameterAttribute._convert_and_validate to make the value a ValidatedList."""
         # The default value is always allowed.
@@ -497,10 +521,14 @@ class IndexedMappedParameterAttribute(ParameterAttribute):
         static_converter = functools.partial(self._call_converter, instance=instance)
 
         value = ValidatedList(
-                [ValidatedDict(element,
-                               converter=[self._validate_units, static_converter])
-                    for element in value], 
-                converter=self._index_converter)
+            [
+                ValidatedDict(
+                    element, converter=[self._validate_units, static_converter]
+                )
+                for element in value
+            ],
+            converter=self._index_converter,
+        )
 
         return value
 
@@ -654,16 +682,23 @@ class _ParameterAttributeHandler:
         # Do not modify the original data.
         smirnoff_data = copy.deepcopy(kwargs)
 
-        smirnoff_data, indexed_mapped_attr_lengths = self._process_indexed_mapped_attributes(smirnoff_data)
-        smirnoff_data = self._process_indexed_attributes(smirnoff_data, indexed_mapped_attr_lengths)
+        (
+            smirnoff_data,
+            indexed_mapped_attr_lengths,
+        ) = self._process_indexed_mapped_attributes(smirnoff_data)
+        smirnoff_data = self._process_indexed_attributes(
+            smirnoff_data, indexed_mapped_attr_lengths
+        )
 
         # Check for missing required arguments.
         given_attributes = set(smirnoff_data.keys())
         required_attributes = set(self._get_required_parameter_attributes().keys())
         missing_attributes = required_attributes.difference(given_attributes)
         if len(missing_attributes) != 0:
-            msg = (f"{self.__class__} require the following missing parameters: {sorted(missing_attributes)}."
-                   f" Defined kwargs are {sorted(smirnoff_data.keys())}")
+            msg = (
+                f"{self.__class__} require the following missing parameters: {sorted(missing_attributes)}."
+                f" Defined kwargs are {sorted(smirnoff_data.keys())}"
+            )
             raise SMIRNOFFSpecError(msg)
 
         # Finally, set attributes of this ParameterType and handle cosmetic attributes.
@@ -675,9 +710,11 @@ class _ParameterAttributeHandler:
             elif allow_cosmetic_attributes:
                 self.add_cosmetic_attribute(key, val)
             else:
-                msg = (f"Unexpected kwarg ({key}: {val})  passed to {self.__class__} constructor. "
-                        "If this is a desired cosmetic attribute, consider setting "
-                        "'allow_cosmetic_attributes=True'")
+                msg = (
+                    f"Unexpected kwarg ({key}: {val})  passed to {self.__class__} constructor. "
+                    "If this is a desired cosmetic attribute, consider setting "
+                    "'allow_cosmetic_attributes=True'"
+                )
                 raise SMIRNOFFSpecError(msg)
 
     def _process_indexed_mapped_attributes(self, smirnoff_data):
@@ -690,12 +727,14 @@ class _ParameterAttributeHandler:
         kwargs = list(smirnoff_data.keys())
         for kwarg in kwargs:
             attr_name, index, key = self._split_attribute_index_mapping(kwarg)
-            
+
             # Check if this is an indexed_mapped attribute.
-            if ((key is not None) and
-                (index is not None) and
-                attr_name in self._get_indexed_mapped_parameter_attributes()):
-                
+            if (
+                (key is not None)
+                and (index is not None)
+                and attr_name in self._get_indexed_mapped_parameter_attributes()
+            ):
+
                 # we start with a dict because have no guarantee of order
                 # in which we will see each kwarg
                 # we'll switch this to a list later
@@ -730,9 +769,11 @@ class _ParameterAttributeHandler:
                     kwarg = reverse[attr_name][i][key]
                     val = smirnoff_data[attr_name][i][key]
 
-                    msg = (f"Unexpected kwarg ({kwarg}: {val})  passed to {self.__class__} constructor. "
-                            "If this is a desired cosmetic attribute, consider setting "
-                            "'allow_cosmetic_attributes=True'")
+                    msg = (
+                        f"Unexpected kwarg ({kwarg}: {val})  passed to {self.__class__} constructor. "
+                        "If this is a desired cosmetic attribute, consider setting "
+                        "'allow_cosmetic_attributes=True'"
+                    )
                     raise SMIRNOFFSpecError(msg)
 
             smirnoff_data[attr_name] = indexed_mapping
@@ -747,7 +788,7 @@ class _ParameterAttributeHandler:
         # Check for indexed attributes and stack them into a list.
         # Keep track of how many indexed attribute we find to make sure they all have the same length.
 
-        # TODO: REFACTOR ME; try looping over contents of `smirnoff_data`, using 
+        # TODO: REFACTOR ME; try looping over contents of `smirnoff_data`, using
         # `split_attribute_index` to extract values
 
         if indexed_attr_lengths is None:
@@ -756,7 +797,7 @@ class _ParameterAttributeHandler:
         for attrib_basename in self._get_indexed_parameter_attributes().keys():
             index = 1
             while True:
-                attrib_w_index = '{}{}'.format(attrib_basename, index)
+                attrib_w_index = "{}{}".format(attrib_basename, index)
 
                 # Exit the while loop if the indexed attribute is not given.
                 # this is the stop condition
@@ -769,8 +810,10 @@ class _ParameterAttributeHandler:
                 if index == 1:
                     # Check if this attribute has been specified with and without index.
                     if attrib_basename in smirnoff_data:
-                        err_msg = (f"The attribute '{attrib_basename}' has been specified "
-                                   f"with and without index: '{attrib_w_index}'")
+                        err_msg = (
+                            f"The attribute '{attrib_basename}' has been specified "
+                            f"with and without index: '{attrib_w_index}'"
+                        )
                         raise TypeError(err_msg)
 
                     # Otherwise create the list object.
@@ -786,13 +829,17 @@ class _ParameterAttributeHandler:
 
             # Update the lengths with this attribute (if it was found).
             if index > 1:
-                indexed_attr_lengths[attrib_basename] = len(smirnoff_data[attrib_basename])
+                indexed_attr_lengths[attrib_basename] = len(
+                    smirnoff_data[attrib_basename]
+                )
 
         # Raise an error if we there are different indexed
         # attributes with a different number of terms.
         if len(set(indexed_attr_lengths.values())) > 1:
-            raise TypeError('The following indexed attributes have '
-                            f'different lengths: {indexed_attr_lengths}')
+            raise TypeError(
+                "The following indexed attributes have "
+                f"different lengths: {indexed_attr_lengths}"
+            )
 
         return smirnoff_data
 
@@ -822,7 +869,9 @@ class _ParameterAttributeHandler:
 
         # Start populating a dict of the attribs.
         indexed_attribs = set(self._get_indexed_parameter_attributes().keys())
-        indexed_mapped_attribs = set(self._get_indexed_mapped_parameter_attributes().keys())
+        indexed_mapped_attribs = set(
+            self._get_indexed_mapped_parameter_attributes().keys()
+        )
         smirnoff_dict = OrderedDict()
 
         # If attribs_to_return is ordered here, that will effectively be an informal output ordering
@@ -832,18 +881,20 @@ class _ParameterAttributeHandler:
             if attrib_name in indexed_mapped_attribs:
                 for idx, mapping in enumerate(attrib_value):
                     for key, val in mapping.items():
-                        attrib_name_indexed, attrib_name_mapped = attrib_name.split('_')
-                        smirnoff_dict[f"{attrib_name_indexed}{str(idx+1)}_{attrib_name_mapped}{key}"] = val
+                        attrib_name_indexed, attrib_name_mapped = attrib_name.split("_")
+                        smirnoff_dict[
+                            f"{attrib_name_indexed}{str(idx+1)}_{attrib_name_mapped}{key}"
+                        ] = val
             elif attrib_name in indexed_attribs:
                 for idx, val in enumerate(attrib_value):
-                    smirnoff_dict[attrib_name + str(idx+1)] = val
+                    smirnoff_dict[attrib_name + str(idx + 1)] = val
             else:
                 smirnoff_dict[attrib_name] = attrib_value
 
         # Serialize cosmetic attributes.
-        if not(discard_cosmetic_attributes):
+        if not (discard_cosmetic_attributes):
             for cosmetic_attrib in self._cosmetic_attribs:
-                smirnoff_dict[cosmetic_attrib] = getattr(self, '_' + cosmetic_attrib)
+                smirnoff_dict[cosmetic_attrib] = getattr(self, "_" + cosmetic_attrib)
 
         return smirnoff_dict
 
@@ -855,29 +906,37 @@ class _ParameterAttributeHandler:
         attr_name, index, key = self._split_attribute_index_mapping(item)
 
         # Check if this is an indexed_mapped attribute.
-        if ((key is not None) and
-            (index is not None) and
-            attr_name in self._get_indexed_mapped_parameter_attributes()):
+        if (
+            (key is not None)
+            and (index is not None)
+            and attr_name in self._get_indexed_mapped_parameter_attributes()
+        ):
             indexed_mapped_attr_value = getattr(self, attr_name)
             try:
                 return indexed_mapped_attr_value[index][key]
             except (IndexError, KeyError) as err:
-                if not err.args: 
-                    err.args=('',)
-                err.args = err.args + (f"'{item}' is out of bound for indexed attribute '{attr_name}'",)
-                raise 
+                if not err.args:
+                    err.args = ("",)
+                err.args = err.args + (
+                    f"'{item}' is out of bound for indexed attribute '{attr_name}'",
+                )
+                raise
 
         # Otherwise, try indexed attribute
         # Separate the indexed attribute name from the list index.
         attr_name, index = self._split_attribute_index(item)
 
         # Check if this is an indexed attribute.
-        if (index is not None) and attr_name in self._get_indexed_parameter_attributes():
+        if (
+            index is not None
+        ) and attr_name in self._get_indexed_parameter_attributes():
             indexed_attr_value = getattr(self, attr_name)
             try:
                 return indexed_attr_value[index]
             except IndexError:
-                raise IndexError(f"'{item}' is out of bound for indexed attribute '{attr_name}'")
+                raise IndexError(
+                    f"'{item}' is out of bound for indexed attribute '{attr_name}'"
+                )
 
         # Otherwise, forward the search to the next class in the MRO.
         try:
@@ -885,8 +944,10 @@ class _ParameterAttributeHandler:
         except AttributeError as e:
             # If this fails because the next classes in the MRO do not
             # implement __getattr__(), then raise the standard Attribute error.
-            if '__getattr__' in str(e):
-                raise AttributeError(f"{self.__class__} object has no attribute '{item}'")
+            if "__getattr__" in str(e):
+                raise AttributeError(
+                    f"{self.__class__} object has no attribute '{item}'"
+                )
             # Otherwise, re-raise the error from the class in the MRO.
             raise
 
@@ -899,33 +960,41 @@ class _ParameterAttributeHandler:
 
         # Check if this is an index_mapped attribute. avoiding an infinite
         # recursion by calling getattr() with non-existing keys.
-        if ((mapkey is not None) and
-            (index is not None) and
-            attr_name in self._get_indexed_mapped_parameter_attributes()):
+        if (
+            (mapkey is not None)
+            and (index is not None)
+            and attr_name in self._get_indexed_mapped_parameter_attributes()
+        ):
             indexed_mapped_attr_value = getattr(self, attr_name)
             try:
                 indexed_mapped_attr_value[index][mapkey] = value
                 return
             except (IndexError, KeyError) as err:
-                if not err.args: 
-                    err.args=('',)
-                err.args = err.args + (f"'{key}' is out of bound for indexed attribute '{attr_name}'",)
-                raise 
-            
+                if not err.args:
+                    err.args = ("",)
+                err.args = err.args + (
+                    f"'{key}' is out of bound for indexed attribute '{attr_name}'",
+                )
+                raise
+
         # Otherwise, try indexed attribute
         # Separate the indexed attribute name from the list index.
         attr_name, index = self._split_attribute_index(key)
 
         # Check if this is an indexed attribute. avoiding an infinite
         # recursion by calling getattr() with non-existing keys.
-        if (index is not None) and (attr_name in self._get_indexed_parameter_attributes()):
+        if (index is not None) and (
+            attr_name in self._get_indexed_parameter_attributes()
+        ):
             indexed_attr_value = getattr(self, attr_name)
             try:
                 indexed_attr_value[index] = value
                 return
             except IndexError:
-                raise IndexError(f"'{key}' is out of bound for indexed attribute '{attr_name}'")
-            
+                raise IndexError(
+                    f"'{key}' is out of bound for indexed attribute '{attr_name}'"
+                )
+
         # Forward the request to the next class in the MRO.
         super().__setattr__(key, value)
 
@@ -948,7 +1017,7 @@ class _ParameterAttributeHandler:
             The value of the attribute to define for this object.
 
         """
-        setattr(self, '_'+attr_name, attr_value)
+        setattr(self, "_" + attr_name, attr_value)
         self._cosmetic_attribs.append(attr_name)
 
     def delete_cosmetic_attribute(self, attr_name):
@@ -965,7 +1034,7 @@ class _ParameterAttributeHandler:
         """
         # TODO: Can we handle this by overriding __delattr__ instead?
         #  Would we also need to override __del__ as well to cover both deletation methods?
-        delattr(self, '_'+attr_name)
+        delattr(self, "_" + attr_name)
         self._cosmetic_attribs.remove(attr_name)
 
     def attribute_is_cosmetic(self, attr_name):
@@ -996,12 +1065,12 @@ class _ParameterAttributeHandler:
         """
 
         # Match any number (\d+) at the end of the string ($).
-        match = re.search(r'\d+$', item)
+        match = re.search(r"\d+$", item)
         if match is None:
             return item, None
 
         index = match.group()  # This is a str.
-        attr_name = item[:-len(index)]
+        attr_name = item[: -len(index)]
         index = int(match.group()) - 1
         return attr_name, index
 
@@ -1014,26 +1083,26 @@ class _ParameterAttributeHandler:
         """
         # Match items of the form <item><index>_<mapping><key>
         # where <index> and <key> always integers
-        match = re.search(r'\d+_[A-z]+\d+$', item)
+        match = re.search(r"\d+_[A-z]+\d+$", item)
         if match is None:
             return item, None, None
 
         # Match any number (\d+) at the end of the string ($).
-        i_match = r'\d+$'
+        i_match = r"\d+$"
 
-        indexed, mapped = item.split('_')
+        indexed, mapped = item.split("_")
 
         # process indexed component
         match_indexed = re.search(i_match, indexed)
         index = match_indexed.group()  # This is a str.
-        attr_name = indexed[:-len(index)]
+        attr_name = indexed[: -len(index)]
         index = int(index) - 1
 
         # process mapped component
         match_mapping = re.search(i_match, mapped)
         key = match_mapping.group()  # This is a str.
         attr_name = f"{attr_name}_{mapped[:-len(key)]}"
-        key = int(key) # we don't subtract 1 here, because these are keys, not indices
+        key = int(key)  # we don't subtract 1 here, because these are keys, not indices
 
         return attr_name, index, key
 
@@ -1080,20 +1149,27 @@ class _ParameterAttributeHandler:
         # sorts the attribute alphabetically by name. Here we want the order
         # to be the same as the declaration order, which is guaranteed by PEP 520,
         # starting from the parent class.
-        parameter_attributes = OrderedDict((name, descriptor) for c in reversed(inspect.getmro(cls))
-                                           for name, descriptor in c.__dict__.items()
-                                           if isinstance(descriptor, ParameterAttribute) and filter(descriptor))
+        parameter_attributes = OrderedDict(
+            (name, descriptor)
+            for c in reversed(inspect.getmro(cls))
+            for name, descriptor in c.__dict__.items()
+            if isinstance(descriptor, ParameterAttribute) and filter(descriptor)
+        )
         return parameter_attributes
 
     @classmethod
     def _get_indexed_mapped_parameter_attributes(cls):
         """Shortcut to retrieve only IndexedMappedParameterAttributes."""
-        return cls._get_parameter_attributes(filter=lambda x: isinstance(x, IndexedMappedParameterAttribute))
+        return cls._get_parameter_attributes(
+            filter=lambda x: isinstance(x, IndexedMappedParameterAttribute)
+        )
 
     @classmethod
     def _get_indexed_parameter_attributes(cls):
         """Shortcut to retrieve only IndexedParameterAttributes."""
-        return cls._get_parameter_attributes(filter=lambda x: isinstance(x, IndexedParameterAttribute))
+        return cls._get_parameter_attributes(
+            filter=lambda x: isinstance(x, IndexedParameterAttribute)
+        )
 
     @classmethod
     def _get_required_parameter_attributes(cls):
@@ -1103,7 +1179,9 @@ class _ParameterAttributeHandler:
     @classmethod
     def _get_optional_parameter_attributes(cls):
         """Shortcut to retrieve only required ParameterAttributes."""
-        return cls._get_parameter_attributes(filter=lambda x: x.default is not x.UNDEFINED)
+        return cls._get_parameter_attributes(
+            filter=lambda x: x.default is not x.UNDEFINED
+        )
 
     def _get_defined_parameter_attributes(self):
         """Returns all the attributes except for the optional attributes that have None default value.
@@ -1114,15 +1192,20 @@ class _ParameterAttributeHandler:
         required = self._get_required_parameter_attributes()
         optional = self._get_optional_parameter_attributes()
         # Filter the optional parameters that are set to their default.
-        optional = OrderedDict((name, descriptor) for name, descriptor in optional.items()
-                               if not(descriptor.default is None and getattr(self, name) == descriptor.default))
+        optional = OrderedDict(
+            (name, descriptor)
+            for name, descriptor in optional.items()
+            if not (
+                descriptor.default is None and getattr(self, name) == descriptor.default
+            )
+        )
         required.update(optional)
         return required
 
 
-#======================================================================
+# ======================================================================
 # PARAMETER TYPE/LIST
-#======================================================================
+# ======================================================================
 
 # We can't actually make this derive from dict, because it's possible for the user to change SMIRKS
 # of parameters already in the list, which would cause the ParameterType object's SMIRKS and
@@ -1181,8 +1264,10 @@ class ParameterList(list):
 
         """
         if not isinstance(other, ParameterList):
-            msg = 'ParameterList.extend(other) expected instance of ParameterList, ' \
-                  'but received {} (type {}) instead'.format(other, type(other))
+            msg = (
+                "ParameterList.extend(other) expected instance of ParameterList, "
+                "but received {} (type {}) instead".format(other, type(other))
+            )
             raise TypeError(msg)
         # TODO: Check if other ParameterList contains the same ParameterTypes?
         super().extend(other)
@@ -1208,7 +1293,9 @@ class ParameterList(list):
             for parameter in self:
                 if parameter.smirks == item:
                     return self.index(parameter)
-            raise IndexError('SMIRKS {item} not found in ParameterList'.format(item=item))
+            raise IndexError(
+                "SMIRKS {item} not found in ParameterList".format(item=item)
+            )
 
     def insert(self, index, parameter):
         """
@@ -1257,15 +1344,13 @@ class ParameterList(list):
             index = self.index(item)
         return super().__getitem__(index)
 
-
     # TODO: Override __setitem__ and __del__ to ensure we can slice by SMIRKS as well
     # This is needed for pickling. See https://github.com/openforcefield/openforcefield/issues/411
     # for more details.
     # TODO: Is there a cleaner way (getstate/setstate perhaps?) to allow FFs to be
     #       pickled?
     def __reduce__(self):
-        return (__class__, ( list( self),), self.__dict__)
-
+        return (__class__, (list(self),), self.__dict__)
 
     def __contains__(self, item):
         """Check to see if either Parameter or SMIRKS is contained in parameter list.
@@ -1300,7 +1385,9 @@ class ParameterList(list):
         parameter_list = list()
 
         for parameter in self:
-            parameter_dict = parameter.to_dict(discard_cosmetic_attributes=discard_cosmetic_attributes)
+            parameter_dict = parameter.to_dict(
+                discard_cosmetic_attributes=discard_cosmetic_attributes
+            )
             parameter_list.append(parameter_dict)
 
         return parameter_list
@@ -1451,8 +1538,7 @@ class ParameterType(_ParameterAttributeHandler):
 
         # TODO: Add check to make sure we can't make tree non-hierarchical
         #       This would require parameter type knows which ParameterList it belongs to
-        ChemicalEnvironment.validate_smirks(
-            smirks, validate_valence_type=True)
+        ChemicalEnvironment.validate_smirks(smirks, validate_valence_type=True)
         return smirks
 
     def __init__(self, smirks, allow_cosmetic_attributes=False, **kwargs):
@@ -1470,18 +1556,18 @@ class ParameterType(_ParameterAttributeHandler):
 
         """
         # This is just to make smirks a required positional argument.
-        kwargs['smirks']  = smirks
+        kwargs["smirks"] = smirks
         super().__init__(allow_cosmetic_attributes=allow_cosmetic_attributes, **kwargs)
 
     def __repr__(self):
-        ret_str = '<{} with '.format(self.__class__.__name__)
+        ret_str = "<{} with ".format(self.__class__.__name__)
         for attr, val in self.to_dict().items():
-            ret_str += f'{attr}: {val}  '
-        ret_str += '>'
+            ret_str += f"{attr}: {val}  "
+        ret_str += ">"
         return ret_str
 
 
-#======================================================================
+# ======================================================================
 # PARAMETER HANDLERS
 #
 # The following classes are Handlers that know how to create Force
@@ -1493,9 +1579,10 @@ class ParameterType(_ParameterAttributeHandler):
 #    to the System; and
 # 3) a labelForce() method that provides access to which terms are applied
 #    to which atoms in specified mols.
-#======================================================================
+# ======================================================================
 
 # TODO: Should we have a parameter handler registry?
+
 
 class ParameterHandler(_ParameterAttributeHandler):
     """Base class for parameter handlers.
@@ -1518,14 +1605,19 @@ class ParameterHandler(_ParameterAttributeHandler):
     _TAGNAME = None  # str of section type handled by this ParameterHandler (XML element name for SMIRNOFF XML representation)
     _INFOTYPE = None  # container class with type information that will be stored in self._parameters
     _OPENMMTYPE = None  # OpenMM Force class (or None if no equivalent)
-    _DEPENDENCIES = None  # list of ParameterHandler classes that must precede this, or None
+    _DEPENDENCIES = (
+        None  # list of ParameterHandler classes that must precede this, or None
+    )
 
-    _KWARGS = [] # Kwargs to catch when create_force is called
-    _SMIRNOFF_VERSION_INTRODUCED = 0.0  # the earliest version of SMIRNOFF spec that supports this ParameterHandler
-    _SMIRNOFF_VERSION_DEPRECATED = None  # if deprecated, the first SMIRNOFF version number it is no longer used
+    _KWARGS = []  # Kwargs to catch when create_force is called
+    _SMIRNOFF_VERSION_INTRODUCED = (
+        0.0  # the earliest version of SMIRNOFF spec that supports this ParameterHandler
+    )
+    _SMIRNOFF_VERSION_DEPRECATED = (
+        None  # if deprecated, the first SMIRNOFF version number it is no longer used
+    )
     _MIN_SUPPORTED_SECTION_VERSION = 0.3
     _MAX_SUPPORTED_SECTION_VERSION = 0.3
-
 
     version = ParameterAttribute()
 
@@ -1541,23 +1633,25 @@ class ParameterHandler(_ParameterAttributeHandler):
         """
         import packaging.version
         from openforcefield.typing.engines.smirnoff import SMIRNOFFVersionError
+
         # Use PEP-440 compliant version number comparison, if requested
         if (
-                packaging.version.parse(str(new_version)) >
-                packaging.version.parse(str(self._MAX_SUPPORTED_SECTION_VERSION))
-                ) or (
-                packaging.version.parse(str(new_version)) <
-                packaging.version.parse(str(self._MIN_SUPPORTED_SECTION_VERSION))
+            packaging.version.parse(str(new_version))
+            > packaging.version.parse(str(self._MAX_SUPPORTED_SECTION_VERSION))
+        ) or (
+            packaging.version.parse(str(new_version))
+            < packaging.version.parse(str(self._MIN_SUPPORTED_SECTION_VERSION))
         ):
             raise SMIRNOFFVersionError(
-                f'SMIRNOFF offxml file was written with version {new_version}, but this version '
-                f'of ForceField only supports version {self._MIN_SUPPORTED_SECTION_VERSION} '
-                f'to version {self._MAX_SUPPORTED_SECTION_VERSION}'
+                f"SMIRNOFF offxml file was written with version {new_version}, but this version "
+                f"of ForceField only supports version {self._MIN_SUPPORTED_SECTION_VERSION} "
+                f"to version {self._MAX_SUPPORTED_SECTION_VERSION}"
             )
         return new_version
 
-
-    def __init__(self, allow_cosmetic_attributes=False, skip_version_check=False, **kwargs):
+    def __init__(
+        self, allow_cosmetic_attributes=False, skip_version_check=False, **kwargs
+    ):
         """
         Initialize a ParameterHandler, optionally with a list of parameters and other kwargs.
 
@@ -1574,9 +1668,9 @@ class ParameterHandler(_ParameterAttributeHandler):
 
         """
         # Skip version check if requested.
-        if 'version' not in kwargs:
+        if "version" not in kwargs:
             if skip_version_check:
-                kwargs['version'] = self._MAX_SUPPORTED_SECTION_VERSION
+                kwargs["version"] = self._MAX_SUPPORTED_SECTION_VERSION
             else:
                 raise SMIRNOFFSpecError(
                     f"Missing version while trying to construct {self.__class__}. "
@@ -1602,7 +1696,9 @@ class ParameterHandler(_ParameterAttributeHandler):
             attribute of the parameter. If False, non-spec kwargs will raise an exception.
 
         """
-        unitless_kwargs, attached_units = extract_serialized_units_from_dict(section_dict)
+        unitless_kwargs, attached_units = extract_serialized_units_from_dict(
+            section_dict
+        )
         smirnoff_data = attach_units(unitless_kwargs, attached_units)
 
         element_name = None
@@ -1620,8 +1716,9 @@ class ParameterHandler(_ParameterAttributeHandler):
             # each parameter_dict, then use it to initialize a ParameterType
             for unitless_param_dict in val:
                 param_dict = attach_units(unitless_param_dict, attached_units)
-                new_parameter = self._INFOTYPE(**param_dict,
-                                               allow_cosmetic_attributes=allow_cosmetic_attributes)
+                new_parameter = self._INFOTYPE(
+                    **param_dict, allow_cosmetic_attributes=allow_cosmetic_attributes
+                )
                 self._parameters.append(new_parameter)
 
     @property
@@ -1667,7 +1764,9 @@ class ParameterHandler(_ParameterAttributeHandler):
         pass
 
     # TODO: Can we ensure SMIRKS and other parameters remain valid after manipulation?
-    def add_parameter(self, parameter_kwargs=None, parameter=None, after=None, before=None):
+    def add_parameter(
+        self, parameter_kwargs=None, parameter=None, after=None, before=None
+    ):
         """Add a parameter to the forcefield, ensuring all parameters are valid.
 
         Parameters
@@ -1724,10 +1823,10 @@ class ParameterHandler(_ParameterAttributeHandler):
         elif parameter:
             new_parameter = parameter
         else:
-            raise ValueError('One of (parameter, parameter_kwargs) must be specified')
+            raise ValueError("One of (parameter, parameter_kwargs) must be specified")
 
         if new_parameter.smirks in [p.smirks for p in self._parameters]:
-            msg = f'A parameter SMIRKS pattern {val} already exists.'
+            msg = f"A parameter SMIRKS pattern {val} already exists."
             raise DuplicateParameterError(msg)
 
         if before is not None:
@@ -1744,10 +1843,10 @@ class ParameterHandler(_ParameterAttributeHandler):
 
         if None not in (before, after):
             if after_index > before_index:
-                raise ValueError('before arg must be before after arg')
+                raise ValueError("before arg must be before after arg")
 
         if after is not None:
-            self._parameters.insert(after_index+1, new_parameter)
+            self._parameters.insert(after_index + 1, new_parameter)
         elif before is not None:
             self._parameters.insert(before_index, new_parameter)
         else:
@@ -1798,7 +1897,7 @@ class ParameterHandler(_ParameterAttributeHandler):
                 # TODO: Cleaner accessing of cosmetic attributes
                 # See issue #338
                 if param.attribute_is_cosmetic(attr):
-                    attr = '_' + attr
+                    attr = "_" + attr
                 if hasattr(param, attr):
                     if getattr(param, attr) == value:
                         params.append(param)
@@ -1870,7 +1969,7 @@ class ParameterHandler(_ParameterAttributeHandler):
             ``matches[particle_indices]`` is the ``ParameterType`` object
             matching the tuple of particle indices in ``entity``.
         """
-        logger.debug('Finding matches for {}'.format(self.__class__.__name__))
+        logger.debug("Finding matches for {}".format(self.__class__.__name__))
 
         matches = transformed_dict_cls()
 
@@ -1880,18 +1979,25 @@ class ParameterHandler(_ParameterAttributeHandler):
         for parameter_type in self._parameters:
             matches_for_this_type = {}
 
-            for environment_match in entity.chemical_environment_matches(parameter_type.smirks):
+            for environment_match in entity.chemical_environment_matches(
+                parameter_type.smirks
+            ):
                 # Update the matches for this parameter type.
                 handler_match = self._Match(parameter_type, environment_match)
-                matches_for_this_type[environment_match.topology_atom_indices] = handler_match
+                matches_for_this_type[
+                    environment_match.topology_atom_indices
+                ] = handler_match
 
             # Update matches of all parameter types.
             matches.update(matches_for_this_type)
 
-            logger.debug('{:64} : {:8} matches'.format(
-                parameter_type.smirks, len(matches_for_this_type)))
+            logger.debug(
+                "{:64} : {:8} matches".format(
+                    parameter_type.smirks, len(matches_for_this_type)
+                )
+            )
 
-        logger.debug('{} matches identified'.format(len(matches)))
+        logger.debug("{} matches identified".format(len(matches)))
         return matches
 
     @staticmethod
@@ -1956,7 +2062,6 @@ class ParameterHandler(_ParameterAttributeHandler):
         """
         pass
 
-
     def to_dict(self, discard_cosmetic_attributes=False):
         """
         Convert this ParameterHandler to an OrderedDict, compliant with the SMIRNOFF data spec.
@@ -1975,15 +2080,19 @@ class ParameterHandler(_ParameterAttributeHandler):
         smirnoff_data = OrderedDict()
 
         # Populate parameter list
-        parameter_list = self._parameters.to_list(discard_cosmetic_attributes=discard_cosmetic_attributes)
+        parameter_list = self._parameters.to_list(
+            discard_cosmetic_attributes=discard_cosmetic_attributes
+        )
 
         # NOTE: This assumes that a ParameterHandler will have just one homogenous ParameterList under it
         if self._INFOTYPE is not None:
-            #smirnoff_data[self._INFOTYPE._ELEMENT_NAME] = unitless_parameter_list
+            # smirnoff_data[self._INFOTYPE._ELEMENT_NAME] = unitless_parameter_list
             smirnoff_data[self._INFOTYPE._ELEMENT_NAME] = parameter_list
 
         # Collect parameter and cosmetic attributes.
-        header_attribute_dict = super().to_dict(discard_cosmetic_attributes=discard_cosmetic_attributes)
+        header_attribute_dict = super().to_dict(
+            discard_cosmetic_attributes=discard_cosmetic_attributes
+        )
         smirnoff_data.update(header_attribute_dict)
 
         return smirnoff_data
@@ -1993,8 +2102,12 @@ class ParameterHandler(_ParameterAttributeHandler):
     # -------------------------------
 
     @classmethod
-    def _check_all_valence_terms_assigned(cls, assigned_terms, valence_terms,
-                                          exception_cls=UnassignedValenceParameterException):
+    def _check_all_valence_terms_assigned(
+        cls,
+        assigned_terms,
+        valence_terms,
+        exception_cls=UnassignedValenceParameterException,
+    ):
         """Check that all valence terms have been assigned and print a user-friendly error message.
 
         Parameters
@@ -2009,6 +2122,7 @@ class ParameterHandler(_ParameterAttributeHandler):
 
         """
         from openforcefield.topology import TopologyAtom
+
         # Provided there are no duplicates in either list,
         # or something weird like a bond has been added to
         # a torsions list - this should work just fine I think.
@@ -2051,10 +2165,10 @@ class ParameterHandler(_ParameterAttributeHandler):
                 topology = valence_terms[0].topology_molecule.topology
             else:
                 topology = valence_terms[0][0].topology_molecule.topology
-            unassigned_str = ''
+            unassigned_str = ""
             for unassigned_tuple in unassigned_terms:
-                unassigned_str += '\n- Topology indices ' + str(unassigned_tuple)
-                unassigned_str += ': names and elements '
+                unassigned_str += "\n- Topology indices " + str(unassigned_tuple)
+                unassigned_str += ": names and elements "
 
                 unassigned_topology_atoms = []
 
@@ -2064,26 +2178,28 @@ class ParameterHandler(_ParameterAttributeHandler):
                     unassigned_topology_atoms.append(topology_atom)
                     unassigned_str += f"({topology_atom.atom.name} {topology_atom.atom.element.symbol}), "
                 unassigned_topology_atom_tuples.append(tuple(unassigned_topology_atoms))
-            err_msg += ("{parameter_handler} was not able to find parameters for the following valence terms:\n"
-                        "{unassigned_str}").format(parameter_handler=cls.__name__,
-                                                     unassigned_str=unassigned_str)
+            err_msg += (
+                "{parameter_handler} was not able to find parameters for the following valence terms:\n"
+                "{unassigned_str}"
+            ).format(parameter_handler=cls.__name__, unassigned_str=unassigned_str)
         if len(not_found_terms) > 0:
             if err_msg != "":
-                err_msg += '\n'
-            not_found_str = '\n- '.join([str(x) for x in not_found_terms])
-            err_msg += ("{parameter_handler} assigned terms that were not found in the topology:\n"
-                        "- {not_found_str}").format(parameter_handler=cls.__name__,
-                                                    not_found_str=not_found_str)
+                err_msg += "\n"
+            not_found_str = "\n- ".join([str(x) for x in not_found_terms])
+            err_msg += (
+                "{parameter_handler} assigned terms that were not found in the topology:\n"
+                "- {not_found_str}"
+            ).format(parameter_handler=cls.__name__, not_found_str=not_found_str)
         if err_msg != "":
-            err_msg += '\n'
+            err_msg += "\n"
             exception = exception_cls(err_msg)
             exception.unassigned_topology_atom_tuples = unassigned_topology_atom_tuples
             exception.handler_class = cls
             raise exception
 
-
-    def _check_attributes_are_equal(self, other, identical_attrs=(),
-                                    tolerance_attrs=(), tolerance=1e-6):
+    def _check_attributes_are_equal(
+        self, other, identical_attrs=(), tolerance_attrs=(), tolerance=1e-6
+    ):
         """Utility function to check that the given attributes of the two handlers are equal.
 
         Parameters
@@ -2095,6 +2211,7 @@ class ParameterHandler(_ParameterAttributeHandler):
         tolerance : float
             The absolute tolerance used to compare the parameters.
         """
+
         def get_unitless_values(attr):
             this_val = getattr(self, attr)
             other_val = getattr(other, attr)
@@ -2112,7 +2229,9 @@ class ParameterHandler(_ParameterAttributeHandler):
                 raise IncompatibleParameterError(
                     "{} values are not identical. "
                     "(handler value: {}, incompatible value: {}".format(
-                        attr, this_val, other_val))
+                        attr, this_val, other_val
+                    )
+                )
 
         for attr in tolerance_attrs:
             this_val, other_val = get_unitless_values(attr)
@@ -2120,10 +2239,12 @@ class ParameterHandler(_ParameterAttributeHandler):
                 raise IncompatibleParameterError(
                     "Difference between '{}' values is beyond allowed tolerance {}. "
                     "(handler value: {}, incompatible value: {}".format(
-                        attr, tolerance, this_val, other_val))
+                        attr, tolerance, this_val, other_val
+                    )
+                )
 
 
-#=============================================================================================
+# =============================================================================================
 
 
 class ConstraintHandler(ParameterHandler):
@@ -2140,13 +2261,13 @@ class ConstraintHandler(ParameterHandler):
 
         .. warning :: This API is experimental and subject to change.
         """
-        _VALENCE_TYPE = 'Bond'
-        _ELEMENT_NAME = 'Constraint'
+
+        _VALENCE_TYPE = "Bond"
+        _ELEMENT_NAME = "Constraint"
 
         distance = ParameterAttribute(default=None, unit=unit.angstrom)
 
-
-    _TAGNAME = 'Constraints'
+    _TAGNAME = "Constraints"
     _INFOTYPE = ConstraintType
     _OPENMMTYPE = None  # don't create a corresponding OpenMM Force class
 
@@ -2154,7 +2275,7 @@ class ConstraintHandler(ParameterHandler):
         constraint_matches = self.find_matches(topology)
         for (atoms, constraint_match) in constraint_matches.items():
             # Update constrained atom pairs in topology
-            #topology.add_constraint(*atoms, constraint.distance)
+            # topology.add_constraint(*atoms, constraint.distance)
             # If a distance is specified (constraint.distance != True), add the constraint here.
             # Otherwise, the equilibrium bond length will be used to constrain the atoms in HarmonicBondHandler
             constraint = constraint_match.parameter_type
@@ -2165,7 +2286,8 @@ class ConstraintHandler(ParameterHandler):
                 system.addConstraint(*atoms, constraint.distance)
                 topology.add_constraint(*atoms, constraint.distance)
 
-#=============================================================================================
+
+# =============================================================================================
 
 
 class BondHandler(ParameterHandler):
@@ -2179,25 +2301,25 @@ class BondHandler(ParameterHandler):
 
         .. warning :: This API is experimental and subject to change.
         """
+
         # ChemicalEnvironment valence type string expected by SMARTS string for this Handler
-        _VALENCE_TYPE = 'Bond'
-        _ELEMENT_NAME = 'Bond'
+        _VALENCE_TYPE = "Bond"
+        _ELEMENT_NAME = "Bond"
 
         # These attributes may be indexed (by integer bond order) if fractional bond orders are used.
         length = ParameterAttribute(unit=unit.angstrom)
-        k = ParameterAttribute(unit=unit.kilocalorie_per_mole / unit.angstrom**2)
+        k = ParameterAttribute(unit=unit.kilocalorie_per_mole / unit.angstrom ** 2)
 
-    _TAGNAME = 'Bonds'  # SMIRNOFF tag name to process
+    _TAGNAME = "Bonds"  # SMIRNOFF tag name to process
     _INFOTYPE = BondType  # class to hold force type info
     _OPENMMTYPE = openmm.HarmonicBondForce  # OpenMM force class to create
     _DEPENDENCIES = [ConstraintHandler]  # ConstraintHandler must be executed first
 
-    potential = ParameterAttribute(default='harmonic')
+    potential = ParameterAttribute(default="harmonic")
     fractional_bondorder_method = ParameterAttribute(default=None)
-    fractional_bondorder_interpolation = ParameterAttribute(default='linear')
+    fractional_bondorder_interpolation = ParameterAttribute(default="linear")
 
-    def check_handler_compatibility(self,
-                                    other_handler):
+    def check_handler_compatibility(self, other_handler):
         """
         Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
@@ -2211,13 +2333,19 @@ class BondHandler(ParameterHandler):
         ------
         IncompatibleParameterError if handler_kwargs are incompatible with existing parameters.
         """
-        string_attrs_to_compare = ['potential', 'fractional_bondorder_method', 'fractional_bondorder_interpolation']
-        self._check_attributes_are_equal(other_handler, identical_attrs=string_attrs_to_compare)
+        string_attrs_to_compare = [
+            "potential",
+            "fractional_bondorder_method",
+            "fractional_bondorder_interpolation",
+        ]
+        self._check_attributes_are_equal(
+            other_handler, identical_attrs=string_attrs_to_compare
+        )
 
     def create_force(self, system, topology, **kwargs):
         # Create or retrieve existing OpenMM Force object
         # TODO: The commented line below should replace the system.getForce search
-        #force = super(BondHandler, self).create_force(system, topology, **kwargs)
+        # force = super(BondHandler, self).create_force(system, topology, **kwargs)
         existing = [system.getForce(i) for i in range(system.getNumForces())]
         existing = [f for f in existing if type(f) == self._OPENMMTYPE]
         if len(existing) == 0:
@@ -2229,10 +2357,12 @@ class BondHandler(ParameterHandler):
         # Add all bonds to the system.
         bond_matches = self.find_matches(topology)
 
-        skipped_constrained_bonds = 0  # keep track of how many bonds were constrained (and hence skipped)
+        skipped_constrained_bonds = (
+            0  # keep track of how many bonds were constrained (and hence skipped)
+        )
         for (topology_atom_indices, bond_match) in bond_matches.items():
             # Get corresponding particle indices in Topology
-            #particle_indices = tuple([ atom.particle_index for atom in atoms ])
+            # particle_indices = tuple([ atom.particle_index for atom in atoms ])
 
             # Ensure atoms are actually bonded correct pattern in Topology
             self._assert_correct_connectivity(bond_match)
@@ -2241,19 +2371,23 @@ class BondHandler(ParameterHandler):
             match = bond_match.environment_match
 
             # Compute equilibrium bond length and spring constant.
-            bond = match.reference_molecule.get_bond_between(*match.reference_atom_indices)
+            bond = match.reference_molecule.get_bond_between(
+                *match.reference_atom_indices
+            )
 
-            if hasattr(bond_params, 'k_bondorder1'):
-                raise NotImplementedError("Partial bondorder treatment is not implemented for bonds.")
+            if hasattr(bond_params, "k_bondorder1"):
+                raise NotImplementedError(
+                    "Partial bondorder treatment is not implemented for bonds."
+                )
 
                 # Interpolate using fractional bond orders
                 # TODO: Do we really want to allow per-bond specification of interpolation schemes?
-                #order = bond.fractional_bond_order
-                #if self.fractional_bondorder_interpolation == 'interpolate-linear':
+                # order = bond.fractional_bond_order
+                # if self.fractional_bondorder_interpolation == 'interpolate-linear':
                 #    k = bond_params.k[0] + (bond_params.k[1] - bond_params.k[0]) * (order - 1.)
                 #    length = bond_params.length[0] + (
                 #        bond_params.length[1] - bond_params.length[0]) * (order - 1.)
-                #else:
+                # else:
                 #    raise Exception(
                 #        "Partial bondorder treatment {} is not implemented.".
                 #        format(self.fractional_bondorder_method))
@@ -2272,22 +2406,28 @@ class BondHandler(ParameterHandler):
                     topology.add_constraint(*topology_atom_indices, length)
                     # Add the constraint to the System.
                     system.addConstraint(*topology_atom_indices, length)
-                    #system.addConstraint(*particle_indices, length)
+                    # system.addConstraint(*particle_indices, length)
                 continue
 
             # Add harmonic bond to HarmonicBondForce
             force.addBond(*topology_atom_indices, length, k)
 
-        logger.info('{} bonds added ({} skipped due to constraints)'.format(
-            len(bond_matches) - skipped_constrained_bonds, skipped_constrained_bonds))
+        logger.info(
+            "{} bonds added ({} skipped due to constraints)".format(
+                len(bond_matches) - skipped_constrained_bonds, skipped_constrained_bonds
+            )
+        )
 
         # Check that no topological bonds are missing force parameters.
         valence_terms = [list(b.atoms) for b in topology.topology_bonds]
-        self._check_all_valence_terms_assigned(assigned_terms=bond_matches, valence_terms=valence_terms,
-                                               exception_cls=UnassignedBondParameterException)
+        self._check_all_valence_terms_assigned(
+            assigned_terms=bond_matches,
+            valence_terms=valence_terms,
+            exception_cls=UnassignedBondParameterException,
+        )
 
 
-#=============================================================================================
+# =============================================================================================
 
 
 class AngleHandler(ParameterHandler):
@@ -2301,21 +2441,21 @@ class AngleHandler(ParameterHandler):
 
         .. warning :: This API is experimental and subject to change.
         """
-        _VALENCE_TYPE = 'Angle'  # ChemicalEnvironment valence type string expected by SMARTS string for this Handler
-        _ELEMENT_NAME = 'Angle'
+
+        _VALENCE_TYPE = "Angle"  # ChemicalEnvironment valence type string expected by SMARTS string for this Handler
+        _ELEMENT_NAME = "Angle"
 
         angle = ParameterAttribute(unit=unit.degree)
-        k = ParameterAttribute(unit=unit.kilocalorie_per_mole / unit.degree**2)
+        k = ParameterAttribute(unit=unit.kilocalorie_per_mole / unit.degree ** 2)
 
-    _TAGNAME = 'Angles'  # SMIRNOFF tag name to process
+    _TAGNAME = "Angles"  # SMIRNOFF tag name to process
     _INFOTYPE = AngleType  # class to hold force type info
     _OPENMMTYPE = openmm.HarmonicAngleForce  # OpenMM force class to create
     _DEPENDENCIES = [ConstraintHandler]  # ConstraintHandler must be executed first
 
-    potential = ParameterAttribute(default='harmonic')
+    potential = ParameterAttribute(default="harmonic")
 
-    def check_handler_compatibility(self,
-                                    other_handler):
+    def check_handler_compatibility(self, other_handler):
         """
         Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
@@ -2329,11 +2469,13 @@ class AngleHandler(ParameterHandler):
         ------
         IncompatibleParameterError if handler_kwargs are incompatible with existing parameters.
         """
-        string_attrs_to_compare = ['potential']
-        self._check_attributes_are_equal(other_handler, identical_attrs=string_attrs_to_compare)
+        string_attrs_to_compare = ["potential"]
+        self._check_attributes_are_equal(
+            other_handler, identical_attrs=string_attrs_to_compare
+        )
 
     def create_force(self, system, topology, **kwargs):
-        #force = super(AngleHandler, self).create_force(system, topology, **kwargs)
+        # force = super(AngleHandler, self).create_force(system, topology, **kwargs)
         existing = [system.getForce(i) for i in range(system.getNumForces())]
         existing = [f for f in existing if type(f) == self._OPENMMTYPE]
         if len(existing) == 0:
@@ -2344,17 +2486,20 @@ class AngleHandler(ParameterHandler):
 
         # Add all angles to the system.
         angle_matches = self.find_matches(topology)
-        skipped_constrained_angles = 0  # keep track of how many angles were constrained (and hence skipped)
+        skipped_constrained_angles = (
+            0  # keep track of how many angles were constrained (and hence skipped)
+        )
         for (atoms, angle_match) in angle_matches.items():
             # Ensure atoms are actually bonded correct pattern in Topology
             # for (i, j) in [(0, 1), (1, 2)]:
             #     topology.assert_bonded(atoms[i], atoms[j])
             self._assert_correct_connectivity(angle_match)
 
-            if topology.is_constrained(
-                    atoms[0], atoms[1]) and topology.is_constrained(
-                        atoms[1], atoms[2]) and topology.is_constrained(
-                            atoms[0], atoms[2]):
+            if (
+                topology.is_constrained(atoms[0], atoms[1])
+                and topology.is_constrained(atoms[1], atoms[2])
+                and topology.is_constrained(atoms[0], atoms[2])
+            ):
                 # Angle is constrained; we don't need to add an angle term.
                 skipped_constrained_angles += 1
                 continue
@@ -2362,23 +2507,29 @@ class AngleHandler(ParameterHandler):
             angle = angle_match.parameter_type
             force.addAngle(*atoms, angle.angle, angle.k)
 
-        logger.info('{} angles added ({} skipped due to constraints)'.format(
-            len(angle_matches) - skipped_constrained_angles,
-            skipped_constrained_angles))
+        logger.info(
+            "{} angles added ({} skipped due to constraints)".format(
+                len(angle_matches) - skipped_constrained_angles,
+                skipped_constrained_angles,
+            )
+        )
 
         # Check that no topological angles are missing force parameters
-        self._check_all_valence_terms_assigned(assigned_terms=angle_matches,
-                                               valence_terms=list(topology.angles),
-                                               exception_cls=UnassignedAngleParameterException)
+        self._check_all_valence_terms_assigned(
+            assigned_terms=angle_matches,
+            valence_terms=list(topology.angles),
+            exception_cls=UnassignedAngleParameterException,
+        )
 
 
-#=============================================================================================
+# =============================================================================================
 
 # TODO: This is technically a validator, not a converter, but ParameterAttribute doesn't support them yet (it'll be easy if we switch to use the attrs library).
 def _allow_only(allowed_values):
     """A converter that checks the new value is only in a set.
     """
     allowed_values = frozenset(allowed_values)
+
     def _value_checker(instance, attr, new_value):
         # This statement means that, in the "SMIRNOFF Data Dict" format, the string "None"
         # and the Python None are the same thing
@@ -2388,11 +2539,14 @@ def _allow_only(allowed_values):
         # Ensure that the new value is in the list of allowed values
         if new_value not in allowed_values:
 
-            err_msg = (f'Attempted to set {instance.__class__.__name__}.{attr.name} '
-                       f'to {new_value}. Currently, only the following values '
-                       f'are supported: {sorted(allowed_values)}.')
+            err_msg = (
+                f"Attempted to set {instance.__class__.__name__}.{attr.name} "
+                f"to {new_value}. Currently, only the following values "
+                f"are supported: {sorted(allowed_values)}."
+            )
             raise SMIRNOFFSpecError(err_msg)
         return new_value
+
     return _value_checker
 
 
@@ -2409,8 +2563,8 @@ class ProperTorsionHandler(ParameterHandler):
         .. warning :: This API is experimental and subject to change.
         """
 
-        _VALENCE_TYPE = 'ProperTorsion'
-        _ELEMENT_NAME = 'Proper'
+        _VALENCE_TYPE = "ProperTorsion"
+        _ELEMENT_NAME = "Proper"
 
         periodicity = IndexedParameterAttribute(converter=int)
         phase = IndexedParameterAttribute(unit=unit.degree)
@@ -2418,24 +2572,24 @@ class ProperTorsionHandler(ParameterHandler):
         idivf = IndexedParameterAttribute(default=None, converter=float)
 
         # fractional bond order params
-        k_bondorder = IndexedMappedParameterAttribute(default=None,
-                                                      unit=unit.kilocalorie_per_mole)
+        k_bondorder = IndexedMappedParameterAttribute(
+            default=None, unit=unit.kilocalorie_per_mole
+        )
 
-    _TAGNAME = 'ProperTorsions'  # SMIRNOFF tag name to process
-    _KWARGS = ['partial_bond_orders_from_molecules']
+    _TAGNAME = "ProperTorsions"  # SMIRNOFF tag name to process
+    _KWARGS = ["partial_bond_orders_from_molecules"]
     _INFOTYPE = ProperTorsionType  # info type to store
     _OPENMMTYPE = openmm.PeriodicTorsionForce  # OpenMM force class to create
 
     potential = ParameterAttribute(
-        default='k*(1+cos(periodicity*theta-phase))',
-        converter=_allow_only(['k*(1+cos(periodicity*theta-phase))'])
+        default="k*(1+cos(periodicity*theta-phase))",
+        converter=_allow_only(["k*(1+cos(periodicity*theta-phase))"]),
     )
-    default_idivf = ParameterAttribute(default='auto')
-    fractional_bondorder_method = ParameterAttribute(default='AM1-Wiberg')
-    fractional_bondorder_interpolation = ParameterAttribute(default='linear')
+    default_idivf = ParameterAttribute(default="auto")
+    fractional_bondorder_method = ParameterAttribute(default="AM1-Wiberg")
+    fractional_bondorder_interpolation = ParameterAttribute(default="linear")
 
-    def check_handler_compatibility(self,
-                                    other_handler):
+    def check_handler_compatibility(self, other_handler):
         """
         Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
@@ -2450,22 +2604,29 @@ class ProperTorsionHandler(ParameterHandler):
         IncompatibleParameterError if handler_kwargs are incompatible with existing parameters.
         """
         float_attrs_to_compare = []
-        string_attrs_to_compare = ['potential',
-                                   'fractional_bondorder_method',
-                                   'fractional_bondorder_interpolation']
+        string_attrs_to_compare = [
+            "potential",
+            "fractional_bondorder_method",
+            "fractional_bondorder_interpolation",
+        ]
 
-        if self.default_idivf == 'auto':
-            string_attrs_to_compare.append('default_idivf')
+        if self.default_idivf == "auto":
+            string_attrs_to_compare.append("default_idivf")
         else:
-            float_attrs_to_compare.append('default_idivf')
+            float_attrs_to_compare.append("default_idivf")
 
-        self._check_attributes_are_equal(other_handler, identical_attrs=string_attrs_to_compare,
-                                         tolerance_attrs=float_attrs_to_compare)
+        self._check_attributes_are_equal(
+            other_handler,
+            identical_attrs=string_attrs_to_compare,
+            tolerance_attrs=float_attrs_to_compare,
+        )
 
     def check_partial_bond_orders_from_molecules_duplicates(self, pb_mols):
         if len(set(map(Molecule.to_smiles, pb_mols))) < len(pb_mols):
-            raise ValueError("At least two user-provided fractional bond order "
-                             "molecules are isomorphic")
+            raise ValueError(
+                "At least two user-provided fractional bond order "
+                "molecules are isomorphic"
+            )
 
     def assign_partial_bond_orders_from_molecules(self, topology, pbo_mols):
 
@@ -2475,13 +2636,16 @@ class ProperTorsionHandler(ParameterHandler):
             for pbo_mol in pbo_mols:
                 # we are as stringent as we are in the ElectrostaticsHandler
                 # TODO: figure out whether bond order matching is redundant with aromatic matching
-                isomorphic, topology_atom_map = Molecule.are_isomorphic(ref_mol, pbo_mol,
-                                                                        return_atom_map=True,
-                                                                        aromatic_matching=True,
-                                                                        formal_charge_matching=True,
-                                                                        bond_order_matching=True,
-                                                                        atom_stereochemistry_matching=True,
-                                                                        bond_stereochemistry_matching=True)
+                isomorphic, topology_atom_map = Molecule.are_isomorphic(
+                    ref_mol,
+                    pbo_mol,
+                    return_atom_map=True,
+                    aromatic_matching=True,
+                    formal_charge_matching=True,
+                    bond_order_matching=True,
+                    atom_stereochemistry_matching=True,
+                    bond_stereochemistry_matching=True,
+                )
 
                 # if matching, assign bond orders and skip to next molecule
                 # first match wins
@@ -2489,14 +2653,18 @@ class ProperTorsionHandler(ParameterHandler):
                     # walk through bonds on reference molecule
                     for bond in ref_mol.bonds:
                         # use atom mapping to translate to pbo_molecule bond
-                        pbo_bond = pbo_mol.get_bond_between(topology_atom_map[bond.atom1_index],
-                                                            topology_atom_map[bond.atom2_index])
+                        pbo_bond = pbo_mol.get_bond_between(
+                            topology_atom_map[bond.atom1_index],
+                            topology_atom_map[bond.atom2_index],
+                        )
                         # extract fractional bond order
                         # assign fractional bond order to reference molecule bond
                         if pbo_bond.fractional_bond_order is None:
-                            raise ValueError(f"Molecule '{ref_mol}' was requested to be parameterized "
-                                    f"with user-provided fractional bond orders from '{pbo_mol}', but not "
-                                    "all bonds were provided with `fractional_bond_order` specified")
+                            raise ValueError(
+                                f"Molecule '{ref_mol}' was requested to be parameterized "
+                                f"with user-provided fractional bond orders from '{pbo_mol}', but not "
+                                "all bonds were provided with `fractional_bond_order` specified"
+                            )
 
                         bond.fractional_bond_order = pbo_bond.fractional_bond_order
 
@@ -2506,7 +2674,7 @@ class ProperTorsionHandler(ParameterHandler):
                     continue
 
     def create_force(self, system, topology, **kwargs):
-        #force = super(ProperTorsionHandler, self).create_force(system, topology, **kwargs)
+        # force = super(ProperTorsionHandler, self).create_force(system, topology, **kwargs)
         existing = [system.getForce(i) for i in range(system.getNumForces())]
         existing = [f for f in existing if type(f) == self._OPENMMTYPE]
 
@@ -2518,12 +2686,16 @@ class ProperTorsionHandler(ParameterHandler):
 
         # check whether any of the reference molecules in the topology
         # are in the partial_bond_orders_from_molecules list
-        if 'partial_bond_orders_from_molecules' in kwargs:
+        if "partial_bond_orders_from_molecules" in kwargs:
             # check whether molecules in the partial_bond_orders_from_molecules
             # list have any duplicates
-            self.check_partial_bond_orders_from_molecules_duplicates(kwargs['partial_bond_orders_from_molecules'])
+            self.check_partial_bond_orders_from_molecules_duplicates(
+                kwargs["partial_bond_orders_from_molecules"]
+            )
 
-            self.assign_partial_bond_orders_from_molecules(topology, kwargs['partial_bond_orders_from_molecules'])
+            self.assign_partial_bond_orders_from_molecules(
+                topology, kwargs["partial_bond_orders_from_molecules"]
+            )
 
         # find all proper torsions for which we have parameters
         # operates on reference molecules in topology
@@ -2536,21 +2708,23 @@ class ProperTorsionHandler(ParameterHandler):
             self._assert_correct_connectivity(torsion_match)
 
             if torsion_match.parameter_type.k_bondorder is None:
-                # TODO: add a check here that we have same number of terms for 
+                # TODO: add a check here that we have same number of terms for
                 # `kX_bondorder*`, `periodicityX`, `phaseX`
                 # only count a given `kX_bondorder*` once
 
                 # assign torsion with no interpolation
                 self._assign_torsion(atom_indices, torsion_match, force)
             else:
-                # TODO: add a check here that we have same number of terms for 
+                # TODO: add a check here that we have same number of terms for
                 # `kX_bondorder*`, `periodicityX`, `phaseX`
                 # only count a given `kX_bondorder*` once
 
                 # assign torsion with interpolation
-                self._assign_fractional_bond_orders(atom_indices, torsion_match, force, **kwargs)
+                self._assign_fractional_bond_orders(
+                    atom_indices, torsion_match, force, **kwargs
+                )
 
-        logger.info('{} torsions added'.format(len(torsion_matches)))
+        logger.info("{} torsions added".format(len(torsion_matches)))
 
         # Check that no topological torsions are missing force parameters
 
@@ -2561,80 +2735,113 @@ class ProperTorsionHandler(ParameterHandler):
         # is focused on the single unique molecules, and then simply just cloned
         # onto the system. It seems like John's proposed System object would do
         # exactly this.
-        self._check_all_valence_terms_assigned(assigned_terms=torsion_matches,
-                                               valence_terms=list(topology.propers),
-                                               exception_cls=UnassignedProperTorsionParameterException)
+        self._check_all_valence_terms_assigned(
+            assigned_terms=torsion_matches,
+            valence_terms=list(topology.propers),
+            exception_cls=UnassignedProperTorsionParameterException,
+        )
 
     def _assign_torsion(self, atom_indices, torsion_match, force):
 
         torsion_params = torsion_match.parameter_type
 
-        for (periodicity, phase, k, idivf) in zip(torsion_params.periodicity,
-                                                  torsion_params.phase,
-                                                  torsion_params.k,
-                                                  torsion_params.idivf):
-            
-            if idivf == 'auto':
+        for (periodicity, phase, k, idivf) in zip(
+            torsion_params.periodicity,
+            torsion_params.phase,
+            torsion_params.k,
+            torsion_params.idivf,
+        ):
+
+            if idivf == "auto":
                 # TODO: Implement correct "auto" behavior
-                raise NotImplementedError("The OpenForceField toolkit hasn't implemented "
-                                          "support for the torsion `idivf` value of 'auto'")
-        
-            force.addTorsion(atom_indices[0], atom_indices[1],
-                             atom_indices[2], atom_indices[3], periodicity,
-                             phase, k/idivf)
+                raise NotImplementedError(
+                    "The OpenForceField toolkit hasn't implemented "
+                    "support for the torsion `idivf` value of 'auto'"
+                )
 
+            force.addTorsion(
+                atom_indices[0],
+                atom_indices[1],
+                atom_indices[2],
+                atom_indices[3],
+                periodicity,
+                phase,
+                k / idivf,
+            )
 
-    def _assign_fractional_bond_orders(self, atom_indices, torsion_match, force, **kwargs):
+    def _assign_fractional_bond_orders(
+        self, atom_indices, torsion_match, force, **kwargs
+    ):
         from openforcefield.utils.toolkits import GLOBAL_TOOLKIT_REGISTRY
 
         torsion_params = torsion_match.parameter_type
         match = torsion_match.environment_match
 
-        for (periodicity, phase, k_bondorder, idivf) in zip(torsion_params.periodicity,
-                                                            torsion_params.phase,
-                                                            torsion_params.k_bondorder,
-                                                            torsion_params.idivf):
+        for (periodicity, phase, k_bondorder, idivf) in zip(
+            torsion_params.periodicity,
+            torsion_params.phase,
+            torsion_params.k_bondorder,
+            torsion_params.idivf,
+        ):
 
             if len(k_bondorder) < 2:
-                raise ValueError("At least 2 bond order values required for `k_bondorder`; "
-                                 "got {}".format(len(k_bondorder)))
+                raise ValueError(
+                    "At least 2 bond order values required for `k_bondorder`; "
+                    "got {}".format(len(k_bondorder))
+                )
 
-            if idivf == 'auto':
+            if idivf == "auto":
                 # TODO: Implement correct "auto" behavior
-                raise NotImplementedError("The OpenForceField toolkit hasn't implemented "
-                                          "support for the torsion `idivf` value of 'auto'")
+                raise NotImplementedError(
+                    "The OpenForceField toolkit hasn't implemented "
+                    "support for the torsion `idivf` value of 'auto'"
+                )
 
             # get central bond for reference molecule
             central_bond = match.reference_molecule.get_bond_between(
-                    match.reference_atom_indices[1], match.reference_atom_indices[2])
+                match.reference_atom_indices[1], match.reference_atom_indices[2]
+            )
 
             # if fractional bond order not calculated yet, we calculate it
             # should only happen once per reference molecule for which we care
             # about fractional bond interpolation
             # and not at all for reference molecules we don't
             if central_bond.fractional_bond_order is None:
-                    toolkit_registry = kwargs.get('toolkit_registry', GLOBAL_TOOLKIT_REGISTRY)
-                    match.reference_molecule.assign_fractional_bond_orders(
-                            toolkit_registry=toolkit_registry,
-                            use_conformers=match.reference_molecule.conformers)
+                toolkit_registry = kwargs.get(
+                    "toolkit_registry", GLOBAL_TOOLKIT_REGISTRY
+                )
+                match.reference_molecule.assign_fractional_bond_orders(
+                    toolkit_registry=toolkit_registry,
+                    use_conformers=match.reference_molecule.conformers,
+                )
 
             # scale k based on the bondorder of the central bond
-            if self.fractional_bondorder_interpolation == 'linear':
+            if self.fractional_bondorder_interpolation == "linear":
                 # we only interpolate on k
-                k = self._linear_interpolate_k(k_bondorder, central_bond.fractional_bond_order)
+                k = self._linear_interpolate_k(
+                    k_bondorder, central_bond.fractional_bond_order
+                )
             else:
                 raise Exception(
-                    "Fractional bondorder treatment {} is not implemented.".
-                    format(self.fractional_bondorder_method))
-                
+                    "Fractional bondorder treatment {} is not implemented.".format(
+                        self.fractional_bondorder_method
+                    )
+                )
+
             # add a torsion with given parameters for topology atoms
-            force.addTorsion(atom_indices[0], atom_indices[1],
-                             atom_indices[2], atom_indices[3], periodicity,
-                             phase, k/idivf)
+            force.addTorsion(
+                atom_indices[0],
+                atom_indices[1],
+                atom_indices[2],
+                atom_indices[3],
+                periodicity,
+                phase,
+                k / idivf,
+            )
 
     @staticmethod
     def _linear_interpolate_k(k_bondorder, fractional_bond_order):
-        
+
         # pre-empt case where no interpolation is necessary
         if fractional_bond_order in k_bondorder:
             return k_bondorder[fractional_bond_order]
@@ -2655,33 +2862,34 @@ class ProperTorsionHandler(ParameterHandler):
 
         # handle case where we can clearly interpolate
         if (above is not None) and (below is not None):
-            return (k_bondorder[below]
-                    + (k_bondorder[above] - k_bondorder[below])
-                    * ((fractional_bond_order - below)/(above - below)))
+            return k_bondorder[below] + (k_bondorder[above] - k_bondorder[below]) * (
+                (fractional_bond_order - below) / (above - below)
+            )
 
         # error if we can't hope to interpolate at all
         elif (above is None) and (below is None):
             raise NotImplementedError(
-                    f"Failed to find interpolation references for "
-                    f"`fractional bond order` '{fractional_bond_order}', "
-                    f"with `k_bond_order` '{k_bondorder}'")
+                f"Failed to find interpolation references for "
+                f"`fractional bond order` '{fractional_bond_order}', "
+                f"with `k_bond_order` '{k_bondorder}'"
+            )
 
         # extrapolate for fractional bond orders below our lowest defined bond order
         elif below is None:
             bond_orders = sorted(k_bondorder)
-            k = (k_bondorder[bond_orders[0]]
-                    - ((k_bondorder[bond_orders[1]] - k_bondorder[bond_orders[0]])
-                       /(bond_orders[1] - bond_orders[0]))
-                    * (bond_orders[0] - fractional_bond_order))
+            k = k_bondorder[bond_orders[0]] - (
+                (k_bondorder[bond_orders[1]] - k_bondorder[bond_orders[0]])
+                / (bond_orders[1] - bond_orders[0])
+            ) * (bond_orders[0] - fractional_bond_order)
             return k
 
         # extrapolate for fractional bond orders above our highest defined bond order
         elif above is None:
             bond_orders = sorted(k_bondorder)
-            k = (k_bondorder[bond_orders[-1]]
-                    + ((k_bondorder[bond_orders[-1]] - k_bondorder[bond_orders[-2]])
-                       /(bond_orders[-1] - bond_orders[-2]))
-                    * (fractional_bond_order - bond_orders[-1]))
+            k = k_bondorder[bond_orders[-1]] + (
+                (k_bondorder[bond_orders[-1]] - k_bondorder[bond_orders[-2]])
+                / (bond_orders[-1] - bond_orders[-2])
+            ) * (fractional_bond_order - bond_orders[-1])
             return k
 
 
@@ -2697,27 +2905,26 @@ class ImproperTorsionHandler(ParameterHandler):
 
         .. warning :: This API is experimental and subject to change.
         """
-        _VALENCE_TYPE = 'ImproperTorsion'
-        _ELEMENT_NAME = 'Improper'
+
+        _VALENCE_TYPE = "ImproperTorsion"
+        _ELEMENT_NAME = "Improper"
 
         periodicity = IndexedParameterAttribute(converter=int)
         phase = IndexedParameterAttribute(unit=unit.degree)
         k = IndexedParameterAttribute(unit=unit.kilocalorie_per_mole)
         idivf = IndexedParameterAttribute(default=None, converter=float)
 
-
-    _TAGNAME = 'ImproperTorsions'  # SMIRNOFF tag name to process
+    _TAGNAME = "ImproperTorsions"  # SMIRNOFF tag name to process
     _INFOTYPE = ImproperTorsionType  # info type to store
     _OPENMMTYPE = openmm.PeriodicTorsionForce  # OpenMM force class to create
 
     potential = ParameterAttribute(
-        default='k*(1+cos(periodicity*theta-phase))',
-        converter=_allow_only(['k*(1+cos(periodicity*theta-phase))'])
+        default="k*(1+cos(periodicity*theta-phase))",
+        converter=_allow_only(["k*(1+cos(periodicity*theta-phase))"]),
     )
-    default_idivf = ParameterAttribute(default='auto')
+    default_idivf = ParameterAttribute(default="auto")
 
-    def check_handler_compatibility(self,
-                                    other_handler):
+    def check_handler_compatibility(self, other_handler):
         """
         Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
@@ -2732,15 +2939,18 @@ class ImproperTorsionHandler(ParameterHandler):
         IncompatibleParameterError if handler_kwargs are incompatible with existing parameters.
         """
         float_attrs_to_compare = []
-        string_attrs_to_compare = ['potential']
+        string_attrs_to_compare = ["potential"]
 
-        if self.default_idivf == 'auto':
-            string_attrs_to_compare.append('default_idivf')
+        if self.default_idivf == "auto":
+            string_attrs_to_compare.append("default_idivf")
         else:
-            float_attrs_to_compare.append('default_idivf')
+            float_attrs_to_compare.append("default_idivf")
 
-        self._check_attributes_are_equal(other_handler, identical_attrs=string_attrs_to_compare,
-                                         tolerance_attrs=float_attrs_to_compare)
+        self._check_attributes_are_equal(
+            other_handler,
+            identical_attrs=string_attrs_to_compare,
+            tolerance_attrs=float_attrs_to_compare,
+        )
 
     def find_matches(self, entity):
         """Find the improper torsions in the topology/molecule matched by a parameter type.
@@ -2760,12 +2970,10 @@ class ImproperTorsionHandler(ParameterHandler):
         return self._find_matches(entity, transformed_dict_cls=ImproperDict)
 
     def create_force(self, system, topology, **kwargs):
-        #force = super(ImproperTorsionHandler, self).create_force(system, topology, **kwargs)
-        #force = super().create_force(system, topology, **kwargs)
+        # force = super(ImproperTorsionHandler, self).create_force(system, topology, **kwargs)
+        # force = super().create_force(system, topology, **kwargs)
         existing = [system.getForce(i) for i in range(system.getNumForces())]
-        existing = [
-            f for f in existing if type(f) == openmm.PeriodicTorsionForce
-        ]
+        existing = [f for f in existing if type(f) == openmm.PeriodicTorsionForce]
         if len(existing) == 0:
             force = openmm.PeriodicTorsionForce()
             system.addForce(force)
@@ -2787,28 +2995,47 @@ class ImproperTorsionHandler(ParameterHandler):
             if improper.idivf is None:
                 improper.idivf = [3 for item in improper.k]
             # Impropers are applied in three paths around the trefoil having the same handedness
-            for (improper_periodicity, improper_phase, improper_k, improper_idivf) in zip(improper.periodicity,
-                                               improper.phase, improper.k, improper.idivf):
+            for (
+                improper_periodicity,
+                improper_phase,
+                improper_k,
+                improper_idivf,
+            ) in zip(improper.periodicity, improper.phase, improper.k, improper.idivf):
                 # TODO: Implement correct "auto" behavior
-                if improper_idivf == 'auto':
+                if improper_idivf == "auto":
                     improper_idivf = 3
-                    logger.warning("The OpenForceField toolkit hasn't implemented "
-                                   "support for the torsion `idivf` value of 'auto'."
-                                   "Currently assuming a value of '3' for impropers.")
+                    logger.warning(
+                        "The OpenForceField toolkit hasn't implemented "
+                        "support for the torsion `idivf` value of 'auto'."
+                        "Currently assuming a value of '3' for impropers."
+                    )
                 # Permute non-central atoms
                 others = [atom_indices[0], atom_indices[2], atom_indices[3]]
                 # ((0, 1, 2), (1, 2, 0), and (2, 0, 1)) are the three paths around the trefoil
-                for p in [(others[i], others[j], others[k]) for (i, j, k) in [(0, 1, 2), (1, 2, 0), (2, 0, 1)]]:
+                for p in [
+                    (others[i], others[j], others[k])
+                    for (i, j, k) in [(0, 1, 2), (1, 2, 0), (2, 0, 1)]
+                ]:
                     # The torsion force gets added three times, since the k is divided by three
-                    force.addTorsion(atom_indices[1], p[0], p[1], p[2],
-                                     improper_periodicity, improper_phase, improper_k/improper_idivf)
+                    force.addTorsion(
+                        atom_indices[1],
+                        p[0],
+                        p[1],
+                        p[2],
+                        improper_periodicity,
+                        improper_phase,
+                        improper_k / improper_idivf,
+                    )
         logger.info(
-            '{} impropers added, each applied in a six-fold trefoil'.format(
-                len(improper_matches)))
+            "{} impropers added, each applied in a six-fold trefoil".format(
+                len(improper_matches)
+            )
+        )
 
 
 class _NonbondedHandler(ParameterHandler):
     """Base class for ParameterHandlers that deal with OpenMM NonbondedForce objects."""
+
     _OPENMMTYPE = openmm.NonbondedForce
 
     def create_force(self, system, topology, **kwargs):
@@ -2817,7 +3044,9 @@ class _NonbondedHandler(ParameterHandler):
         # TODO: This should be an attribute of the _system_, not the _topology_. However, since we're still using
         #  OpenMM's System class, I am storing this data on the OFF Topology until we make an OFF System class.
         if not hasattr(topology, "_ref_mol_to_charge_method"):
-            topology._ref_mol_to_charge_method = {ref_mol: None for ref_mol in topology.reference_molecules}
+            topology._ref_mol_to_charge_method = {
+                ref_mol: None for ref_mol in topology.reference_molecules
+            }
 
         # Retrieve the system's OpenMM NonbondedForce
         existing = [system.getForce(i) for i in range(system.getNumForces())]
@@ -2878,22 +3107,22 @@ class vdWHandler(_NonbondedHandler):
     .. warning :: This API is experimental and subject to change.
     """
 
-
     class vdWType(ParameterType):
         """A SMIRNOFF vdWForce type.
 
         .. warning :: This API is experimental and subject to change.
         """
-        _VALENCE_TYPE = 'Atom'  # ChemicalEnvironment valence type expected for SMARTS
-        _ELEMENT_NAME = 'Atom'
+
+        _VALENCE_TYPE = "Atom"  # ChemicalEnvironment valence type expected for SMARTS
+        _ELEMENT_NAME = "Atom"
 
         epsilon = ParameterAttribute(unit=unit.kilocalorie_per_mole)
         sigma = ParameterAttribute(default=None, unit=unit.angstrom)
         rmin_half = ParameterAttribute(default=None, unit=unit.angstrom)
 
         def __init__(self, **kwargs):
-            sigma = kwargs.get('sigma', None)
-            rmin_half = kwargs.get('rmin_half', None)
+            sigma = kwargs.get("sigma", None)
+            rmin_half = kwargs.get("rmin_half", None)
             if (sigma is None) and (rmin_half is None):
                 raise SMIRNOFFSpecError("Either sigma or rmin_half must be specified.")
             if (sigma is not None) and (rmin_half is not None):
@@ -2903,19 +3132,17 @@ class vdWHandler(_NonbondedHandler):
 
             super().__init__(**kwargs)
 
-    _TAGNAME = 'vdW'  # SMIRNOFF tag name to process
+    _TAGNAME = "vdW"  # SMIRNOFF tag name to process
     _INFOTYPE = vdWType  # info type to store
     # _KWARGS = ['ewaldErrorTolerance',
     #            'useDispersionCorrection',
     #            'usePbc'] # Kwargs to catch when create_force is called
 
     potential = ParameterAttribute(
-        default='Lennard-Jones-12-6',
-        converter=_allow_only(['Lennard-Jones-12-6'])
+        default="Lennard-Jones-12-6", converter=_allow_only(["Lennard-Jones-12-6"])
     )
     combining_rules = ParameterAttribute(
-        default='Lorentz-Berthelot',
-        converter=_allow_only(['Lorentz-Berthelot'])
+        default="Lorentz-Berthelot", converter=_allow_only(["Lorentz-Berthelot"])
     )
 
     scale12 = ParameterAttribute(default=0.0, converter=float)
@@ -2926,37 +3153,41 @@ class vdWHandler(_NonbondedHandler):
     cutoff = ParameterAttribute(default=9.0 * unit.angstroms, unit=unit.angstrom)
     switch_width = ParameterAttribute(default=1.0 * unit.angstroms, unit=unit.angstrom)
     method = ParameterAttribute(
-        default='cutoff',
-        converter=_allow_only(['cutoff', 'PME'])
+        default="cutoff", converter=_allow_only(["cutoff", "PME"])
     )
 
     # TODO: Use _allow_only when ParameterAttribute will support multiple converters (it'll be easy when we switch to use the attrs library)
     @scale12.converter
     def scale12(self, attrs, new_scale12):
         if new_scale12 != 0.0:
-            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale12 values other than 0.0. "
-                                    "Specified 1-2 scaling was {}".format(self._scale12))
+            raise SMIRNOFFSpecError(
+                "Current OFF toolkit is unable to handle scale12 values other than 0.0. "
+                "Specified 1-2 scaling was {}".format(self._scale12)
+            )
         return new_scale12
 
     @scale13.converter
     def scale13(self, attrs, new_scale13):
         if new_scale13 != 0.0:
-            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale13 values other than 0.0. "
-                                    "Specified 1-3 scaling was {}".format(self._scale13))
+            raise SMIRNOFFSpecError(
+                "Current OFF toolkit is unable to handle scale13 values other than 0.0. "
+                "Specified 1-3 scaling was {}".format(self._scale13)
+            )
         return new_scale13
 
     @scale15.converter
     def scale15(self, attrs, new_scale15):
         if new_scale15 != 1.0:
-            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale15 values other than 1.0. "
-                                    "Specified 1-5 scaling was {}".format(self._scale15))
+            raise SMIRNOFFSpecError(
+                "Current OFF toolkit is unable to handle scale15 values other than 1.0. "
+                "Specified 1-5 scaling was {}".format(self._scale15)
+            )
         return new_scale15
 
     # Tolerance when comparing float attributes for handler compatibility.
     _SCALETOL = 1e-5
 
-    def check_handler_compatibility(self,
-                                    other_handler):
+    def check_handler_compatibility(self, other_handler):
         """
         Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
@@ -2970,34 +3201,37 @@ class vdWHandler(_NonbondedHandler):
         ------
         IncompatibleParameterError if handler_kwargs are incompatible with existing parameters.
         """
-        float_attrs_to_compare = ['scale12', 'scale13', 'scale14', 'scale15']
-        string_attrs_to_compare = ['potential', 'combining_rules', 'method']
-        unit_attrs_to_compare = ['cutoff']
+        float_attrs_to_compare = ["scale12", "scale13", "scale14", "scale15"]
+        string_attrs_to_compare = ["potential", "combining_rules", "method"]
+        unit_attrs_to_compare = ["cutoff"]
 
-        self._check_attributes_are_equal(other_handler, identical_attrs=string_attrs_to_compare,
-                                         tolerance_attrs=float_attrs_to_compare+unit_attrs_to_compare,
-                                         tolerance=self._SCALETOL)
+        self._check_attributes_are_equal(
+            other_handler,
+            identical_attrs=string_attrs_to_compare,
+            tolerance_attrs=float_attrs_to_compare + unit_attrs_to_compare,
+            tolerance=self._SCALETOL,
+        )
 
     def create_force(self, system, topology, **kwargs):
         force = super().create_force(system, topology, **kwargs)
 
         # If we're using PME, then the only possible openMM Nonbonded type is LJPME
-        if self._method == 'PME':
+        if self._method == "PME":
             # If we're given a nonperiodic box, we always set NoCutoff. Later we'll add support for CutoffNonPeriodic
-            if (topology.box_vectors is None):
+            if topology.box_vectors is None:
                 force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
                 # if (topology.box_vectors is None):
                 #     raise SMIRNOFFSpecError("If vdW method is  PME, a periodic Topology "
                 #                             "must be provided")
             else:
                 force.setNonbondedMethod(openmm.NonbondedForce.LJPME)
-                force.setCutoffDistance(9. * unit.angstrom)
-                force.setEwaldErrorTolerance(1.e-4)
+                force.setCutoffDistance(9.0 * unit.angstrom)
+                force.setEwaldErrorTolerance(1.0e-4)
 
         # If method is cutoff, then we currently support openMM's PME for periodic system and NoCutoff for nonperiodic
-        elif self._method == 'cutoff':
+        elif self._method == "cutoff":
             # If we're given a nonperiodic box, we always set NoCutoff. Later we'll add support for CutoffNonPeriodic
-            if (topology.box_vectors is None):
+            if topology.box_vectors is None:
                 force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
             else:
                 force.setNonbondedMethod(openmm.NonbondedForce.PME)
@@ -3007,21 +3241,20 @@ class vdWHandler(_NonbondedHandler):
         # Iterate over all defined Lennard-Jones types, allowing later matches to override earlier ones.
         atom_matches = self.find_matches(topology)
 
-
         # Set the particle Lennard-Jones terms.
         for atom_key, atom_match in atom_matches.items():
             atom_idx = atom_key[0]
             ljtype = atom_match.parameter_type
             if ljtype.sigma is None:
-                sigma = 2. * ljtype.rmin_half / (2.**(1. / 6.))
+                sigma = 2.0 * ljtype.rmin_half / (2.0 ** (1.0 / 6.0))
             else:
                 sigma = ljtype.sigma
-            force.setParticleParameters(atom_idx, 0.0, sigma,
-                                        ljtype.epsilon)
+            force.setParticleParameters(atom_idx, 0.0, sigma, ljtype.epsilon)
 
         # Check that no atoms (n.b. not particles) are missing force parameters.
-        self._check_all_valence_terms_assigned(assigned_terms=atom_matches,
-                                               valence_terms=list(topology.topology_atoms))
+        self._check_all_valence_terms_assigned(
+            assigned_terms=atom_matches, valence_terms=list(topology.topology_atoms)
+        )
 
     # TODO: Can we express separate constraints for postprocessing and normal processing?
     def postprocess_system(self, system, topology, **kwargs):
@@ -3036,8 +3269,12 @@ class vdWHandler(_NonbondedHandler):
 
             for topology_bond in topology_molecule.bonds:
 
-                top_index_1 = topology_molecule._ref_to_top_index[topology_bond.bond.atom1_index]
-                top_index_2 = topology_molecule._ref_to_top_index[topology_bond.bond.atom2_index]
+                top_index_1 = topology_molecule._ref_to_top_index[
+                    topology_bond.bond.atom1_index
+                ]
+                top_index_2 = topology_molecule._ref_to_top_index[
+                    topology_bond.bond.atom2_index
+                ]
 
                 top_index_1 += top_mol_particle_start_index
                 top_index_2 += top_mol_particle_start_index
@@ -3049,12 +3286,13 @@ class vdWHandler(_NonbondedHandler):
             # to prevent interference with other kinds of forces in the future?
             # TODO: Can we generalize this to allow for `CustomNonbondedForce` implementations too?
             if isinstance(force, openmm.NonbondedForce):
-                #nonbonded.createExceptionsFromBonds(bond_particle_indices, self.coulomb14scale, self.lj14scale)
+                # nonbonded.createExceptionsFromBonds(bond_particle_indices, self.coulomb14scale, self.lj14scale)
 
                 # TODO: Don't mess with electrostatic scaling here. Have a separate electrostatics handler.
-                force.createExceptionsFromBonds(bond_particle_indices, 0.83333,
-                                                self._scale14)
-                #force.createExceptionsFromBonds(bond_particle_indices, self.coulomb14scale, self._scale14)
+                force.createExceptionsFromBonds(
+                    bond_particle_indices, 0.83333, self._scale14
+                )
+                # force.createExceptionsFromBonds(bond_particle_indices, self.coulomb14scale, self._scale14)
 
 
 class ElectrostaticsHandler(_NonbondedHandler):
@@ -3062,10 +3300,10 @@ class ElectrostaticsHandler(_NonbondedHandler):
 
     .. warning :: This API is experimental and subject to change.
     """
-    _TAGNAME = 'Electrostatics'
-    _DEPENDENCIES = [vdWHandler]
-    _KWARGS = ['charge_from_molecules', 'allow_nonintegral_charges']
 
+    _TAGNAME = "Electrostatics"
+    _DEPENDENCIES = [vdWHandler]
+    _KWARGS = ["charge_from_molecules", "allow_nonintegral_charges"]
 
     scale12 = ParameterAttribute(default=0.0, converter=float)
     scale13 = ParameterAttribute(default=0.0, converter=float)
@@ -3074,30 +3312,35 @@ class ElectrostaticsHandler(_NonbondedHandler):
     cutoff = ParameterAttribute(default=9.0 * unit.angstrom, unit=unit.angstrom)
     switch_width = ParameterAttribute(default=0.0 * unit.angstrom, unit=unit.angstrom)
     method = ParameterAttribute(
-        default='PME',
-        converter=_allow_only(['Coulomb', 'PME'])
+        default="PME", converter=_allow_only(["Coulomb", "PME"])
     )
 
     # TODO: Use _allow_only when ParameterAttribute will support multiple converters (it'll be easy when we switch to use the attrs library)
     @scale12.converter
     def scale12(self, attrs, new_scale12):
         if new_scale12 != 0.0:
-            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale12 values other than 0.0. "
-                                    "Specified 1-2 scaling was {}".format(self._scale12))
+            raise SMIRNOFFSpecError(
+                "Current OFF toolkit is unable to handle scale12 values other than 0.0. "
+                "Specified 1-2 scaling was {}".format(self._scale12)
+            )
         return new_scale12
 
     @scale13.converter
     def scale13(self, attrs, new_scale13):
         if new_scale13 != 0.0:
-            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale13 values other than 0.0. "
-                                    "Specified 1-3 scaling was {}".format(self._scale13))
+            raise SMIRNOFFSpecError(
+                "Current OFF toolkit is unable to handle scale13 values other than 0.0. "
+                "Specified 1-3 scaling was {}".format(self._scale13)
+            )
         return new_scale13
 
     @scale15.converter
     def scale15(self, attrs, new_scale15):
         if new_scale15 != 1.0:
-            raise SMIRNOFFSpecError("Current OFF toolkit is unable to handle scale15 values other than 1.0. "
-                                    "Specified 1-5 scaling was {}".format(self._scale15))
+            raise SMIRNOFFSpecError(
+                "Current OFF toolkit is unable to handle scale15 values other than 1.0. "
+                "Specified 1-5 scaling was {}".format(self._scale15)
+            )
         return new_scale15
 
     @switch_width.converter
@@ -3112,8 +3355,7 @@ class ElectrostaticsHandler(_NonbondedHandler):
     # Tolerance when comparing float attributes for handler compatibility.
     _SCALETOL = 1e-5
 
-    def check_handler_compatibility(self,
-                                    other_handler):
+    def check_handler_compatibility(self, other_handler):
         """
         Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
@@ -3127,14 +3369,16 @@ class ElectrostaticsHandler(_NonbondedHandler):
         ------
         IncompatibleParameterError if handler_kwargs are incompatible with existing parameters.
         """
-        float_attrs_to_compare = ['scale12', 'scale13', 'scale14', 'scale15']
-        string_attrs_to_compare = ['method']
-        unit_attrs_to_compare = ['cutoff', 'switch_width']
+        float_attrs_to_compare = ["scale12", "scale13", "scale14", "scale15"]
+        string_attrs_to_compare = ["method"]
+        unit_attrs_to_compare = ["cutoff", "switch_width"]
 
-        self._check_attributes_are_equal(other_handler, identical_attrs=string_attrs_to_compare,
-                                         tolerance_attrs=float_attrs_to_compare+unit_attrs_to_compare,
-                                         tolerance=self._SCALETOL)
-
+        self._check_attributes_are_equal(
+            other_handler,
+            identical_attrs=string_attrs_to_compare,
+            tolerance_attrs=float_attrs_to_compare + unit_attrs_to_compare,
+            tolerance=self._SCALETOL,
+        )
 
     def assign_charge_from_molecules(self, molecule, charge_mols):
         """
@@ -3158,19 +3402,24 @@ class ElectrostaticsHandler(_NonbondedHandler):
 
         # Check each charge_mol for whether it's isomorphic to the input molecule
         for charge_mol in charge_mols:
-            ismorphic, topology_atom_map = Molecule.are_isomorphic(molecule, charge_mol,
-                                                                   return_atom_map=True,
-                                                                   aromatic_matching=True,
-                                                                   formal_charge_matching=True,
-                                                                   bond_order_matching=True,
-                                                                   atom_stereochemistry_matching=True,
-                                                                   bond_stereochemistry_matching=True)
+            ismorphic, topology_atom_map = Molecule.are_isomorphic(
+                molecule,
+                charge_mol,
+                return_atom_map=True,
+                aromatic_matching=True,
+                formal_charge_matching=True,
+                bond_order_matching=True,
+                atom_stereochemistry_matching=True,
+                bond_stereochemistry_matching=True,
+            )
             # if they are isomorphic then use the mapping
             if ismorphic:
                 # Take the first valid atom indexing map
                 # Set the partial charges
                 # Make a copy of the charge molecule's charges array (this way it's the right shape)
-                temp_mol_charges = copy.deepcopy(simtk.unit.Quantity(charge_mol.partial_charges))
+                temp_mol_charges = copy.deepcopy(
+                    simtk.unit.Quantity(charge_mol.partial_charges)
+                )
                 for charge_idx, ref_idx in topology_atom_map.items():
                     temp_mol_charges[ref_idx] = charge_mol.partial_charges[charge_idx]
                 molecule.partial_charges = temp_mol_charges
@@ -3180,7 +3429,11 @@ class ElectrostaticsHandler(_NonbondedHandler):
         return False
 
     def create_force(self, system, topology, **kwargs):
-        from openforcefield.topology import FrozenMolecule, TopologyAtom, TopologyVirtualSite
+        from openforcefield.topology import (
+            FrozenMolecule,
+            TopologyAtom,
+            TopologyVirtualSite,
+        )
 
         force = super().create_force(system, topology, **kwargs)
 
@@ -3193,37 +3446,48 @@ class ElectrostaticsHandler(_NonbondedHandler):
 
             # First, check whether any of the reference molecules in the topology are in the charge_from_mol list
             charges_from_charge_mol = False
-            if 'charge_from_molecules' in kwargs:
-                charges_from_charge_mol = self.assign_charge_from_molecules(ref_mol, kwargs['charge_from_molecules'])
+            if "charge_from_molecules" in kwargs:
+                charges_from_charge_mol = self.assign_charge_from_molecules(
+                    ref_mol, kwargs["charge_from_molecules"]
+                )
 
             # If this reference molecule wasn't in the charge_from_molecules list, end this iteration
-            if not(charges_from_charge_mol):
+            if not (charges_from_charge_mol):
                 continue
 
             # Otherwise, the molecule is in the charge_from_molecules list, and we should assign charges to all
             # instances of it in this topology.
-            for topology_molecule in topology._reference_molecule_to_topology_molecules[ref_mol]:
-
+            for topology_molecule in topology._reference_molecule_to_topology_molecules[
+                ref_mol
+            ]:
 
                 for topology_particle in topology_molecule.particles:
 
                     if type(topology_particle) is TopologyAtom:
-                        ref_mol_particle_index = topology_particle.atom.molecule_particle_index
+                        ref_mol_particle_index = (
+                            topology_particle.atom.molecule_particle_index
+                        )
                     elif type(topology_particle) is TopologyVirtualSite:
-                        ref_mol_particle_index = topology_particle.virtual_site.molecule_particle_index
+                        ref_mol_particle_index = (
+                            topology_particle.virtual_site.molecule_particle_index
+                        )
                     else:
-                        raise ValueError(f'Particles of type {type(topology_particle)} are not supported')
+                        raise ValueError(
+                            f"Particles of type {type(topology_particle)} are not supported"
+                        )
 
                     topology_particle_index = topology_particle.topology_particle_index
 
                     particle_charge = ref_mol._partial_charges[ref_mol_particle_index]
 
                     # Retrieve nonbonded parameters for reference atom (charge not set yet)
-                    _, sigma, epsilon = force.getParticleParameters(topology_particle_index)
+                    _, sigma, epsilon = force.getParticleParameters(
+                        topology_particle_index
+                    )
                     # Set the nonbonded force with the partial charge
-                    force.setParticleParameters(topology_particle_index,
-                                                particle_charge, sigma,
-                                                epsilon)
+                    force.setParticleParameters(
+                        topology_particle_index, particle_charge, sigma, epsilon
+                    )
 
             # Finally, mark that charges were assigned for this reference molecule
             self.mark_charges_assigned(ref_mol, topology)
@@ -3234,13 +3498,17 @@ class ElectrostaticsHandler(_NonbondedHandler):
 
         # First, check whether the vdWHandler set the nonbonded method to LJPME, because that means
         # that electrostatics also has to be PME
-        if (current_nb_method == openmm.NonbondedForce.LJPME) and (self._method != 'PME'):
-            raise IncompatibleParameterError("In current Open Force Field toolkit implementation, if vdW "
-                                             "treatment is set to LJPME, electrostatics must also be PME "
-                                             "(electrostatics treatment currently set to {}".format(self._method))
+        if (current_nb_method == openmm.NonbondedForce.LJPME) and (
+            self._method != "PME"
+        ):
+            raise IncompatibleParameterError(
+                "In current Open Force Field toolkit implementation, if vdW "
+                "treatment is set to LJPME, electrostatics must also be PME "
+                "(electrostatics treatment currently set to {}".format(self._method)
+            )
 
         # Then, set nonbonded methods based on method keyword
-        if self._method == 'PME':
+        if self._method == "PME":
             # Check whether the topology is nonperiodic, in which case we always switch to NoCutoff
             # (vdWHandler will have already set this to NoCutoff)
             # TODO: This is an assumption right now, and a bad one. See issue #219
@@ -3255,41 +3523,48 @@ class ElectrostaticsHandler(_NonbondedHandler):
                     # There's no need to check for matching cutoff/tolerance here since both are hard-coded defaults
                 else:
                     force.setNonbondedMethod(openmm.NonbondedForce.PME)
-                    force.setCutoffDistance(9. * unit.angstrom)
-                    force.setEwaldErrorTolerance(1.e-4)
+                    force.setCutoffDistance(9.0 * unit.angstrom)
+                    force.setEwaldErrorTolerance(1.0e-4)
 
             settings_matched = True
 
         # If vdWHandler set the nonbonded method to NoCutoff, then we don't need to change anything
-        elif self._method == 'Coulomb':
+        elif self._method == "Coulomb":
             if topology.box_vectors is None:
                 # (vdWHandler will have already set this to NoCutoff)
                 assert current_nb_method == openmm.NonbondedForce.NoCutoff
                 settings_matched = True
             else:
-                raise IncompatibleParameterError("Electrostatics method set to Coulomb, and topology is periodic. "
-                                                 "In the future, this will lead to use of OpenMM's CutoffPeriodic "
-                                                 "Nonbonded force method, however this is not supported in the "
-                                                 "current Open Force Field toolkit.")
+                raise IncompatibleParameterError(
+                    "Electrostatics method set to Coulomb, and topology is periodic. "
+                    "In the future, this will lead to use of OpenMM's CutoffPeriodic "
+                    "Nonbonded force method, however this is not supported in the "
+                    "current Open Force Field toolkit."
+                )
 
         # If the vdWHandler set the nonbonded method to PME, then ensure that it has the same cutoff
-        elif self._method == 'reaction-field':
+        elif self._method == "reaction-field":
             if topology.box_vectors is None:
                 # (vdWHandler will have already set this to NoCutoff)
                 assert current_nb_method == openmm.NonbondedForce.NoCutoff
                 settings_matched = True
             else:
-                raise IncompatibleParameterError("Electrostatics method set to reaction-field. In the future, "
-                                                 "this will lead to use of OpenMM's CutoffPeriodic or CutoffNonPeriodic"
-                                                 " Nonbonded force method, however this is not supported in the "
-                                                 "current Open Force Field toolkit")
+                raise IncompatibleParameterError(
+                    "Electrostatics method set to reaction-field. In the future, "
+                    "this will lead to use of OpenMM's CutoffPeriodic or CutoffNonPeriodic"
+                    " Nonbonded force method, however this is not supported in the "
+                    "current Open Force Field toolkit"
+                )
 
         if not settings_matched:
-            raise IncompatibleParameterError("Unable to support provided vdW method, electrostatics "
-                                             "method ({}), and topology periodicity ({}) selections. Additional "
-                                             "options for nonbonded treatment may be added in future versions "
-                                             "of the Open Force Field toolkit.".format(self._method,
-                                                                                topology.box_vectors is not None))
+            raise IncompatibleParameterError(
+                "Unable to support provided vdW method, electrostatics "
+                "method ({}), and topology periodicity ({}) selections. Additional "
+                "options for nonbonded treatment may be added in future versions "
+                "of the Open Force Field toolkit.".format(
+                    self._method, topology.box_vectors is not None
+                )
+            )
 
     def postprocess_system(self, system, topology, **kwargs):
         force = super().create_force(system, topology, **kwargs)
@@ -3305,25 +3580,31 @@ class ElectrostaticsHandler(_NonbondedHandler):
                 msg += f"{ref_mol.to_smiles()}\n"
             raise UnassignedMoleculeChargeException(msg)
 
-
         # Unless check is disabled, ensure that the sum of partial charges on a molecule
         # add up to approximately its formal charge
-        allow_nonintegral_charges = kwargs.get('allow_nonintegral_charges', False)
+        allow_nonintegral_charges = kwargs.get("allow_nonintegral_charges", False)
         for top_mol in topology.topology_molecules:
             # Skip check if user manually disables it.
             if allow_nonintegral_charges:
                 continue
             formal_charge_sum = top_mol.reference_molecule.total_charge
-            partial_charge_sum = 0. * unit.elementary_charge
+            partial_charge_sum = 0.0 * unit.elementary_charge
             for top_particle in top_mol.particles:
-                q, _, _ = force.getParticleParameters(top_particle.topology_particle_index)
+                q, _, _ = force.getParticleParameters(
+                    top_particle.topology_particle_index
+                )
                 partial_charge_sum += q
-            if abs(formal_charge_sum - partial_charge_sum) > 0.01 * unit.elementary_charge:
-                msg = f"Partial charge sum ({partial_charge_sum}) " \
-                      f"for molecule '{top_mol.reference_molecule.name}' (SMILES " \
-                      f"{top_mol.reference_molecule.to_smiles()} does not equal formal charge sum " \
-                      f"({formal_charge_sum}). To override this error, provide the " \
-                      f"'allow_nonintegral_charges=True' keyword to ForceField.create_openmm_system"
+            if (
+                abs(formal_charge_sum - partial_charge_sum)
+                > 0.01 * unit.elementary_charge
+            ):
+                msg = (
+                    f"Partial charge sum ({partial_charge_sum}) "
+                    f"for molecule '{top_mol.reference_molecule.name}' (SMILES "
+                    f"{top_mol.reference_molecule.to_smiles()} does not equal formal charge sum "
+                    f"({formal_charge_sum}). To override this error, provide the "
+                    f"'allow_nonintegral_charges=True' keyword to ForceField.create_openmm_system"
+                )
                 raise NonintegralMoleculeChargeException(msg)
 
 
@@ -3338,21 +3619,25 @@ class LibraryChargeHandler(_NonbondedHandler):
 
         .. warning :: This API is experimental and subject to change.
         """
+
         _VALENCE_TYPE = None  # This disables the connectivity check when parsing LibraryChargeType objects
-        _ELEMENT_NAME = 'LibraryCharge'
+        _ELEMENT_NAME = "LibraryCharge"
 
         name = ParameterAttribute(default=None)
         charge = IndexedParameterAttribute(unit=unit.elementary_charge)
 
         def __init__(self, **kwargs):
             super().__init__(**kwargs)
-            unique_tags, connectivity = GLOBAL_TOOLKIT_REGISTRY.call('get_tagged_smarts_connectivity', self.smirks)
+            unique_tags, connectivity = GLOBAL_TOOLKIT_REGISTRY.call(
+                "get_tagged_smarts_connectivity", self.smirks
+            )
             if len(self.charge) != len(unique_tags):
-                raise SMIRNOFFSpecError(f"LibraryCharge {self} was initialized with unequal number of "
-                                        f"tagged atoms and charges")
+                raise SMIRNOFFSpecError(
+                    f"LibraryCharge {self} was initialized with unequal number of "
+                    f"tagged atoms and charges"
+                )
 
-
-    _TAGNAME = 'LibraryCharges'  # SMIRNOFF tag name to process
+    _TAGNAME = "LibraryCharges"  # SMIRNOFF tag name to process
     _INFOTYPE = LibraryChargeType  # info type to store
     _DEPENDENCIES = [vdWHandler, ElectrostaticsHandler]
 
@@ -3389,9 +3674,13 @@ class LibraryChargeHandler(_NonbondedHandler):
         for topology_indices, library_charge in atom_matches.items():
             for charge_idx, top_idx in enumerate(topology_indices):
                 if top_idx in assignable_atoms:
-                    logger.debug(f'Multiple library charge assignments found for atom {top_idx}')
+                    logger.debug(
+                        f"Multiple library charge assignments found for atom {top_idx}"
+                    )
                 assignable_atoms.add(top_idx)
-                atom_assignments[top_idx] = library_charge.parameter_type.charge[charge_idx]
+                atom_assignments[top_idx] = library_charge.parameter_type.charge[
+                    charge_idx
+                ]
         # TODO: Should header include a residue separator delimiter? Maybe not, since it's not clear how having
         #       multiple LibraryChargeHandlers could return a single set of matches while respecting different
         #       separators.
@@ -3411,8 +3700,13 @@ class LibraryChargeHandler(_NonbondedHandler):
 
             # Ensure all of the atoms in this mol are covered, otherwise skip it
             top_particle_idxs = [atom.topology_particle_index for atom in top_mol.atoms]
-            if len(set(top_particle_idxs).intersection(assignable_atoms)) != top_mol.n_atoms:
-                logger.debug('Entire molecule is not covered. Skipping library charge assignment.')
+            if (
+                len(set(top_particle_idxs).intersection(assignable_atoms))
+                != top_mol.n_atoms
+            ):
+                logger.debug(
+                    "Entire molecule is not covered. Skipping library charge assignment."
+                )
                 continue
 
             # If we pass both tests above, go ahead and assign charges
@@ -3420,10 +3714,9 @@ class LibraryChargeHandler(_NonbondedHandler):
             #       and assigning charges to all other instances of it in this topology
             for top_particle_idx in top_particle_idxs:
                 _, sigma, epsilon = force.getParticleParameters(top_particle_idx)
-                force.setParticleParameters(top_particle_idx,
-                                            atom_assignments[top_particle_idx],
-                                            sigma,
-                                            epsilon)
+                force.setParticleParameters(
+                    top_particle_idx, atom_assignments[top_particle_idx], sigma, epsilon
+                )
 
             ref_mols_assigned.add(top_mol.reference_molecule)
 
@@ -3432,20 +3725,19 @@ class LibraryChargeHandler(_NonbondedHandler):
             self.mark_charges_assigned(assigned_mol, topology)
 
 
-
 class ToolkitAM1BCCHandler(_NonbondedHandler):
     """Handle SMIRNOFF ``<ToolkitAM1BCC>`` tags
 
     .. warning :: This API is experimental and subject to change.
     """
 
-    _TAGNAME = 'ToolkitAM1BCC'  # SMIRNOFF tag name to process
+    _TAGNAME = "ToolkitAM1BCC"  # SMIRNOFF tag name to process
     _DEPENDENCIES = [vdWHandler, ElectrostaticsHandler, LibraryChargeHandler]
-    _KWARGS = ['toolkit_registry'] # Kwargs to catch when create_force is called
+    _KWARGS = ["toolkit_registry"]  # Kwargs to catch when create_force is called
 
-    def check_handler_compatibility(self,
-                                    other_handler,
-                                    assume_missing_is_default=True):
+    def check_handler_compatibility(
+        self, other_handler, assume_missing_is_default=True
+    ):
         """
         Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
@@ -3464,8 +3756,11 @@ class ToolkitAM1BCCHandler(_NonbondedHandler):
     def create_force(self, system, topology, **kwargs):
         import warnings
         from openforcefield.utils.toolkits import GLOBAL_TOOLKIT_REGISTRY
-        from openforcefield.topology import FrozenMolecule, TopologyAtom, TopologyVirtualSite
-
+        from openforcefield.topology import (
+            FrozenMolecule,
+            TopologyAtom,
+            TopologyVirtualSite,
+        )
 
         force = super().create_force(system, topology, **kwargs)
 
@@ -3476,38 +3771,49 @@ class ToolkitAM1BCCHandler(_NonbondedHandler):
                 continue
 
             # If the molecule wasn't already assigned charge values, calculate them here
-            toolkit_registry = kwargs.get('toolkit_registry', GLOBAL_TOOLKIT_REGISTRY)
+            toolkit_registry = kwargs.get("toolkit_registry", GLOBAL_TOOLKIT_REGISTRY)
             try:
                 # We don't need to generate conformers here, since that will be done by default in
                 # compute_partial_charges_am1bcc if the use_conformers kwarg isn't defined
-                ref_mol.compute_partial_charges_am1bcc(toolkit_registry=toolkit_registry)
+                ref_mol.compute_partial_charges_am1bcc(
+                    toolkit_registry=toolkit_registry
+                )
             except Exception as e:
                 warnings.warn(str(e), Warning)
                 continue
 
             # Assign charges to relevant atoms
-            for topology_molecule in topology._reference_molecule_to_topology_molecules[ref_mol]:
+            for topology_molecule in topology._reference_molecule_to_topology_molecules[
+                ref_mol
+            ]:
                 for topology_particle in topology_molecule.particles:
                     if type(topology_particle) is TopologyAtom:
-                        ref_mol_particle_index = topology_particle.atom.molecule_particle_index
+                        ref_mol_particle_index = (
+                            topology_particle.atom.molecule_particle_index
+                        )
                     elif type(topology_particle) is TopologyVirtualSite:
-                        ref_mol_particle_index = topology_particle.virtual_site.molecule_particle_index
+                        ref_mol_particle_index = (
+                            topology_particle.virtual_site.molecule_particle_index
+                        )
                     else:
-                        raise ValueError(f'Particles of type {type(topology_particle)} are not supported')
+                        raise ValueError(
+                            f"Particles of type {type(topology_particle)} are not supported"
+                        )
 
                     topology_particle_index = topology_particle.topology_particle_index
 
                     particle_charge = ref_mol._partial_charges[ref_mol_particle_index]
 
                     # Retrieve nonbonded parameters for reference atom (charge not set yet)
-                    _, sigma, epsilon = force.getParticleParameters(topology_particle_index)
+                    _, sigma, epsilon = force.getParticleParameters(
+                        topology_particle_index
+                    )
                     # Set the nonbonded force with the partial charge
-                    force.setParticleParameters(topology_particle_index,
-                                                particle_charge, sigma,
-                                                epsilon)
+                    force.setParticleParameters(
+                        topology_particle_index, particle_charge, sigma, epsilon
+                    )
             # Finally, mark that charges were assigned for this reference molecule
             self.mark_charges_assigned(ref_mol, topology)
-
 
     # TODO: Move chargeModel and library residue charges to SMIRNOFF spec
     def postprocess_system(self, system, topology, **kwargs):
@@ -3518,27 +3824,30 @@ class ToolkitAM1BCCHandler(_NonbondedHandler):
         # QUESTION: Should we instead apply this to the Topology in a preprocessing step, prior to spreading out charge onto virtual sites?
         for force in system.getForces():
             if force.__class__.__name__ in [
-                    'NonbondedForce'
+                "NonbondedForce"
             ]:  # TODO: We need to apply this to all Force types that involve charges, such as (Custom)GBSA forces and CustomNonbondedForce
                 for (atoms, bond_match) in bond_matches.items():
                     # Get corresponding particle indices in Topology
                     bond = bond_match.parameter_type
 
-                    particle_indices = tuple(
-                        [atom.particle_index for atom in atoms])
+                    particle_indices = tuple([atom.particle_index for atom in atoms])
                     # Retrieve parameters
                     [charge0, sigma0, epsilon0] = force.getParticleParameters(
-                        particle_indices[0])
+                        particle_indices[0]
+                    )
                     [charge1, sigma1, epsilon1] = force.getParticleParameters(
-                        particle_indices[1])
+                        particle_indices[1]
+                    )
                     # Apply bond charge increment
                     charge0 -= bond.increment
                     charge1 += bond.increment
                     # Update charges
-                    force.setParticleParameters(particle_indices[0], charge0,
-                                                sigma0, epsilon0)
-                    force.setParticleParameters(particle_indices[1], charge1,
-                                                sigma1, epsilon1)
+                    force.setParticleParameters(
+                        particle_indices[0], charge0, sigma0, epsilon0
+                    )
+                    force.setParticleParameters(
+                        particle_indices[1], charge1, sigma1, epsilon1
+                    )
                     # TODO: Calculate exceptions
 
 
@@ -3553,32 +3862,39 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
 
         .. warning :: This API is experimental and subject to change.
         """
+
         _VALENCE_TYPE = None  # This disables the connectivity check when parsing LibraryChargeType objects
-        _ELEMENT_NAME = 'ChargeIncrement'
+        _ELEMENT_NAME = "ChargeIncrement"
 
         charge_increment = IndexedParameterAttribute(unit=unit.elementary_charge)
 
         def __init__(self, **kwargs):
             super().__init__(**kwargs)
-            unique_tags, connectivity = GLOBAL_TOOLKIT_REGISTRY.call('get_tagged_smarts_connectivity', self.smirks)
+            unique_tags, connectivity = GLOBAL_TOOLKIT_REGISTRY.call(
+                "get_tagged_smarts_connectivity", self.smirks
+            )
             if len(self.charge_increment) != len(unique_tags):
-                raise SMIRNOFFSpecError(f"ChargeIncrement {self} was initialized with unequal number of "
-                                        f"tagged atoms and charge increments")
+                raise SMIRNOFFSpecError(
+                    f"ChargeIncrement {self} was initialized with unequal number of "
+                    f"tagged atoms and charge increments"
+                )
 
-
-    _TAGNAME = 'ChargeIncrementModel'  # SMIRNOFF tag name to process
+    _TAGNAME = "ChargeIncrementModel"  # SMIRNOFF tag name to process
     _INFOTYPE = ChargeIncrementType  # info type to store
-    _DEPENDENCIES = [vdWHandler, ElectrostaticsHandler, LibraryChargeHandler, ToolkitAM1BCCHandler]
+    _DEPENDENCIES = [
+        vdWHandler,
+        ElectrostaticsHandler,
+        LibraryChargeHandler,
+        ToolkitAM1BCCHandler,
+    ]
 
     number_of_conformers = ParameterAttribute(default=1, converter=int)
 
-    partial_charge_method = ParameterAttribute(
-        default='AM1-Mulliken', converter=str
-    )
+    partial_charge_method = ParameterAttribute(default="AM1-Mulliken", converter=str)
 
-    def check_handler_compatibility(self,
-                                    other_handler,
-                                    assume_missing_is_default=True):
+    def check_handler_compatibility(
+        self, other_handler, assume_missing_is_default=True
+    ):
         """
         Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
@@ -3593,11 +3909,13 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
         IncompatibleParameterError if handler_kwargs are incompatible with existing parameters.
         """
 
-        int_attrs_to_compare = ['number_of_conformers']
-        string_attrs_to_compare = ['partial_charge_method']
+        int_attrs_to_compare = ["number_of_conformers"]
+        string_attrs_to_compare = ["partial_charge_method"]
 
-        self._check_attributes_are_equal(other_handler,
-                                         identical_attrs=string_attrs_to_compare+int_attrs_to_compare)
+        self._check_attributes_are_equal(
+            other_handler,
+            identical_attrs=string_attrs_to_compare + int_attrs_to_compare,
+        )
 
     def find_matches(self, entity):
         """Find the elements of the topology/molecule matched by a parameter type.
@@ -3621,7 +3939,11 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
 
     def create_force(self, system, topology, **kwargs):
         import warnings
-        from openforcefield.topology import FrozenMolecule, TopologyAtom, TopologyVirtualSite
+        from openforcefield.topology import (
+            FrozenMolecule,
+            TopologyAtom,
+            TopologyVirtualSite,
+        )
 
         # We only want one instance of this force type
         existing = [system.getForce(i) for i in range(system.getNumForces())]
@@ -3638,12 +3960,14 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
             if self.check_charges_assigned(ref_mol, topology):
                 continue
 
-            toolkit_registry = kwargs.get('toolkit_registry', GLOBAL_TOOLKIT_REGISTRY)
+            toolkit_registry = kwargs.get("toolkit_registry", GLOBAL_TOOLKIT_REGISTRY)
             try:
                 # If the molecule wasn't assigned parameters from a manually-input charge_mol, calculate them here
                 ref_mol.generate_conformers(n_conformers=self.number_of_conformers)
-                ref_mol.assign_partial_charges(partial_charge_method=self.partial_charge_method,
-                                                toolkit_registry=toolkit_registry)
+                ref_mol.assign_partial_charges(
+                    partial_charge_method=self.partial_charge_method,
+                    toolkit_registry=toolkit_registry,
+                )
             except Exception as e:
                 warnings.warn(str(e), Warning)
                 continue
@@ -3651,13 +3975,19 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
             charges_to_assign = {}
 
             # Assign initial, un-incremented charges to relevant atoms
-            for topology_molecule in topology._reference_molecule_to_topology_molecules[ref_mol]:
+            for topology_molecule in topology._reference_molecule_to_topology_molecules[
+                ref_mol
+            ]:
                 for topology_particle in topology_molecule.particles:
                     topology_particle_index = topology_particle.topology_particle_index
                     if type(topology_particle) is TopologyAtom:
-                        ref_mol_particle_index = topology_particle.atom.molecule_particle_index
+                        ref_mol_particle_index = (
+                            topology_particle.atom.molecule_particle_index
+                        )
                     if type(topology_particle) is TopologyVirtualSite:
-                        ref_mol_particle_index = topology_particle.virtual_site.molecule_particle_index
+                        ref_mol_particle_index = (
+                            topology_particle.virtual_site.molecule_particle_index
+                        )
                     particle_charge = ref_mol._partial_charges[ref_mol_particle_index]
                     charges_to_assign[topology_particle_index] = particle_charge
 
@@ -3673,18 +4003,22 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
             for (_, charge_increment_match) in charge_increment_matches.items():
                 # Adjust the values in the charges_to_assign dict by adding any
                 # charge increments onto the existing values
-                atom_indices = charge_increment_match.environment_match.topology_atom_indices
+                atom_indices = (
+                    charge_increment_match.environment_match.topology_atom_indices
+                )
                 charge_increment = charge_increment_match.parameter_type
-                for top_particle_idx, charge_increment in zip(atom_indices, charge_increment.charge_increment):
+                for top_particle_idx, charge_increment in zip(
+                    atom_indices, charge_increment.charge_increment
+                ):
                     if top_particle_idx in charges_to_assign:
                         charges_to_assign[top_particle_idx] += charge_increment
 
             # Set the incremented charges on the System particles
             for topology_particle_index, charge_to_assign in charges_to_assign.items():
                 _, sigma, epsilon = force.getParticleParameters(topology_particle_index)
-                force.setParticleParameters(topology_particle_index,
-                                            charge_to_assign, sigma,
-                                            epsilon)
+                force.setParticleParameters(
+                    topology_particle_index, charge_to_assign, sigma, epsilon
+                )
 
             # Finally, mark that charges were assigned for this reference molecule
             self.mark_charges_assigned(ref_mol, topology)
@@ -3701,32 +4035,37 @@ class GBSAHandler(ParameterHandler):
 
         .. warning :: This API is experimental and subject to change.
         """
-        _VALENCE_TYPE = 'Atom'
-        _ELEMENT_NAME = 'Atom'
+
+        _VALENCE_TYPE = "Atom"
+        _ELEMENT_NAME = "Atom"
 
         radius = ParameterAttribute(unit=unit.angstrom)
         scale = ParameterAttribute(converter=float)
 
-    _TAGNAME = 'GBSA'
+    _TAGNAME = "GBSA"
     _INFOTYPE = GBSAType
     _OPENMMTYPE = openmm.GBSAOBCForce
     # It's important that this runs AFTER partial charges are assigned to all particles, since this will need to
     # collect and assign them to the GBSA particles
-    _DEPENDENCIES = [vdWHandler, ElectrostaticsHandler,
-                     ToolkitAM1BCCHandler, ChargeIncrementModelHandler, LibraryChargeHandler]
+    _DEPENDENCIES = [
+        vdWHandler,
+        ElectrostaticsHandler,
+        ToolkitAM1BCCHandler,
+        ChargeIncrementModelHandler,
+        LibraryChargeHandler,
+    ]
 
     gb_model = ParameterAttribute(
-        default='OBC1',
-        converter=_allow_only(['HCT', 'OBC1', 'OBC2'])
+        default="OBC1", converter=_allow_only(["HCT", "OBC1", "OBC2"])
     )
     solvent_dielectric = ParameterAttribute(default=78.5, converter=float)
     solute_dielectric = ParameterAttribute(default=1, converter=float)
-    sa_model = ParameterAttribute(default='ACE', converter=_allow_only(['ACE', None])
+    sa_model = ParameterAttribute(default="ACE", converter=_allow_only(["ACE", None]))
+    surface_area_penalty = ParameterAttribute(
+        default=5.4 * unit.calorie / unit.mole / unit.angstrom ** 2,
+        unit=unit.calorie / unit.mole / unit.angstrom ** 2,
     )
-    surface_area_penalty = ParameterAttribute(default=5.4*unit.calorie / unit.mole / unit.angstrom**2,
-                                              unit=unit.calorie / unit.mole / unit.angstrom**2)
-    solvent_radius = ParameterAttribute(default=1.4*unit.angstrom, unit=unit.angstrom)
-
+    solvent_radius = ParameterAttribute(default=1.4 * unit.angstrom, unit=unit.angstrom)
 
     def _validate_parameters(self):
         """
@@ -3736,61 +4075,73 @@ class GBSAHandler(ParameterHandler):
         #   surface_area_energy is 5.4 cal/mol/A^2
         #   solvent_radius is 1.4 A
         # Justification at https://github.com/openforcefield/openforcefield/pull/363
-        if self.gb_model == 'HCT':
-            if ((self.surface_area_penalty != 5.4 * unit.calorie / unit.mole / unit.angstrom**2) and
-                (self.sa_model is not None)):
-                raise IncompatibleParameterError(f"The current implementation of HCT GBSA does not "
-                                                 f"support surface_area_penalty values other than 5.4 "
-                                                 f"cal/mol A^2 (data source specified value of "
-                                                 f"{self.surface_area_penalty})")
+        if self.gb_model == "HCT":
+            if (
+                self.surface_area_penalty
+                != 5.4 * unit.calorie / unit.mole / unit.angstrom ** 2
+            ) and (self.sa_model is not None):
+                raise IncompatibleParameterError(
+                    f"The current implementation of HCT GBSA does not "
+                    f"support surface_area_penalty values other than 5.4 "
+                    f"cal/mol A^2 (data source specified value of "
+                    f"{self.surface_area_penalty})"
+                )
 
-            if ((self.solvent_radius != 1.4 * unit.angstrom) and
-                (self.sa_model is not None)):
-                raise IncompatibleParameterError(f"The current implementation of HCT GBSA does not "
-                                                 f"support solvent_radius values other than 1.4 "
-                                                 f"A (data source specified value of "
-                                                 f"{self.solvent_radius})")
-
+            if (self.solvent_radius != 1.4 * unit.angstrom) and (
+                self.sa_model is not None
+            ):
+                raise IncompatibleParameterError(
+                    f"The current implementation of HCT GBSA does not "
+                    f"support solvent_radius values other than 1.4 "
+                    f"A (data source specified value of "
+                    f"{self.solvent_radius})"
+                )
 
         # If we're using OBC1 via GBSAOBC1Force(CustomAmberGBForceBase), then we need to ensure that:
         #   surface_area_energy is 5.4 cal/mol/A^2
         #   solvent_radius is 1.4 A
         # Justification at https://github.com/openforcefield/openforcefield/pull/363
-        if self.gb_model == 'OBC1':
-            if ((self.surface_area_penalty != 5.4 * unit.calorie / unit.mole / unit.angstrom**2) and
-                (self.sa_model is not None)):
-                raise IncompatibleParameterError(f"The current implementation of OBC1 GBSA does not "
-                                                 f"support surface_area_penalty values other than 5.4 "
-                                                 f"cal/mol A^2 (data source specified value of "
-                                                 f"{self.surface_area_penalty})")
+        if self.gb_model == "OBC1":
+            if (
+                self.surface_area_penalty
+                != 5.4 * unit.calorie / unit.mole / unit.angstrom ** 2
+            ) and (self.sa_model is not None):
+                raise IncompatibleParameterError(
+                    f"The current implementation of OBC1 GBSA does not "
+                    f"support surface_area_penalty values other than 5.4 "
+                    f"cal/mol A^2 (data source specified value of "
+                    f"{self.surface_area_penalty})"
+                )
 
-            if ((self.solvent_radius != 1.4 * unit.angstrom) and
-                (self.sa_model is not None)):
-                raise IncompatibleParameterError(f"The current implementation of OBC1 GBSA does not "
-                                                 f"support solvent_radius values other than 1.4 "
-                                                 f"A (data source specified value of "
-                                                 f"{self.solvent_radius})")
-
+            if (self.solvent_radius != 1.4 * unit.angstrom) and (
+                self.sa_model is not None
+            ):
+                raise IncompatibleParameterError(
+                    f"The current implementation of OBC1 GBSA does not "
+                    f"support solvent_radius values other than 1.4 "
+                    f"A (data source specified value of "
+                    f"{self.solvent_radius})"
+                )
 
         # If we're using OBC2 via GBSAOBCForce, then we need to ensure that
         #   solvent_radius is 1.4 A
         # Justification at https://github.com/openforcefield/openforcefield/pull/363
-        if self.gb_model == 'OBC2':
+        if self.gb_model == "OBC2":
 
-            if ((self.solvent_radius != 1.4 * unit.angstrom) and
-                (self.sa_model is not None)):
-                raise IncompatibleParameterError(f"The current implementation of OBC1 GBSA does not "
-                                                 f"support solvent_radius values other than 1.4 "
-                                                 f"A (data source specified value of "
-                                                 f"{self.solvent_radius})")
-
-
+            if (self.solvent_radius != 1.4 * unit.angstrom) and (
+                self.sa_model is not None
+            ):
+                raise IncompatibleParameterError(
+                    f"The current implementation of OBC1 GBSA does not "
+                    f"support solvent_radius values other than 1.4 "
+                    f"A (data source specified value of "
+                    f"{self.solvent_radius})"
+                )
 
     # Tolerance when comparing float attributes for handler compatibility.
     _SCALETOL = 1e-5
 
-    def check_handler_compatibility(self,
-                                    other_handler):
+    def check_handler_compatibility(self, other_handler):
         """
         Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
         called if a second handler is attempted to be initialized for the same tag.
@@ -3804,15 +4155,16 @@ class GBSAHandler(ParameterHandler):
         ------
         IncompatibleParameterError if handler_kwargs are incompatible with existing parameters.
         """
-        float_attrs_to_compare = ['solvent_dielectric', 'solute_dielectric']
-        string_attrs_to_compare = ['gb_model', 'sa_model']
-        unit_attrs_to_compare = ['surface_area_penalty', 'solvent_radius']
+        float_attrs_to_compare = ["solvent_dielectric", "solute_dielectric"]
+        string_attrs_to_compare = ["gb_model", "sa_model"]
+        unit_attrs_to_compare = ["surface_area_penalty", "solvent_radius"]
 
-        self._check_attributes_are_equal(other_handler, identical_attrs=string_attrs_to_compare,
-                                         tolerance_attrs=float_attrs_to_compare+unit_attrs_to_compare,
-                                         tolerance=self._SCALETOL)
-
-
+        self._check_attributes_are_equal(
+            other_handler,
+            identical_attrs=string_attrs_to_compare,
+            tolerance_attrs=float_attrs_to_compare + unit_attrs_to_compare,
+            tolerance=self._SCALETOL,
+        )
 
     def create_force(self, system, topology, **kwargs):
         import simtk
@@ -3821,18 +4173,16 @@ class GBSAHandler(ParameterHandler):
 
         # Grab the existing nonbonded force (which will have particle charges)
         existing = [system.getForce(i) for i in range(system.getNumForces())]
-        existing = [
-            f for f in existing if type(f) == openmm.NonbondedForce
-        ]
+        existing = [f for f in existing if type(f) == openmm.NonbondedForce]
         assert len(existing) == 1
 
         nonbonded_force = existing[0]
 
         # No previous GBSAForce should exist, so we're safe just making one here.
         force_map = {
-            'HCT': simtk.openmm.app.internal.customgbforces.GBSAHCTForce,
-            'OBC1': simtk.openmm.app.internal.customgbforces.GBSAOBC1Force,
-            'OBC2': simtk.openmm.GBSAOBCForce,
+            "HCT": simtk.openmm.app.internal.customgbforces.GBSAHCTForce,
+            "OBC1": simtk.openmm.app.internal.customgbforces.GBSAOBC1Force,
+            "OBC2": simtk.openmm.GBSAOBCForce,
             # It's tempting to do use the class below, but the customgbforce
             # version of OBC2 doesn't provide setSolventRadius()
             #'OBC2': simtk.openmm.app.internal.customgbforces.GBSAOBC2Force,
@@ -3842,25 +4192,28 @@ class GBSAHandler(ParameterHandler):
         if nonbonded_force.getNonbondedMethod() == openmm.NonbondedForce.NoCutoff:
             amber_cutoff = None
         else:
-            amber_cutoff = nonbonded_force.getCutoffDistance().value_in_unit(unit.nanometer)
+            amber_cutoff = nonbonded_force.getCutoffDistance().value_in_unit(
+                unit.nanometer
+            )
 
-        if self.gb_model == 'OBC2':
+        if self.gb_model == "OBC2":
             gbsa_force = openmm_force_type()
 
         else:
             # We set these values in the constructor if we use the internal AMBER GBSA type wrapper
-            gbsa_force = openmm_force_type(solventDielectric=self.solvent_dielectric,
-                                           soluteDielectric=self.solute_dielectric,
-                                           SA=self.sa_model,
-                                           cutoff=amber_cutoff,
-                                           kappa=0,
-                                           )
+            gbsa_force = openmm_force_type(
+                solventDielectric=self.solvent_dielectric,
+                soluteDielectric=self.solute_dielectric,
+                SA=self.sa_model,
+                cutoff=amber_cutoff,
+                kappa=0,
+            )
             # WARNING: If using a CustomAmberGBForce, the functional form is affected by whether
             # the cutoff kwarg is None *during initialization*. So, if you initialize it with a
             # non-None value, and then try to change it to None, you're likely to get unphysical results.
 
         # Set the GBSAForce to have the same cutoff as NonbondedForce
-        #gbsa_force.setCutoffDistance(nonbonded_force.getCutoffDistance())
+        # gbsa_force.setCutoffDistance(nonbonded_force.getCutoffDistance())
         if amber_cutoff is not None:
             gbsa_force.setCutoffDistance(amber_cutoff)
 
@@ -3872,21 +4225,20 @@ class GBSAHandler(ParameterHandler):
             # http://docs.openmm.org/latest/api-python/generated/simtk.openmm.openmm.GBSAOBCForce.html
             # http://docs.openmm.org/latest/api-python/generated/simtk.openmm.openmm.CustomGBForce.html
 
-            #gbsa_force.setNonbondedMethod(simtk.openmm.NonbondedForce.CutoffPeriodic)
+            # gbsa_force.setNonbondedMethod(simtk.openmm.NonbondedForce.CutoffPeriodic)
             gbsa_force.setNonbondedMethod(simtk.openmm.CustomGBForce.CutoffPeriodic)
         else:
-            #gbsa_force.setNonbondedMethod(simtk.openmm.NonbondedForce.NoCutoff)
+            # gbsa_force.setNonbondedMethod(simtk.openmm.NonbondedForce.NoCutoff)
             gbsa_force.setNonbondedMethod(simtk.openmm.CustomGBForce.NoCutoff)
 
         # Add all GBSA terms to the system. Note that this will have been done above
-        if self.gb_model == 'OBC2':
+        if self.gb_model == "OBC2":
             gbsa_force.setSolventDielectric(self.solvent_dielectric)
             gbsa_force.setSoluteDielectric(self.solute_dielectric)
             if self.sa_model is None:
                 gbsa_force.setSurfaceAreaEnergy(0)
             else:
                 gbsa_force.setSurfaceAreaEnergy(self.surface_area_penalty)
-
 
         # Iterate over all defined GBSA types, allowing later matches to override earlier ones.
         atom_matches = self.find_matches(topology)
@@ -3902,8 +4254,8 @@ class GBSAHandler(ParameterHandler):
         # To keep it simple, we DO NOT pre-populate the particles in the GBSA force here.
         # We call addParticle further below instead.
         # These lines are commented out intentionally as an example of what NOT to do.
-        #for topology_particle in topology.topology_particles:
-            #gbsa_force.addParticle([0.0, 1.0, 0.0])
+        # for topology_particle in topology.topology_particles:
+        # gbsa_force.addParticle([0.0, 1.0, 0.0])
 
         params_to_add = [[] for _ in topology.topology_particles]
         for atom_key, atom_match in atom_matches.items():
@@ -3912,7 +4264,7 @@ class GBSAHandler(ParameterHandler):
             charge, _, _2 = nonbonded_force.getParticleParameters(atom_idx)
             params_to_add[atom_idx] = [charge, gbsatype.radius, gbsatype.scale]
 
-        if self.gb_model == 'OBC2':
+        if self.gb_model == "OBC2":
             for particle_param in params_to_add:
                 gbsa_force.addParticle(*particle_param)
         else:
@@ -3923,13 +4275,15 @@ class GBSAHandler(ParameterHandler):
             gbsa_force.finalize()
 
         # Check that no atoms (n.b. not particles) are missing force parameters.
-        self._check_all_valence_terms_assigned(assigned_terms=atom_matches,
-                                               valence_terms=list(topology.topology_atoms))
+        self._check_all_valence_terms_assigned(
+            assigned_terms=atom_matches, valence_terms=list(topology.topology_atoms)
+        )
 
         system.addForce(gbsa_force)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.testmod()
     # doctest.run_docstring_examples(_ParameterAttributeHandler, globals())

--- a/openforcefield/utils/__init__.py
+++ b/openforcefield/utils/__init__.py
@@ -2,6 +2,3 @@
 
 from openforcefield.utils.utils import *
 from openforcefield.utils.toolkits import *
-
-
-

--- a/openforcefield/utils/callback.py
+++ b/openforcefield/utils/callback.py
@@ -6,9 +6,9 @@ Utility classes and functions to create objects supporting callback registration
 """
 
 __all__ = [
-    'callback_method',
-    'CallbackRegistrationError',
-    'Callbackable',
+    "callback_method",
+    "CallbackRegistrationError",
+    "Callbackable",
 ]
 
 
@@ -23,6 +23,7 @@ import inspect
 # =====================================================================
 # CALLBACKABLE CLASSES
 # =====================================================================
+
 
 def callback_method(func=None, events=()):
     """Decorator used to mark a method as callbackable.
@@ -65,6 +66,7 @@ def callback_method(func=None, events=()):
 
 class CallbackRegistrationError(TypeError):
     """Error raised when callback registration fails."""
+
     pass
 
 
@@ -159,8 +161,10 @@ class Callbackable:
             try:
                 attr._callback_events
             except AttributeError:
-                raise CallbackRegistrationError(f'{self.__class__}.{event_name} is not '
-                                                f'tagged with the @callback_method decorator')
+                raise CallbackRegistrationError(
+                    f"{self.__class__}.{event_name} is not "
+                    f"tagged with the @callback_method decorator"
+                )
 
         # Update the instance callbacks dictionary.
         try:
@@ -181,8 +185,10 @@ class Callbackable:
                 return
 
         # The event wasn't found.
-        raise CallbackRegistrationError(f'No method of {self.__class__} is associated '
-                                        f'to the callback event "{event_name}".')
+        raise CallbackRegistrationError(
+            f"No method of {self.__class__} is associated "
+            f'to the callback event "{event_name}".'
+        )
 
     def _raise_callback_events(self, func_name, *args, **kwargs):
         events = getattr(self, func_name)._callback_events
@@ -193,6 +199,7 @@ class Callbackable:
                 callback(self, func_name, *args, **kwargs)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.run_docstring_examples(Callbackable, globals())

--- a/openforcefield/utils/collections.py
+++ b/openforcefield/utils/collections.py
@@ -6,8 +6,8 @@ Custom collections classes.
 """
 
 __all__ = [
-    'ValidatedList',
-    'ValidatedDict',
+    "ValidatedList",
+    "ValidatedDict",
 ]
 
 
@@ -21,6 +21,7 @@ from collections import abc
 # =====================================================================
 # VALIDATED LIST
 # =====================================================================
+
 
 class ValidatedList(list):
     """A list that runs custom converter and validators when new elements are added.
@@ -127,7 +128,7 @@ class ValidatedList(list):
     # TODO: Is there a cleaner way (getstate/setstate perhaps?) to allow FFs to be
     #       pickled?
     def __reduce__(self):
-        return (__class__, ( list( self),), self.__dict__)
+        return (__class__, (list(self),), self.__dict__)
 
     def _convert_and_validate(self, seq):
         """Run all converters and the validator on the given sequence."""
@@ -184,6 +185,7 @@ class ValidatedDict(dict):
     {'c': 1.0, 'd': 2.0, 'e': 3.0}
 
     """
+
     def __init__(self, mapping, converter=None, validator=None):
         """
         Initialize the dict.
@@ -213,8 +215,8 @@ class ValidatedDict(dict):
         super().__init__(mapping)
 
     def update(self, other):
-       other = self._convert_and_validate(dict(other))
-       super().update(other)
+        other = self._convert_and_validate(dict(other))
+        super().update(other)
 
     def copy(self):
         return self.__class__(self)
@@ -228,7 +230,7 @@ class ValidatedDict(dict):
     # TODO: Is there a cleaner way (getstate/setstate perhaps?) to allow FFs to be
     #       pickled?
     def __reduce__(self):
-        return (__class__, ( dict( self),), self.__dict__)
+        return (__class__, (dict(self),), self.__dict__)
 
     def _convert_and_validate(self, mapping):
         """Run all converters and the validator on the given mapping."""
@@ -236,8 +238,7 @@ class ValidatedDict(dict):
         # Run all element converters.
         if self._converters is not None:
             for converter in self._converters:
-                mapping = {key: converter(value)
-                        for key, value in mapping.items()}
+                mapping = {key: converter(value) for key, value in mapping.items()}
 
         # Run all element validators.
         if self._validators is not None:
@@ -247,6 +248,7 @@ class ValidatedDict(dict):
         return mapping
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.run_docstring_examples(ValidatedList, globals())

--- a/openforcefield/utils/serialization.py
+++ b/openforcefield/utils/serialization.py
@@ -9,16 +9,16 @@ Serialization mix-in
 
 """
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import abc
 
 
-#=============================================================================================
+# =============================================================================================
 # SERIALIZATION MIX-IN
-#=============================================================================================
+# =============================================================================================
 
 
 class Serializable(abc.ABC):
@@ -119,6 +119,7 @@ class Serializable(abc.ABC):
 
         """
         import json
+
         d = self.to_dict()
         return json.dumps(d, indent=indent)
 
@@ -141,6 +142,7 @@ class Serializable(abc.ABC):
 
         """
         import json
+
         d = json.loads(serialized)
         return cls.from_dict(d)
 
@@ -157,6 +159,7 @@ class Serializable(abc.ABC):
 
         """
         import bson
+
         d = self.to_dict()
         return bson.dumps(d)
 
@@ -179,6 +182,7 @@ class Serializable(abc.ABC):
 
         """
         import bson
+
         d = bson.loads(serialized)
         return cls.from_dict(d)
 
@@ -220,6 +224,7 @@ class Serializable(abc.ABC):
 
         """
         import toml
+
         d = toml.loads(serialized)
         return cls.from_dict(d)
 
@@ -228,21 +233,20 @@ class Serializable(abc.ABC):
         """Like BaseRepresenter.represent_mapping, but does not issue the sort().
         """
         import yaml
+
         value = []
         node = yaml.MappingNode(tag, value, flow_style=flow_style)
         if dump.alias_key is not None:
             dump.represented_objects[dump.alias_key] = node
         best_style = True
-        if hasattr(mapping, 'items'):
+        if hasattr(mapping, "items"):
             mapping = mapping.items()
         for item_key, item_value in mapping:
             node_key = dump.represent_data(item_key)
             node_value = dump.represent_data(item_value)
-            if not (isinstance(node_key, yaml.ScalarNode)
-                    and not node_key.style):
+            if not (isinstance(node_key, yaml.ScalarNode) and not node_key.style):
                 best_style = False
-            if not (isinstance(node_value, yaml.ScalarNode)
-                    and not node_value.style):
+            if not (isinstance(node_value, yaml.ScalarNode) and not node_value.style):
                 best_style = False
             value.append((node_key, node_value))
         if flow_style is None:
@@ -266,8 +270,13 @@ class Serializable(abc.ABC):
         """
         import yaml
         from collections import OrderedDict
-        yaml.SafeDumper.add_representer(OrderedDict,
-            lambda dumper, value: self._represent_odict(dumper, u'tag:yaml.org,2002:map', value))
+
+        yaml.SafeDumper.add_representer(
+            OrderedDict,
+            lambda dumper, value: self._represent_odict(
+                dumper, u"tag:yaml.org,2002:map", value
+            ),
+        )
         d = self.to_dict()
         return yaml.safe_dump(d, width=180)
 
@@ -291,8 +300,13 @@ class Serializable(abc.ABC):
         """
         import yaml
         from collections import OrderedDict
-        yaml.SafeDumper.add_representer(OrderedDict,
-            lambda dumper, value: self._represent_odict(dumper, u'tag:yaml.org,2002:map', value))
+
+        yaml.SafeDumper.add_representer(
+            OrderedDict,
+            lambda dumper, value: self._represent_odict(
+                dumper, u"tag:yaml.org,2002:map", value
+            ),
+        )
         d = yaml.safe_load(serialized)
         return cls.from_dict(d)
 
@@ -309,6 +323,7 @@ class Serializable(abc.ABC):
 
         """
         import msgpack
+
         d = self.to_dict()
         return msgpack.dumps(d, use_bin_type=True)
 
@@ -331,6 +346,7 @@ class Serializable(abc.ABC):
 
         """
         import msgpack
+
         d = msgpack.loads(serialized, raw=False)
         return cls.from_dict(d)
 
@@ -352,13 +368,14 @@ class Serializable(abc.ABC):
 
         """
         import xmltodict
+
         # An XML document requires one and only one root node.
         root_name = self.__class__.__name__
         d = {root_name: self.to_dict()}
         # Configure indentation level.
         if indent is not None:
             pretty = True
-            indent = ' ' * indent
+            indent = " " * indent
         else:
             pretty = False
         # Convert data from dictionary to XML format.
@@ -406,6 +423,7 @@ class Serializable(abc.ABC):
 
         """
         import pickle
+
         d = self.to_dict()
         return pickle.dumps(d)
 
@@ -431,5 +449,6 @@ class Serializable(abc.ABC):
 
         """
         import pickle
+
         d = pickle.loads(serialized)
         return cls.from_dict(d)

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -21,34 +21,34 @@ Currently supported toolkits:
 """
 
 __all__ = [
-    'DEFAULT_AROMATICITY_MODEL',
-    'ALLOWED_AROMATICITY_MODELS',
-    'DEFAULT_FRACTIONAL_BOND_ORDER_MODEL',
-    'ALLOWED_FRACTIONAL_BOND_ORDER_MODELS',
-    'DEFAULT_CHARGE_MODEL',
-    'ALLOWED_CHARGE_MODELS',
-    'LicenseError',
-    'MissingPackageError',
-    'ToolkitUnavailableException',
-    'InvalidToolkitError',
-    'UndefinedStereochemistryError',
-    'GAFFAtomTypeWarning',
-    'ToolkitWrapper',
-    'OpenEyeToolkitWrapper',
-    'RDKitToolkitWrapper',
-    'AmberToolsToolkitWrapper',
-    'ToolkitRegistry',
-    'GLOBAL_TOOLKIT_REGISTRY',
-    'OPENEYE_AVAILABLE',
-    'RDKIT_AVAILABLE',
-    'AMBERTOOLS_AVAILABLE',
-    'BASIC_CHEMINFORMATICS_TOOLKITS'
+    "DEFAULT_AROMATICITY_MODEL",
+    "ALLOWED_AROMATICITY_MODELS",
+    "DEFAULT_FRACTIONAL_BOND_ORDER_MODEL",
+    "ALLOWED_FRACTIONAL_BOND_ORDER_MODELS",
+    "DEFAULT_CHARGE_MODEL",
+    "ALLOWED_CHARGE_MODELS",
+    "LicenseError",
+    "MissingPackageError",
+    "ToolkitUnavailableException",
+    "InvalidToolkitError",
+    "UndefinedStereochemistryError",
+    "GAFFAtomTypeWarning",
+    "ToolkitWrapper",
+    "OpenEyeToolkitWrapper",
+    "RDKitToolkitWrapper",
+    "AmberToolsToolkitWrapper",
+    "ToolkitRegistry",
+    "GLOBAL_TOOLKIT_REGISTRY",
+    "OPENEYE_AVAILABLE",
+    "RDKIT_AVAILABLE",
+    "AMBERTOOLS_AVAILABLE",
+    "BASIC_CHEMINFORMATICS_TOOLKITS",
 ]
 
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import copy
 from distutils.spawn import find_executable
@@ -62,48 +62,56 @@ import inspect
 from simtk import unit
 import numpy as np
 
-from openforcefield.utils import all_subclasses, MessageException, inherit_docstrings, temporary_cd
+from openforcefield.utils import (
+    all_subclasses,
+    MessageException,
+    inherit_docstrings,
+    temporary_cd,
+)
 
 
-#=============================================================================================
+# =============================================================================================
 # CONFIGURE LOGGER
-#=============================================================================================
+# =============================================================================================
 
 logger = logging.getLogger(__name__)
 
-#=============================================================================================
+# =============================================================================================
 # SUPPORTED MODELS
 #
 # TODO: We may no longer need these since we now require SMIRNOFF to specify these models explicitly.
-#=============================================================================================
+# =============================================================================================
 
-DEFAULT_AROMATICITY_MODEL = 'OEAroModel_MDL'  # TODO: Is there a more specific name and reference for the aromaticity model?
-ALLOWED_AROMATICITY_MODELS = ['OEAroModel_MDL']
+DEFAULT_AROMATICITY_MODEL = "OEAroModel_MDL"  # TODO: Is there a more specific name and reference for the aromaticity model?
+ALLOWED_AROMATICITY_MODELS = ["OEAroModel_MDL"]
 
-DEFAULT_FRACTIONAL_BOND_ORDER_MODEL = 'Wiberg'  # TODO: Is there a more specific name and reference for the fractional bond order models?
-ALLOWED_FRACTIONAL_BOND_ORDER_MODELS = ['Wiberg']
+DEFAULT_FRACTIONAL_BOND_ORDER_MODEL = "Wiberg"  # TODO: Is there a more specific name and reference for the fractional bond order models?
+ALLOWED_FRACTIONAL_BOND_ORDER_MODELS = ["Wiberg"]
 
-DEFAULT_CHARGE_MODEL = 'AM1-BCC'  # TODO: Should this be `AM1-BCC`, or should we encode BCCs explicitly via AM1-CM2 preprocessing?
-ALLOWED_CHARGE_MODELS = ['AM1-BCC'
-                         ]  # TODO: Which models do we want to support?
+DEFAULT_CHARGE_MODEL = "AM1-BCC"  # TODO: Should this be `AM1-BCC`, or should we encode BCCs explicitly via AM1-CM2 preprocessing?
+ALLOWED_CHARGE_MODELS = ["AM1-BCC"]  # TODO: Which models do we want to support?
 
 
-#=============================================================================================
+# =============================================================================================
 # Exceptions
-#=============================================================================================
+# =============================================================================================
+
 
 class LicenseError(Exception):
     """This function requires a license that cannot be found."""
+
     pass
 
 
 class MissingPackageError(MessageException):
     """This function requires a package that is not installed."""
+
     pass
 
 
 class ToolkitUnavailableException(MessageException):
     """The requested toolkit is unavailable."""
+
     # TODO: Allow toolkit to be specified and used in formatting/printing exception.
     pass
 
@@ -114,45 +122,52 @@ class InvalidToolkitError(MessageException):
 
 class UndefinedStereochemistryError(MessageException):
     """A molecule was attempted to be loaded with undefined stereochemistry"""
+
     pass
 
 
 class GAFFAtomTypeWarning(RuntimeWarning):
     """A warning raised if a loaded mol2 file possibly uses GAFF atom types."""
+
     pass
 
 
 class ChargeMethodUnavailableError(MessageException):
     """A toolkit does not support the requested partial_charge_method combination"""
+
     pass
 
 
 class IncorrectNumConformersError(MessageException):
     """The requested partial_charge_method expects a different number of conformers than was provided"""
+
     pass
 
 
 class IncorrectNumConformersWarning(Warning):
     """The requested partial_charge_method expects a different number of conformers than was provided"""
+
     pass
 
 
 class ChargeCalculationError(MessageException):
     """An unhandled error occured in an external toolkit during charge calculation"""
+
     pass
 
 
-#=============================================================================================
+# =============================================================================================
 # TOOLKIT UTILITY DECORATORS
-#=============================================================================================
+# =============================================================================================
 
-#=============================================================================================
+# =============================================================================================
 # UTILITY FUNCTIONS
-#=============================================================================================
+# =============================================================================================
 
-#=============================================================================================
+# =============================================================================================
 # CHEMINFORMATICS TOOLKIT WRAPPERS
-#=============================================================================================
+# =============================================================================================
+
 
 class ToolkitWrapper:
     """
@@ -160,22 +175,26 @@ class ToolkitWrapper:
 
     .. warning :: This API is experimental and subject to change.
     """
+
     _is_available = None  # True if toolkit is available
     _toolkit_name = None  # Name of the toolkit
-    _toolkit_installation_instructions = None  # Installation instructions for the toolkit
+    _toolkit_installation_instructions = (
+        None  # Installation instructions for the toolkit
+    )
 
-    #@staticmethod
+    # @staticmethod
     # TODO: Right now, to access the class definition, I have to make this a classmethod
     # and thereby call it with () on the outermost decorator. Is this wasting time? Are we caching
     # the is_available results?
     @classmethod
-    def requires_toolkit(cls):  #remember cls is a ToolkitWrapper subclass here
+    def requires_toolkit(cls):  # remember cls is a ToolkitWrapper subclass here
         def decorator(func):
             @wraps(func)
             def wrapped_function(*args, **kwargs):
                 if not cls.is_available():
-                    msg = 'This function requires the {} toolkit'.format(
-                        cls._toolkit_name)
+                    msg = "This function requires the {} toolkit".format(
+                        cls._toolkit_name
+                    )
                     raise LicenseError(msg)
                 value = func(*args, **kwargs)
                 return value
@@ -185,7 +204,7 @@ class ToolkitWrapper:
         return decorator
 
     @property
-    #@classmethod
+    # @classmethod
     def toolkit_name(self):
         """
         The name of the toolkit wrapped by this class.
@@ -200,7 +219,7 @@ class ToolkitWrapper:
         """
         return cls._toolkit_installation_instructions
 
-    #@classmethod
+    # @classmethod
     @property
     def toolkit_file_read_formats(self):
         """
@@ -208,7 +227,7 @@ class ToolkitWrapper:
         """
         return self._toolkit_file_read_formats
 
-    #@classmethod
+    # @classmethod
     @property
     def toolkit_file_write_formats(self):
         """
@@ -229,10 +248,7 @@ class ToolkitWrapper:
         """
         return NotImplementedError
 
-    def from_file(self,
-                  file_path,
-                  file_format,
-                  allow_undefined_stereo=False):
+    def from_file(self, file_path, file_format, allow_undefined_stereo=False):
         """
         Return an openforcefield.topology.Molecule from a file using this toolkit.
 
@@ -253,10 +269,7 @@ class ToolkitWrapper:
         """
         return NotImplementedError
 
-    def from_file_obj(self,
-                      file_obj,
-                      file_format,
-                      allow_undefined_stereo=False):
+    def from_file_obj(self, file_obj, file_format, allow_undefined_stereo=False):
         """
         Return an openforcefield.topology.Molecule from a file-like object (an object with a ".read()" method using this
          toolkit.
@@ -279,13 +292,14 @@ class ToolkitWrapper:
         """
         return NotImplementedError
 
-
-    def _check_n_conformers(self,
-                            molecule,
-                            partial_charge_method,
-                            min_confs=None,
-                            max_confs=None,
-                            strict_n_conformers=False):
+    def _check_n_conformers(
+        self,
+        molecule,
+        partial_charge_method,
+        min_confs=None,
+        max_confs=None,
+        strict_n_conformers=False,
+    ):
         """
         Private method for validating the number of conformers on a molecule prior to partial
         charge calculation
@@ -310,17 +324,22 @@ class ToolkitWrapper:
             If the wrong number of conformers is attached to the input molecule, and strict_n_conformers is True.
         """
         import warnings
+
         n_confs = molecule.n_conformers
-        wrong_confs_msg = f"Molecule '{molecule}' has {n_confs} conformers, " \
+        wrong_confs_msg = (
+            f"Molecule '{molecule}' has {n_confs} conformers, "
             f"but charge method '{partial_charge_method}' expects"
-        exception_suffix = "You can disable this error by setting `strict_n_conformers=False' " \
-                           "when calling 'molecule.assign_partial_charges'."
+        )
+        exception_suffix = (
+            "You can disable this error by setting `strict_n_conformers=False' "
+            "when calling 'molecule.assign_partial_charges'."
+        )
         # If there's no n_confs filter, then this molecule automatically passes
         if min_confs is None and max_confs is None:
             return
         # If there's constraints on both ends, check both limits
         elif min_confs is not None and max_confs is not None:
-            if not(min_confs <= n_confs <= max_confs):
+            if not (min_confs <= n_confs <= max_confs):
                 if min_confs == max_confs:
                     wrong_confs_msg += f" exactly {min_confs}."
                 else:
@@ -330,13 +349,13 @@ class ToolkitWrapper:
                 return
         # If there's only a max constraint, check that
         elif min_confs is not None and max_confs is None:
-            if not(min_confs <= n_confs):
+            if not (min_confs <= n_confs):
                 wrong_confs_msg += f" at least {min_confs}."
             else:
                 return
         # If there's only a maximum constraint, check that
         elif min_confs is None and max_confs is not None:
-            if not(n_confs <= max_confs):
+            if not (n_confs <= max_confs):
                 wrong_confs_msg += f" at most {max_confs}."
             else:
                 return
@@ -355,9 +374,12 @@ class BuiltInToolkitWrapper(ToolkitWrapper):
 
     .. warning :: This API is experimental and subject to change.
     """
-    _toolkit_name = 'Built-in Toolkit'
-    _toolkit_installation_instructions = 'This toolkit is installed with the Open Force Field Toolkit and does ' \
-                                         'not require additional dependencies.'
+
+    _toolkit_name = "Built-in Toolkit"
+    _toolkit_installation_instructions = (
+        "This toolkit is installed with the Open Force Field Toolkit and does "
+        "not require additional dependencies."
+    )
 
     def __init__(self):
         super().__init__()
@@ -365,12 +387,13 @@ class BuiltInToolkitWrapper(ToolkitWrapper):
         self._toolkit_file_read_formats = []
         self._toolkit_file_write_formats = []
 
-
-    def assign_partial_charges(self,
-                               molecule,
-                               partial_charge_method=None,
-                               use_conformers=None,
-                               strict_n_conformers=False):
+    def assign_partial_charges(
+        self,
+        molecule,
+        partial_charge_method=None,
+        use_conformers=None,
+        strict_n_conformers=False,
+    ):
         """
         Compute partial charges with the built-in toolkit using simple arithmetic operations, and assign
         the new values to the partial_charges attribute.
@@ -401,41 +424,50 @@ class BuiltInToolkitWrapper(ToolkitWrapper):
         ChargeCalculationError if the charge calculation is supported by this toolkit, but fails
         """
         from openforcefield.topology import Molecule
-        PARTIAL_CHARGE_METHODS = {'zeros':         {'rec_confs':0,
-                                                    'min_confs':0,
-                                                    'max_confs':0},
-                                  'formal_charge': {'rec_confs':0,
-                                                    'min_confs':0,
-                                                    'max_confs':0}
-                                  }
+
+        PARTIAL_CHARGE_METHODS = {
+            "zeros": {"rec_confs": 0, "min_confs": 0, "max_confs": 0},
+            "formal_charge": {"rec_confs": 0, "min_confs": 0, "max_confs": 0},
+        }
 
         if partial_charge_method is None:
-            partial_charge_method = 'formal_charge'
+            partial_charge_method = "formal_charge"
 
         # Make a temporary copy of the molecule, since we'll be messing with its conformers
         mol_copy = Molecule(molecule)
 
         partial_charge_method = partial_charge_method.lower()
         if partial_charge_method not in PARTIAL_CHARGE_METHODS:
-            raise ChargeMethodUnavailableError(f'Partial charge method "{partial_charge_method}"" is not supported by '
-                                               f'the Built-in toolkit. Available charge methods are '
-                                               f'{list(PARTIAL_CHARGE_METHODS.keys())}')
+            raise ChargeMethodUnavailableError(
+                f'Partial charge method "{partial_charge_method}"" is not supported by '
+                f"the Built-in toolkit. Available charge methods are "
+                f"{list(PARTIAL_CHARGE_METHODS.keys())}"
+            )
 
         if use_conformers is None:
             # Note that this refers back to the GLOBAL_TOOLKIT_REGISTRY by default, since
             # BuiltInToolkitWrapper can't generate conformers
-            mol_copy.generate_conformers(n_conformers=PARTIAL_CHARGE_METHODS[partial_charge_method]['rec_confs'])
+            mol_copy.generate_conformers(
+                n_conformers=PARTIAL_CHARGE_METHODS[partial_charge_method]["rec_confs"]
+            )
         else:
             mol_copy._conformers = None
             for conformer in use_conformers:
                 mol_copy.add_conformer(conformer)
-            self._check_n_conformers(mol_copy, partial_charge_method=partial_charge_method, min_confs=0,
-                                     max_confs=0,strict_n_conformers=strict_n_conformers)
+            self._check_n_conformers(
+                mol_copy,
+                partial_charge_method=partial_charge_method,
+                min_confs=0,
+                max_confs=0,
+                strict_n_conformers=strict_n_conformers,
+            )
 
-        partial_charges = unit.Quantity(np.zeros((molecule.n_particles)), unit.elementary_charge)
-        if partial_charge_method == 'zeroes':
+        partial_charges = unit.Quantity(
+            np.zeros((molecule.n_particles)), unit.elementary_charge
+        )
+        if partial_charge_method == "zeroes":
             pass
-        elif partial_charge_method == 'formal_charge':
+        elif partial_charge_method == "formal_charge":
             for part_idx, particle in enumerate(molecule.particles):
                 partial_charges[part_idx] = particle.formal_charge
 
@@ -449,32 +481,74 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
     .. warning :: This API is experimental and subject to change.
     """
-    _toolkit_name = 'OpenEye Toolkit'
-    _toolkit_installation_instructions = 'The OpenEye toolkit requires a (free for academics) license, and can be ' \
-                                         'found at: ' \
-                                         'https://docs.eyesopen.com/toolkits/python/quickstart-python/install.html'
+
+    _toolkit_name = "OpenEye Toolkit"
+    _toolkit_installation_instructions = (
+        "The OpenEye toolkit requires a (free for academics) license, and can be "
+        "found at: "
+        "https://docs.eyesopen.com/toolkits/python/quickstart-python/install.html"
+    )
 
     def __init__(self):
 
         self._toolkit_file_read_formats = [
-            'CAN', 'CDX', 'CSV', 'FASTA', 'INCHI', 'INCHIKEY', 'ISM', 'MDL', 'MF',
-            'MMOD', 'MOL2', 'MOL2H', 'MOPAC', 'OEB', 'PDB', 'RDF', 'SDF', 'SKC',
-            'SLN', 'SMI', 'USM', 'XYC'
+            "CAN",
+            "CDX",
+            "CSV",
+            "FASTA",
+            "INCHI",
+            "INCHIKEY",
+            "ISM",
+            "MDL",
+            "MF",
+            "MMOD",
+            "MOL2",
+            "MOL2H",
+            "MOPAC",
+            "OEB",
+            "PDB",
+            "RDF",
+            "SDF",
+            "SKC",
+            "SLN",
+            "SMI",
+            "USM",
+            "XYC",
         ]
         self._toolkit_file_write_formats = [
-            'CAN', 'CDX', 'CSV', 'FASTA', 'INCHI', 'INCHIKEY', 'ISM', 'MDL', 'MF',
-            'MMOD', 'MOL2', 'MOL2H', 'MOPAC', 'OEB', 'PDB', 'RDF', 'SDF', 'SKC',
-            'SLN', 'SMI', 'USM', 'XYC'
+            "CAN",
+            "CDX",
+            "CSV",
+            "FASTA",
+            "INCHI",
+            "INCHIKEY",
+            "ISM",
+            "MDL",
+            "MF",
+            "MMOD",
+            "MOL2",
+            "MOL2H",
+            "MOPAC",
+            "OEB",
+            "PDB",
+            "RDF",
+            "SDF",
+            "SKC",
+            "SLN",
+            "SMI",
+            "USM",
+            "XYC",
         ]
 
         # check if the toolkit can be loaded
         if not self.is_available():
-            raise ToolkitUnavailableException(f'The required toolkit {self._toolkit_name} is not '
-                                              f'available. {self._toolkit_installation_instructions}')
+            raise ToolkitUnavailableException(
+                f"The required toolkit {self._toolkit_name} is not "
+                f"available. {self._toolkit_installation_instructions}"
+            )
 
     @staticmethod
-    def is_available(
-            oetools=('oechem', 'oequacpac', 'oeiupac', 'oeomega')):
+    def is_available(oetools=("oechem", "oequacpac", "oeiupac", "oeomega")):
         """
         Check if the given OpenEye toolkit components are available.
 
@@ -498,10 +572,10 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         """
         # Complete list of module -> license function to check.
         license_function_names = {
-            'oechem': 'OEChemIsLicensed',
-            'oequacpac': 'OEQuacPacIsLicensed',
-            'oeiupac': 'OEIUPACIsLicensed',
-            'oeomega': 'OEOmegaIsLicensed'
+            "oechem": "OEChemIsLicensed",
+            "oequacpac": "OEQuacPacIsLicensed",
+            "oeiupac": "OEIUPACIsLicensed",
+            "oeomega": "OEOmegaIsLicensed",
         }
         supported_tools = set(license_function_names.keys())
 
@@ -514,14 +588,17 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         # Check for unkown tools.
         unknown_tools = oetools.difference(supported_tools)
         if len(unknown_tools) > 0:
-            raise ValueError("Found unkown OpenEye tools: {}. Supported values are: {}".format(
-                sorted(unknown_tools), sorted(supported_tools)))
+            raise ValueError(
+                "Found unkown OpenEye tools: {}. Supported values are: {}".format(
+                    sorted(unknown_tools), sorted(supported_tools)
+                )
+            )
 
         # Check license of all tools.
         all_licensed = True
         for tool in oetools:
             try:
-                module = importlib.import_module('openeye.' + tool)
+                module = importlib.import_module("openeye." + tool)
             except (ImportError, ModuleNotFoundError):
                 return False
             else:
@@ -553,14 +630,16 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         """
         # TODO: Add tests for the from_object functions
         from openeye import oechem
-        if isinstance(object, oechem.OEMolBase):
-            return self.from_openeye(object, allow_undefined_stereo=allow_undefined_stereo)
-        raise NotImplementedError('Cannot create Molecule from {} object'.format(type(object)))
 
-    def from_file(self,
-                  file_path,
-                  file_format,
-                  allow_undefined_stereo=False):
+        if isinstance(object, oechem.OEMolBase):
+            return self.from_openeye(
+                object, allow_undefined_stereo=allow_undefined_stereo
+            )
+        raise NotImplementedError(
+            "Cannot create Molecule from {} object".format(type(object))
+        )
+
+    def from_file(self, file_path, file_format, allow_undefined_stereo=False):
         """
         Return an openforcefield.topology.Molecule from a file using this toolkit.
 
@@ -597,13 +676,13 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         """
         from openeye import oechem
-        ifs = oechem.oemolistream(file_path)
-        return self._read_oemolistream_molecules(ifs, allow_undefined_stereo, file_path=file_path)
 
-    def from_file_obj(self,
-                      file_obj,
-                      file_format,
-                      allow_undefined_stereo=False):
+        ifs = oechem.oemolistream(file_path)
+        return self._read_oemolistream_molecules(
+            ifs, allow_undefined_stereo, file_path=file_path
+        )
+
+    def from_file_obj(self, file_obj, file_format, allow_undefined_stereo=False):
         """
         Return an openforcefield.topology.Molecule from a file-like object (an object with a ".read()" method using
         this toolkit.
@@ -635,7 +714,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         # Configure input molecule stream.
         ifs = oechem.oemolistream()
         ifs.openstring(file_obj.read())
-        oeformat = getattr(oechem, 'OEFormat_' + file_format)
+        oeformat = getattr(oechem, "OEFormat_" + file_format)
         ifs.SetFormat(oeformat)
 
         return self._read_oemolistream_molecules(ifs, allow_undefined_stereo)
@@ -655,7 +734,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         """
         with tempfile.TemporaryDirectory() as tmpdir:
-            outfile = 'temp_molecule.' + file_format
+            outfile = "temp_molecule." + file_format
             self.to_file(molecule, outfile, file_format)
             file_data = open(outfile).read()
         file_obj.write(file_data)
@@ -675,9 +754,10 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         """
         from openeye import oechem
+
         oemol = self.to_openeye(molecule)
         ofs = oechem.oemolostream(file_path)
-        openeye_format = getattr(oechem, 'OEFormat_' + file_format.upper())
+        openeye_format = getattr(oechem, "OEFormat_" + file_format.upper())
         ofs.SetFormat(openeye_format)
 
         # OFFTK strictly treats SDF as a single-conformer format.
@@ -694,8 +774,10 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             oemol.NewConf(oecoords)
         # We're standardizing on putting partial charges into SDFs under the `atom.dprop.PartialCharge` property
         if (file_format.lower() == "sdf") and (molecule.partial_charges is not None):
-            partial_charges_list = [oeatom.GetPartialCharge() for oeatom in oemol.GetAtoms()]
-            partial_charges_str = ' '.join([f'{val:f}' for val in partial_charges_list])
+            partial_charges_list = [
+                oeatom.GetPartialCharge() for oeatom in oemol.GetAtoms()
+            ]
+            partial_charges_str = " ".join([f"{val:f}" for val in partial_charges_list])
             # TODO: "dprop" means "double precision" -- Is there any way to make Python more accurately
             #  describe/infer the proper data type?
             oechem.OESetSDData(oemol, "atom.dprop.PartialCharge", partial_charges_str)
@@ -727,6 +809,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             mol.partial_charges=None.
         """
         from openeye import oechem
+
         for dp in oechem.OEGetSDDataPairs(oemol):
             if dp.GetTag() == "atom.dprop.PartialCharge":
                 charges_str = oechem.OEGetSDData(oemol, "atom.dprop.PartialCharge")
@@ -739,7 +822,9 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         return False
 
     @classmethod
-    def _read_oemolistream_molecules(cls, oemolistream, allow_undefined_stereo, file_path=None):
+    def _read_oemolistream_molecules(
+        cls, oemolistream, allow_undefined_stereo, file_path=None
+    ):
         """
         Reads and return the Molecules in a OEMol input stream.
 
@@ -770,7 +855,9 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             oechem.OE3DToInternalStereo(oemol)
 
             # If this is either a multi-conformer or multi-molecule SD file, check to see if there are partial charges
-            if (oemolistream.GetFormat() == oechem.OEFormat_SDF) and hasattr(oemol, 'GetConfs'):
+            if (oemolistream.GetFormat() == oechem.OEFormat_SDF) and hasattr(
+                oemol, "GetConfs"
+            ):
                 # The openFF toolkit treats each conformer in a "multiconformer" SDF as
                 # a separate molecule.
                 # https://github.com/openforcefield/openforcefield/issues/202
@@ -789,21 +876,27 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
                     # Then, we take any SD data pairs that were on the oemol, and copy them on to "this_conf_oemcmol".
                     # These SD pairs will be populated if we're dealing with a single-conformer SDF.
                     for dp in oechem.OEGetSDDataPairs(oemol):
-                        oechem.OESetSDData(this_conf_oemcmol, dp.GetTag(), dp.GetValue())
+                        oechem.OESetSDData(
+                            this_conf_oemcmol, dp.GetTag(), dp.GetValue()
+                        )
                     # On the other hand, these SD pairs will be populated if we're dealing with a MULTI-conformer SDF.
                     for dp in oechem.OEGetSDDataPairs(conf):
-                        oechem.OESetSDData(this_conf_oemcmol, dp.GetTag(), dp.GetValue())
+                        oechem.OESetSDData(
+                            this_conf_oemcmol, dp.GetTag(), dp.GetValue()
+                        )
                     # This function fishes out the special SD data tag we use for partial charge
                     # ("atom.dprop.PartialCharge"), and applies those as OETK-supported partial charges on the OEAtoms
-                    has_charges = cls._turn_oemolbase_sd_charges_into_partial_charges(this_conf_oemcmol)
+                    has_charges = cls._turn_oemolbase_sd_charges_into_partial_charges(
+                        this_conf_oemcmol
+                    )
 
                     # Finally, we feed the molecule into `from_openeye`, where it converted into an OFFMol
                     mol = cls.from_openeye(
-                        this_conf_oemcmol,
-                        allow_undefined_stereo=allow_undefined_stereo)
+                        this_conf_oemcmol, allow_undefined_stereo=allow_undefined_stereo
+                    )
 
                     # If the molecule didn't even have the `PartialCharges` tag, we set it from zeroes to None here.
-                    if not(has_charges):
+                    if not (has_charges):
                         mol.partial_charges = None
                     mols.append(mol)
 
@@ -812,8 +905,8 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
                 # stash partial charges into actual per-atom partial charges
                 cls._turn_oemolbase_sd_charges_into_partial_charges(oemol)
                 mol = cls.from_openeye(
-                    oemol,
-                    allow_undefined_stereo=allow_undefined_stereo)
+                    oemol, allow_undefined_stereo=allow_undefined_stereo
+                )
                 mols.append(mol)
 
             # Check if this is an AMBER-produced mol2 file, which we can not load because they use GAFF atom types.
@@ -841,6 +934,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         """
 
         from openeye import oequacpac
+
         options = oequacpac.OEFormalChargeOptions()
         # add one as the input is included
         options.SetMaxCount(max_states + 1)
@@ -857,7 +951,9 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         return molecules
 
-    def enumerate_stereoisomers(self, molecule, undefined_only=False, max_isomers=20, rationalise=True):
+    def enumerate_stereoisomers(
+        self, molecule, undefined_only=False, max_isomers=20, rationalise=True
+    ):
         """
         Enumerate the stereocenters and bonds of the current molecule.
 
@@ -882,6 +978,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         """
         from openeye import oeomega, oechem
+
         oemol = self.to_openeye(molecule=molecule)
 
         # arguments for this function can be found here
@@ -930,6 +1027,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             A list of openforcefield.topology.Molecule instances excluding the input molecule.
         """
         from openeye import oequacpac
+
         oemol = self.to_openeye(molecule=molecule)
 
         tautomers = []
@@ -946,7 +1044,9 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             # remove the input tautomer from the output
             taut = self.from_openeye(tautomer, allow_undefined_stereo=True)
             if taut != molecule:
-                tautomers.append(self.from_openeye(tautomer, allow_undefined_stereo=True))
+                tautomers.append(
+                    self.from_openeye(tautomer, allow_undefined_stereo=True)
+                )
 
         return tautomers
 
@@ -969,16 +1069,13 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         """
         # Handle default.
         if file_path is None:
-            file_path = ''
+            file_path = ""
         else:
             # Append a ':' character that will separate the file
             # path from the molecule string representation.
-            file_path = file_path + ':'
+            file_path = file_path + ":"
         # atomic_number: (GAFF_type, element_name)
-        warning_atomic_numbers = {
-            76: ('OS', 'Osmium'),
-            67: ('HO', 'Holmium')
-        }
+        warning_atomic_numbers = {76: ("OS", "Osmium"), 67: ("HO", "Holmium")}
 
         for atom in molecule.atoms:
             try:
@@ -987,9 +1084,12 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
                 pass
             else:
                 import warnings
-                warn_msg = (f'OpenEye interpreted the type "{atom_type}" in {file_path}{molecule.name}'
-                            f' as {element_name}. Does your mol2 file uses Tripos SYBYL atom types?'
-                            ' Other atom types such as GAFF are not supported.')
+
+                warn_msg = (
+                    f'OpenEye interpreted the type "{atom_type}" in {file_path}{molecule.name}'
+                    f" as {element_name}. Does your mol2 file uses Tripos SYBYL atom types?"
+                    " Other atom types such as GAFF are not supported."
+                )
                 warnings.warn(warn_msg, GAFFAtomTypeWarning)
 
     @staticmethod
@@ -1019,9 +1119,9 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         cip = oechem.OEPerceiveCIPStereo(oemol, oeatom)
 
         if cip == oechem.OECIPAtomStereo_S:
-            return 'S'
+            return "S"
         elif cip == oechem.OECIPAtomStereo_R:
-            return 'R'
+            return "R"
         elif cip == oechem.OECIPAtomStereo_NotStereo:
             # Not a stereocenter
             # TODO: Should this be a different case from ``None``?
@@ -1055,9 +1155,9 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         cip = oechem.OEPerceiveCIPStereo(oemol, oebond)
 
         if cip == oechem.OECIPBondStereo_E:
-            return 'E'
+            return "E"
         elif cip == oechem.OECIPBondStereo_Z:
-            return 'Z'
+            return "Z"
         elif cip == oechem.OECIPBondStereo_NotStereo:
             return None
 
@@ -1111,7 +1211,6 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         from openforcefield.topology.molecule import Molecule
         import math
 
-
         # Add explicit hydrogens if they're implicit
         if oechem.OEHasImplicitHydrogens(oemol):
             oechem.OEAddExplicitHydrogens(oemol)
@@ -1140,39 +1239,45 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
                 if not (oebond.HasStereoSpecified()):
                     unspec_db = True
                     problematic_bonds.append(oebond)
-        if (unspec_chiral or unspec_db):
+        if unspec_chiral or unspec_db:
 
             def oeatom_to_str(oeatom):
-                return 'atomic num: {}, name: {}, idx: {}, aromatic: {}, chiral: {}'.format(
-                    oeatom.GetAtomicNum(), oeatom.GetName(), oeatom.GetIdx(),
-                    oeatom.IsAromatic(), oeatom.IsChiral())
+                return "atomic num: {}, name: {}, idx: {}, aromatic: {}, chiral: {}".format(
+                    oeatom.GetAtomicNum(),
+                    oeatom.GetName(),
+                    oeatom.GetIdx(),
+                    oeatom.IsAromatic(),
+                    oeatom.IsChiral(),
+                )
 
             def oebond_to_str(oebond):
-                return "order: {}, chiral: {}".format(oebond.GetOrder(),
-                                                      oebond.IsChiral())
+                return "order: {}, chiral: {}".format(
+                    oebond.GetOrder(), oebond.IsChiral()
+                )
 
             def describe_oeatom(oeatom):
-                description = "Atom {} with bonds:".format(
-                    oeatom_to_str(oeatom))
+                description = "Atom {} with bonds:".format(oeatom_to_str(oeatom))
                 for oebond in oeatom.GetBonds():
                     description += "\nbond {} to atom {}".format(
-                        oebond_to_str(oebond),
-                        oeatom_to_str(oebond.GetNbr(oeatom)))
+                        oebond_to_str(oebond), oeatom_to_str(oebond.GetNbr(oeatom))
+                    )
                 return description
 
-            msg = "OEMol has unspecified stereochemistry. " \
-                  "oemol.GetTitle(): {}\n".format(oemol.GetTitle())
+            msg = (
+                "OEMol has unspecified stereochemistry. "
+                "oemol.GetTitle(): {}\n".format(oemol.GetTitle())
+            )
             if len(problematic_atoms) != 0:
                 msg += "Problematic atoms are:\n"
                 for problematic_atom in problematic_atoms:
-                    msg += describe_oeatom(problematic_atom) + '\n'
+                    msg += describe_oeatom(problematic_atom) + "\n"
             if len(problematic_bonds) != 0:
                 msg += "Problematic bonds are: {}\n".format(problematic_bonds)
             if allow_undefined_stereo:
-                msg = 'Warning (not error because allow_undefined_stereo=True): ' + msg
+                msg = "Warning (not error because allow_undefined_stereo=True): " + msg
                 logger.warning(msg)
             else:
-                msg = 'Unable to make OFFMol from OEMol: ' + msg
+                msg = "Unable to make OFFMol from OEMol: " + msg
                 raise UndefinedStereochemistryError(msg)
 
         molecule = Molecule()
@@ -1191,24 +1296,27 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             formal_charge = oeatom.GetFormalCharge() * unit.elementary_charge
             is_aromatic = oeatom.IsAromatic()
             stereochemistry = OpenEyeToolkitWrapper._openeye_cip_atom_stereochemistry(
-                oemol, oeatom)
-            #stereochemistry = self._openeye_cip_atom_stereochemistry(oemol, oeatom)
-            name = ''
-            if oeatom.HasData('name'):
-                name = oeatom.GetData('name')
+                oemol, oeatom
+            )
+            # stereochemistry = self._openeye_cip_atom_stereochemistry(oemol, oeatom)
+            name = ""
+            if oeatom.HasData("name"):
+                name = oeatom.GetData("name")
             atom_index = molecule.add_atom(
                 atomic_number,
                 formal_charge,
                 is_aromatic,
                 stereochemistry=stereochemistry,
-                name=name)
+                name=name,
+            )
             map_atoms[
-                oe_idx] = atom_index  # store for mapping oeatom to molecule atom indices below
+                oe_idx
+            ] = atom_index  # store for mapping oeatom to molecule atom indices below
             atom_mapping[atom_index] = map_id
 
         # if we have a full atom map add it to the molecule, 0 indicates a missing mapping or no mapping
         if 0 not in atom_mapping.values():
-            molecule._properties['atom_map'] = atom_mapping
+            molecule._properties["atom_map"] = atom_mapping
 
         for oebond in oemol.GetBonds():
             atom1_index = map_atoms[oebond.GetBgnIdx()]
@@ -1216,9 +1324,10 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             bond_order = oebond.GetOrder()
             is_aromatic = oebond.IsAromatic()
             stereochemistry = OpenEyeToolkitWrapper._openeye_cip_bond_stereochemistry(
-                oemol, oebond)
-            if oebond.HasData('fractional_bond_order'):
-                fractional_bond_order = oebond.GetData('fractional_bond_order')
+                oemol, oebond
+            )
+            if oebond.HasData("fractional_bond_order"):
+                fractional_bond_order = oebond.GetData("fractional_bond_order")
             else:
                 fractional_bond_order = None
 
@@ -1228,21 +1337,24 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
                 bond_order,
                 is_aromatic=is_aromatic,
                 stereochemistry=stereochemistry,
-                fractional_bond_order=fractional_bond_order)
+                fractional_bond_order=fractional_bond_order,
+            )
 
         # TODO: Copy conformations, if present
         # TODO: Come up with some scheme to know when to import coordinates
         # From SMILES: no
         # From MOL2: maybe
         # From other: maybe
-        if hasattr(oemol, 'GetConfs'):
+        if hasattr(oemol, "GetConfs"):
             for conf in oemol.GetConfs():
                 n_atoms = molecule.n_atoms
                 positions = unit.Quantity(
-                    np.zeros([n_atoms, 3], np.float), unit.angstrom)
+                    np.zeros([n_atoms, 3], np.float), unit.angstrom
+                )
                 for oe_id in conf.GetCoords().keys():
-                    off_atom_coords = unit.Quantity(conf.GetCoords()[oe_id],
-                                                    unit.angstrom)
+                    off_atom_coords = unit.Quantity(
+                        conf.GetCoords()[oe_id], unit.angstrom
+                    )
                     off_atom_index = map_atoms[oe_id]
                     positions[off_atom_index, :] = off_atom_coords
                 if (positions == 0 * unit.angstrom).all() and n_atoms > 1:
@@ -1251,8 +1363,8 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         # Copy partial charges, if present
         partial_charges = unit.Quantity(
-            np.zeros(molecule.n_atoms, dtype=np.float),
-            unit=unit.elementary_charge)
+            np.zeros(molecule.n_atoms, dtype=np.float), unit=unit.elementary_charge
+        )
 
         # If all OEAtoms have a partial charge of NaN, then the OFFMol should
         # have its partial_charges attribute set to None
@@ -1263,7 +1375,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             unitless_charge = oe_atom.GetPartialCharge()
             if not math.isnan(unitless_charge):
                 any_partial_charge_is_not_nan = True
-                #break
+                # break
             charge = unitless_charge * unit.elementary_charge
             partial_charges[off_idx] = charge
 
@@ -1330,36 +1442,36 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             )
 
         oemol = oechem.OEMol()
-        #if not(molecule.name is None):
+        # if not(molecule.name is None):
         oemol.SetTitle(molecule.name)
         map_atoms = {}  # {off_idx : oe_idx}
         # Add atoms
         oemol_atoms = list()  # list of corresponding oemol atoms
         for atom in molecule.atoms:
             oeatom = oemol.NewAtom(atom.atomic_number)
-            oeatom.SetFormalCharge(atom.formal_charge.value_in_unit(unit.elementary_charge)) # simtk.unit.Quantity(1, unit.elementary_charge)
+            oeatom.SetFormalCharge(
+                atom.formal_charge.value_in_unit(unit.elementary_charge)
+            )  # simtk.unit.Quantity(1, unit.elementary_charge)
             # TODO: Do we want to provide _any_ pathway for Atom.is_aromatic to influence the OEMol?
-            #oeatom.SetAromatic(atom.is_aromatic)
-            oeatom.SetData('name', atom.name)
-            oeatom.SetPartialCharge(float('nan'))
+            # oeatom.SetAromatic(atom.is_aromatic)
+            oeatom.SetData("name", atom.name)
+            oeatom.SetPartialCharge(float("nan"))
             oemol_atoms.append(oeatom)
             map_atoms[atom.molecule_atom_index] = oeatom.GetIdx()
 
         # Add bonds
         oemol_bonds = list()  # list of corresponding oemol bonds
         for bond in molecule.bonds:
-            #atom1_index = molecule.atoms.index(bond.atom1)
-            #atom2_index = molecule.atoms.index(bond.atom2)
+            # atom1_index = molecule.atoms.index(bond.atom1)
+            # atom2_index = molecule.atoms.index(bond.atom2)
             atom1_index = bond.atom1_index
             atom2_index = bond.atom2_index
-            oebond = oemol.NewBond(oemol_atoms[atom1_index],
-                                   oemol_atoms[atom2_index])
+            oebond = oemol.NewBond(oemol_atoms[atom1_index], oemol_atoms[atom2_index])
             oebond.SetOrder(bond.bond_order)
             # TODO: Do we want to provide _any_ pathway for Bond.is_aromatic to influence the OEMol?
-            #oebond.SetAromatic(bond.is_aromatic)
+            # oebond.SetAromatic(bond.is_aromatic)
             if not (bond.fractional_bond_order is None):
-                oebond.SetData('fractional_bond_order',
-                               bond.fractional_bond_order)
+                oebond.SetData("fractional_bond_order", bond.fractional_bond_order)
             oemol_bonds.append(oebond)
 
         oechem.OEAssignAromaticFlags(oemol, oe_aro_model)
@@ -1371,22 +1483,26 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
             # Set arbitrary initial stereochemistry
             neighs = [n for n in oeatom.GetAtoms()]
-            oeatom.SetStereo(neighs, oechem.OEAtomStereo_Tetra,
-                             oechem.OEAtomStereo_Right)
+            oeatom.SetStereo(
+                neighs, oechem.OEAtomStereo_Tetra, oechem.OEAtomStereo_Right
+            )
 
             # Flip chirality if stereochemistry isincorrect
             oeatom_stereochemistry = OpenEyeToolkitWrapper._openeye_cip_atom_stereochemistry(
-                oemol, oeatom)
+                oemol, oeatom
+            )
             if oeatom_stereochemistry != atom.stereochemistry:
                 # Flip the stereochemistry
-                oeatom.SetStereo(neighs, oechem.OEAtomStereo_Tetra,
-                                 oechem.OEAtomStereo_Left)
+                oeatom.SetStereo(
+                    neighs, oechem.OEAtomStereo_Tetra, oechem.OEAtomStereo_Left
+                )
                 # Verify it matches now as a sanity check
                 oeatom_stereochemistry = OpenEyeToolkitWrapper._openeye_cip_atom_stereochemistry(
-                    oemol, oeatom)
+                    oemol, oeatom
+                )
                 if oeatom_stereochemistry != atom.stereochemistry:
                     raise Exception(
-                        'Programming error: OpenEye atom stereochemistry assumptions failed.'
+                        "Programming error: OpenEye atom stereochemistry assumptions failed."
                     )
 
         # Set bond stereochemistry
@@ -1397,33 +1513,34 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             atom1_index = bond.molecule.atoms.index(bond.atom1)
             atom2_index = bond.molecule.atoms.index(bond.atom2)
             # Set arbitrary initial stereochemistry
-            oeatom1, oeatom2 = oemol_atoms[atom1_index], oemol_atoms[
-                atom2_index]
-            oeatom1_neighbor = [
-                n for n in oeatom1.GetAtoms() if not n == oeatom2
-            ][0]
-            oeatom2_neighbor = [
-                n for n in oeatom2.GetAtoms() if not n == oeatom1
-            ][0]
-            #oebond.SetStereo([oeatom1, oeatom2], oechem.OEBondStereo_CisTrans, oechem.OEBondStereo_Cis)
-            oebond.SetStereo([oeatom1_neighbor, oeatom2_neighbor],
-                             oechem.OEBondStereo_CisTrans,
-                             oechem.OEBondStereo_Cis)
+            oeatom1, oeatom2 = oemol_atoms[atom1_index], oemol_atoms[atom2_index]
+            oeatom1_neighbor = [n for n in oeatom1.GetAtoms() if not n == oeatom2][0]
+            oeatom2_neighbor = [n for n in oeatom2.GetAtoms() if not n == oeatom1][0]
+            # oebond.SetStereo([oeatom1, oeatom2], oechem.OEBondStereo_CisTrans, oechem.OEBondStereo_Cis)
+            oebond.SetStereo(
+                [oeatom1_neighbor, oeatom2_neighbor],
+                oechem.OEBondStereo_CisTrans,
+                oechem.OEBondStereo_Cis,
+            )
 
             # Flip stereochemistry if incorrect
             oebond_stereochemistry = OpenEyeToolkitWrapper._openeye_cip_bond_stereochemistry(
-                oemol, oebond)
+                oemol, oebond
+            )
             if oebond_stereochemistry != bond.stereochemistry:
                 # Flip the stereochemistry
-                oebond.SetStereo([oeatom1_neighbor, oeatom2_neighbor],
-                                 oechem.OEBondStereo_CisTrans,
-                                 oechem.OEBondStereo_Trans)
+                oebond.SetStereo(
+                    [oeatom1_neighbor, oeatom2_neighbor],
+                    oechem.OEBondStereo_CisTrans,
+                    oechem.OEBondStereo_Trans,
+                )
                 # Verify it matches now as a sanity check
                 oebond_stereochemistry = OpenEyeToolkitWrapper._openeye_cip_bond_stereochemistry(
-                    oemol, oebond)
+                    oemol, oebond
+                )
                 if oebond_stereochemistry != bond.stereochemistry:
                     raise Exception(
-                        'Programming error: OpenEye bond stereochemistry assumptions failed.'
+                        "Programming error: OpenEye bond stereochemistry assumptions failed."
                     )
 
         # Retain conformations, if present
@@ -1431,8 +1548,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             oemol.DeleteConfs()
             for conf in molecule._conformers:
                 # OE needs a 1 x (3*n_Atoms) double array as input
-                flat_coords = np.zeros((oemol.NumAtoms() * 3),
-                                       dtype=np.float32)
+                flat_coords = np.zeros((oemol.NumAtoms() * 3), dtype=np.float32)
                 for index, oe_idx in map_atoms.items():
                     (x, y, z) = conf[index, :] / unit.angstrom
                     flat_coords[(3 * oe_idx)] = x
@@ -1453,7 +1569,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             #  It's worth investigating whether we make this assumption elsewhere in the codebase, since
             #  the OE docs may indicate that this sort of usage is a very bad thing to do.
             #  https://docs.eyesopen.com/toolkits/python/oechemtk/atombondindices.html#indices-for-molecule-lookup-considered-harmful
-            #for oe_idx, oe_atom in enumerate(oemol.GetAtoms()):
+            # for oe_idx, oe_atom in enumerate(oemol.GetAtoms()):
             for oe_atom in oemol.GetAtoms():
                 oe_idx = oe_atom.GetIdx()
                 oe_atom.SetPartialCharge(oe_indexed_charges[oe_idx])
@@ -1495,28 +1611,37 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             The SMILES of the input molecule.
         """
         from openeye import oechem
+
         oemol = self.to_openeye(molecule)
 
         # this sets up the default settings following the old DEFAULT flag
         # more information on flags can be found here
         # <https://docs.eyesopen.com/toolkits/python/oechemtk/OEChemConstants/OESMILESFlag.html#OEChem::OESMILESFlag>
-        smiles_options = oechem.OESMILESFlag_Canonical | oechem.OESMILESFlag_Isotopes | oechem.OESMILESFlag_RGroups
+        smiles_options = (
+            oechem.OESMILESFlag_Canonical
+            | oechem.OESMILESFlag_Isotopes
+            | oechem.OESMILESFlag_RGroups
+        )
 
         # check if we want an isomeric smiles
         if isomeric:
             # add the atom and bond stereo flags
-            smiles_options |= oechem.OESMILESFlag_AtomStereo | oechem.OESMILESFlag_BondStereo
+            smiles_options |= (
+                oechem.OESMILESFlag_AtomStereo | oechem.OESMILESFlag_BondStereo
+            )
 
         if explicit_hydrogens:
             # add the hydrogen flag
             smiles_options |= oechem.OESMILESFlag_Hydrogens
 
         if mapped:
-            assert explicit_hydrogens is True, "Mapped smiles require all hydrogens and " \
-                                                "stereochemsitry to be defined to retain order"
+            assert explicit_hydrogens is True, (
+                "Mapped smiles require all hydrogens and "
+                "stereochemsitry to be defined to retain order"
+            )
 
             # if we only want to map specific atoms check for an atom map
-            atom_map = molecule._properties.get('atom_map', None)
+            atom_map = molecule._properties.get("atom_map", None)
             if atom_map is not None:
                 # make sure there are no repeated indices
                 map_ids = set(atom_map.values())
@@ -1569,6 +1694,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         """
 
         from openeye import oechem
+
         oemol = self.to_openeye(molecule)
 
         if fixed_hydrogens:
@@ -1605,6 +1731,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         """
 
         from openeye import oechem
+
         oemol = self.to_openeye(molecule)
 
         if fixed_hydrogens:
@@ -1633,6 +1760,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         """
 
         from openeye import oechem
+
         oemol = self.to_openeye(molecule)
 
         oechem.OECanonicalOrderAtoms(oemol)
@@ -1647,7 +1775,10 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         vbnd = []
         for bond in oemol.GetBonds():
-            if bond.GetBgn().GetAtomicNum() != oechem.OEElemNo_H and bond.GetEnd().GetAtomicNum() != oechem.OEElemNo_H:
+            if (
+                bond.GetBgn().GetAtomicNum() != oechem.OEElemNo_H
+                and bond.GetEnd().GetAtomicNum() != oechem.OEElemNo_H
+            ):
                 vbnd.append(bond)
         oemol.OrderBonds(vbnd)
 
@@ -1659,7 +1790,9 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         return self.from_openeye(oemol, allow_undefined_stereo=True)
 
-    def from_smiles(self, smiles, hydrogens_are_explicit=False, allow_undefined_stereo=False):
+    def from_smiles(
+        self, smiles, hydrogens_are_explicit=False, allow_undefined_stereo=False
+    ):
         """
         Create a Molecule from a SMILES string using the OpenEye toolkit.
 
@@ -1683,27 +1816,31 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         """
 
         from openeye import oechem
+
         oemol = oechem.OEGraphMol()
         oechem.OESmilesToMol(oemol, smiles)
         if not (hydrogens_are_explicit):
             result = oechem.OEAddExplicitHydrogens(oemol)
             if result == False:
                 raise ValueError(
-                    "Addition of explicit hydrogens failed in from_openeye")
+                    "Addition of explicit hydrogens failed in from_openeye"
+                )
         elif hydrogens_are_explicit and oechem.OEHasImplicitHydrogens(oemol):
             raise ValueError(
                 f"'hydrogens_are_explicit' was specified as True, but OpenEye Toolkit interpreted "
                 f"SMILES '{smiles}' as having implicit hydrogen. If this SMILES is intended to "
                 f"express all explicit hydrogens in the molecule, then you should construct the "
                 f"desired molecule as an OEMol (where oechem.OEHasImplicitHydrogens(oemol) returns "
-                f"False), and then use Molecule.from_openeye() to create the desired OFFMol.")
+                f"False), and then use Molecule.from_openeye() to create the desired OFFMol."
+            )
 
         # Set partial charges to None, since they couldn't have been stored in a SMILES
         for atom in oemol.GetAtoms():
-            atom.SetPartialCharge(float('nan'))
+            atom.SetPartialCharge(float("nan"))
 
-        molecule = self.from_openeye(oemol,
-                                     allow_undefined_stereo=allow_undefined_stereo)
+        molecule = self.from_openeye(
+            oemol, allow_undefined_stereo=allow_undefined_stereo
+        )
         return molecule
 
     def from_inchi(self, inchi, allow_undefined_stereo=False):
@@ -1726,6 +1863,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         """
 
         from openeye import oechem
+
         # This calls the same functions as OESmilesToMol
         oemol = oechem.OEGraphMol()
         oechem.OEInChIToMol(oemol, inchi)
@@ -1733,13 +1871,19 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         # try and catch InChI parsing fails
         # if there are no atoms don't build the molecule
         if oemol.NumAtoms() == 0:
-            raise RuntimeError('There was an issue parsing the InChI string, please check and try again.')
+            raise RuntimeError(
+                "There was an issue parsing the InChI string, please check and try again."
+            )
 
-        molecule = self.from_openeye(oemol, allow_undefined_stereo=allow_undefined_stereo)
+        molecule = self.from_openeye(
+            oemol, allow_undefined_stereo=allow_undefined_stereo
+        )
 
         return molecule
 
-    def generate_conformers(self, molecule, n_conformers=1, rms_cutoff=None, clear_existing=True):
+    def generate_conformers(
+        self, molecule, n_conformers=1, rms_cutoff=None, clear_existing=True
+    ):
         """
         Generate molecule conformers using OpenEye Omega.
 
@@ -1765,12 +1909,13 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         """
         from openeye import oeomega
+
         oemol = self.to_openeye(molecule)
         omega = oeomega.OEOmega()
         omega.SetMaxConfs(n_conformers)
         omega.SetCanonOrder(False)
         omega.SetSampleHydrogens(True)
-        omega.SetEnergyWindow(15.0)  #unit?
+        omega.SetEnergyWindow(15.0)  # unit?
         if rms_cutoff is None:
             omega.SetRMSThreshold(1.0)
         else:
@@ -1785,7 +1930,6 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             if new_status is False:
                 raise Exception("OpenEye Omega conformer generation failed")
 
-
         molecule2 = self.from_openeye(oemol, allow_undefined_stereo=True)
 
         if clear_existing:
@@ -1794,11 +1938,13 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         for conformer in molecule2._conformers:
             molecule._add_conformer(conformer)
 
-    def assign_partial_charges(self,
-                               molecule,
-                               partial_charge_method=None,
-                               use_conformers=None,
-                               strict_n_conformers=False):
+    def assign_partial_charges(
+        self,
+        molecule,
+        partial_charge_method=None,
+        use_conformers=None,
+        strict_n_conformers=False,
+    ):
         """
         Compute partial charges with OpenEye quacpac, and assign
         the new values to the partial_charges attribute.
@@ -1836,42 +1982,52 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         import numpy as np
         from openforcefield.topology import Molecule
 
-        SUPPORTED_CHARGE_METHODS = {'am1bcc': {'oe_charge_method': oequacpac.OEAM1BCCCharges,
-                                               'min_confs': 1,
-                                               'max_confs': 1,
-                                               'rec_confs': 1,
-                                               },
-                                    'am1-mulliken': {'oe_charge_method': oequacpac.OEAM1Charges,
-                                                     'min_confs': 1,
-                                                     'max_confs': 1,
-                                                     'rec_confs': 1,
-                                                     },
-                                    'gasteiger': {'oe_charge_method': oequacpac.OEGasteigerCharges,
-                                                  'min_confs': 0,
-                                                  'max_confs': 0,
-                                                  'rec_confs': 0,
-                                                  },
-                                    'mmff94': {'oe_charge_method': oequacpac.OEMMFF94Charges,
-                                                  'min_confs': 0,
-                                                  'max_confs': 0,
-                                                  'rec_confs': 0,
-                                                  },
-                                    'am1bccnosymspt': {'oe_charge_method': oequacpac.OEAM1BCCCharges,
-                                                       'min_confs': 1,
-                                                       'max_confs': 1,
-                                                       'rec_confs': 1,
-                                                       },
-                                    'am1elf10': {'oe_charge_method': oequacpac.OEELFCharges(oequacpac.OEAM1Charges(optimize=True, symmetrize=True), 10),
-                                                 'min_confs': 1,
-                                                 'max_confs': None,
-                                                 'rec_confs': 500,
-                                                },
-                                    'am1bccelf10': {'oe_charge_method': oequacpac.OEAM1BCCELF10Charges,
-                                                  'min_confs': 1,
-                                                  'max_confs': None,
-                                                  'rec_confs': 500,
-                                                  },
-                                    }
+        SUPPORTED_CHARGE_METHODS = {
+            "am1bcc": {
+                "oe_charge_method": oequacpac.OEAM1BCCCharges,
+                "min_confs": 1,
+                "max_confs": 1,
+                "rec_confs": 1,
+            },
+            "am1-mulliken": {
+                "oe_charge_method": oequacpac.OEAM1Charges,
+                "min_confs": 1,
+                "max_confs": 1,
+                "rec_confs": 1,
+            },
+            "gasteiger": {
+                "oe_charge_method": oequacpac.OEGasteigerCharges,
+                "min_confs": 0,
+                "max_confs": 0,
+                "rec_confs": 0,
+            },
+            "mmff94": {
+                "oe_charge_method": oequacpac.OEMMFF94Charges,
+                "min_confs": 0,
+                "max_confs": 0,
+                "rec_confs": 0,
+            },
+            "am1bccnosymspt": {
+                "oe_charge_method": oequacpac.OEAM1BCCCharges,
+                "min_confs": 1,
+                "max_confs": 1,
+                "rec_confs": 1,
+            },
+            "am1elf10": {
+                "oe_charge_method": oequacpac.OEELFCharges(
+                    oequacpac.OEAM1Charges(optimize=True, symmetrize=True), 10
+                ),
+                "min_confs": 1,
+                "max_confs": None,
+                "rec_confs": 500,
+            },
+            "am1bccelf10": {
+                "oe_charge_method": oequacpac.OEAM1BCCELF10Charges,
+                "min_confs": 1,
+                "max_confs": None,
+                "rec_confs": 500,
+            },
+        }
 
         if partial_charge_method is None:
             partial_charge_method = "am1-mulliken"
@@ -1890,22 +2046,26 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         mol_copy = Molecule(molecule)
 
         if use_conformers is None:
-            if charge_method['rec_confs'] == 0:
+            if charge_method["rec_confs"] == 0:
                 mol_copy._conformers = None
             else:
-                self.generate_conformers(mol_copy,
-                                         n_conformers=charge_method['rec_confs'],
-                                         rms_cutoff=0.25*unit.angstrom)
+                self.generate_conformers(
+                    mol_copy,
+                    n_conformers=charge_method["rec_confs"],
+                    rms_cutoff=0.25 * unit.angstrom,
+                )
                 # TODO: What's a "best practice" RMS cutoff to use here?
         else:
             mol_copy._conformers = None
             for conformer in use_conformers:
                 mol_copy.add_conformer(conformer)
-            self._check_n_conformers(mol_copy,
-                                     partial_charge_method=partial_charge_method,
-                                     min_confs=charge_method['min_confs'],
-                                     max_confs=charge_method['max_confs'],
-                                     strict_n_conformers=strict_n_conformers)
+            self._check_n_conformers(
+                mol_copy,
+                partial_charge_method=partial_charge_method,
+                min_confs=charge_method["min_confs"],
+                max_confs=charge_method["max_confs"],
+                strict_n_conformers=strict_n_conformers,
+            )
 
         oemol = mol_copy.to_openeye()
 
@@ -1919,9 +2079,11 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         if partial_charge_method == "am1bccnosymspt":
             optimize = False
             symmetrize = False
-            quacpac_status = oequacpac.OEAssignCharges(oemol, charge_method['oe_charge_method'](optimize, symmetrize))
+            quacpac_status = oequacpac.OEAssignCharges(
+                oemol, charge_method["oe_charge_method"](optimize, symmetrize)
+            )
         else:
-            oe_charge_method = charge_method['oe_charge_method']
+            oe_charge_method = charge_method["oe_charge_method"]
 
             if callable(oe_charge_method):
                 oe_charge_method = oe_charge_method()
@@ -1932,22 +2094,33 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         # This logic handles errors encountered in #34, which can occur when using ELF10 conformer selection
         if not quacpac_status:
 
-            oe_charge_engine = oequacpac.OEAM1Charges if partial_charge_method == "am1elf10" else oequacpac.OEAM1BCCCharges
+            oe_charge_engine = (
+                oequacpac.OEAM1Charges
+                if partial_charge_method == "am1elf10"
+                else oequacpac.OEAM1BCCCharges
+            )
 
-            if "SelectElfPop: issue with removing trans COOH conformers" in (errfs.str().decode("UTF-8")):
-                logger.warning(f"Warning: charge assignment involving ELF10 conformer selection failed due to a known bug (toolkit issue "
-                               f"#346). Downgrading to {oe_charge_engine.__name__} charge assignment for this molecule. More information"
-                               f"is available at https://github.com/openforcefield/openforcefield/issues/346")
+            if "SelectElfPop: issue with removing trans COOH conformers" in (
+                errfs.str().decode("UTF-8")
+            ):
+                logger.warning(
+                    f"Warning: charge assignment involving ELF10 conformer selection failed due to a known bug (toolkit issue "
+                    f"#346). Downgrading to {oe_charge_engine.__name__} charge assignment for this molecule. More information"
+                    f"is available at https://github.com/openforcefield/openforcefield/issues/346"
+                )
                 quacpac_status = oequacpac.OEAssignCharges(oemol, oe_charge_engine())
 
         if quacpac_status is False:
-            raise ChargeCalculationError(f'Unable to assign charges: {errfs.str().decode("UTF-8")}')
+            raise ChargeCalculationError(
+                f'Unable to assign charges: {errfs.str().decode("UTF-8")}'
+            )
 
         # Extract and return charges
         ## TODO: Make sure atom mapping remains constant
 
         charges = unit.Quantity(
-            np.zeros([oemol.NumAtoms()], np.float64), unit.elementary_charge)
+            np.zeros([oemol.NumAtoms()], np.float64), unit.elementary_charge
+        )
         for oeatom in oemol.GetAtoms():
             index = oeatom.GetIdx()
             charge = oeatom.GetPartialCharge()
@@ -1956,8 +2129,9 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         molecule.partial_charges = charges
 
-
-    def compute_partial_charges_am1bcc(self, molecule, use_conformers=None, strict_n_conformers=False):
+    def compute_partial_charges_am1bcc(
+        self, molecule, use_conformers=None, strict_n_conformers=False
+    ):
         """
         Compute AM1BCC partial charges with OpenEye quacpac. This function will attempt to use
         the OEAM1BCCELF10 charge generation method, but may print a warning and fall back to
@@ -1986,16 +2160,23 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         """
 
         import warnings
-        warnings.warn("compute_partial_charges_am1bcc will be deprecated in an upcoming release. "
-                      "Use assign_partial_charges(partial_charge_method='am1bccelf10') instead.",
-                      DeprecationWarning)
-        self.assign_partial_charges(molecule,
-                                    partial_charge_method='am1bccelf10',
-                                    use_conformers=use_conformers,
-                                    strict_n_conformers=strict_n_conformers)
+
+        warnings.warn(
+            "compute_partial_charges_am1bcc will be deprecated in an upcoming release. "
+            "Use assign_partial_charges(partial_charge_method='am1bccelf10') instead.",
+            DeprecationWarning,
+        )
+        self.assign_partial_charges(
+            molecule,
+            partial_charge_method="am1bccelf10",
+            use_conformers=use_conformers,
+            strict_n_conformers=strict_n_conformers,
+        )
         return molecule.partial_charges
 
-    def assign_fractional_bond_orders(self, molecule, bond_order_model=None, use_conformers=None):
+    def assign_fractional_bond_orders(
+        self, molecule, bond_order_model=None, use_conformers=None
+    ):
         """
         Update and store list of bond orders this molecule. Bond orders are stored on each
         bond, in the `bond.fractional_bond_order` attribute.
@@ -2015,6 +2196,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
          """
         from openeye import oequacpac
         from openforcefield.topology import Molecule
+
         # Make a copy since we'll be messing with this molecule's conformers
         temp_mol = Molecule(molecule)
         if use_conformers is None:
@@ -2024,7 +2206,6 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             for conformer in use_conformers:
                 temp_mol.add_conformer(conformer)
 
-
         if temp_mol.n_conformers == 0:
             raise Exception(
                 "No conformers present in molecule submitted for fractional bond order calculation. Consider "
@@ -2033,7 +2214,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             )
 
         if bond_order_model is None:
-            bond_order_model = 'am1-wiberg'
+            bond_order_model = "am1-wiberg"
 
         # Based on example at https://docs.eyesopen.com/toolkits/python/quacpactk/examples_summary_wibergbondorders.html
         oemol = self.to_openeye(temp_mol)
@@ -2046,16 +2227,18 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             # TODO: Make sure that modifying am1options actually works
             am1options.SetSemiMethod(oequacpac.OEMethodType_PM3)
         else:
-            raise ValueError(f"Bond order model '{bond_order_model}' is not supported by OpenEyeToolkitWrapper. "
-                             f"Supported models are ['am1-wiberg', 'pm3-wiberg']")
+            raise ValueError(
+                f"Bond order model '{bond_order_model}' is not supported by OpenEyeToolkitWrapper. "
+                f"Supported models are ['am1-wiberg', 'pm3-wiberg']"
+            )
 
-        #for conf in oemol.GetConfs():
-        #TODO: How to handle multiple confs here?
+        # for conf in oemol.GetConfs():
+        # TODO: How to handle multiple confs here?
         status = am1.CalcAM1(am1results, oemol)
 
         if status is False:
             raise Exception(
-                'Unable to assign charges (in the process of calculating fractional bond orders)'
+                "Unable to assign charges (in the process of calculating fractional bond orders)"
             )
 
         # TODO: Will bonds always map back to the same index? Consider doing a topology mapping.
@@ -2093,10 +2276,13 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         """
         from openeye import oechem
         from openforcefield.typing.chemistry import SMIRKSParsingError
+
         qmol = oechem.OEQMol()
         status = oechem.OEParseSmarts(qmol, smarts)
         if status == False:
-            raise SMIRKSParsingError(f"OpenEye Toolkit was unable to parse SMIRKS {smarts}")
+            raise SMIRKSParsingError(
+                f"OpenEye Toolkit was unable to parse SMIRKS {smarts}"
+            )
 
         unique_tags = set()
         connections = set()
@@ -2144,6 +2330,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         """
         from openeye import oechem
         from openeye.oechem import OESubSearch
+
         # Make a copy of molecule so we don't influence original (probably safer than deepcopy per C Bayly)
         mol = oechem.OEMol(oemol)
 
@@ -2157,15 +2344,13 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             if type(aromaticity_model) == str:
                 # Check if the user has provided a manually-specified aromaticity_model
                 if hasattr(oechem, aromaticity_model):
-                    oearomodel = getattr(oechem,
-                                         'OEAroModel_' + aromaticity_model)
+                    oearomodel = getattr(oechem, "OEAroModel_" + aromaticity_model)
                 else:
                     raise ValueError(
                         "Error: provided aromaticity model not recognized by oechem."
                     )
             else:
-                raise ValueError(
-                    "Error: provided aromaticity model must be a string.")
+                raise ValueError("Error: provided aromaticity model must be a string.")
 
             # If aromaticity model was provided, prepare molecule
             oechem.OEClearAromaticFlags(mol)
@@ -2185,20 +2370,16 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
             atom_indices = dict()
             for matched_atom in match.GetAtoms():
                 if matched_atom.pattern.GetMapIdx() != 0:
-                    atom_indices[matched_atom.pattern.GetMapIdx() -
-                                 1] = matched_atom.target.GetIdx()
+                    atom_indices[
+                        matched_atom.pattern.GetMapIdx() - 1
+                    ] = matched_atom.target.GetIdx()
             # Compress into list
-            atom_indices = [
-                atom_indices[index] for index in range(len(atom_indices))
-            ]
+            atom_indices = [atom_indices[index] for index in range(len(atom_indices))]
             # Convert to tuple
             matches.append(tuple(atom_indices))
         return matches
 
-    def find_smarts_matches(self,
-                            molecule,
-                            smarts,
-                            aromaticity_model='OEAroModel_MDL'):
+    def find_smarts_matches(self, molecule, smarts, aromaticity_model="OEAroModel_MDL"):
         """
         Find all SMARTS matches for the specified molecule, using the specified aromaticity model.
 
@@ -2227,24 +2408,34 @@ class RDKitToolkitWrapper(ToolkitWrapper):
     .. warning :: This API is experimental and subject to change.
     """
 
-    _toolkit_name = 'The RDKit'
-    _toolkit_installation_instructions = 'A conda-installable version of the free and open source RDKit cheminformatics ' \
-                                         'toolkit can be found at: https://anaconda.org/rdkit/rdkit'
+    _toolkit_name = "The RDKit"
+    _toolkit_installation_instructions = (
+        "A conda-installable version of the free and open source RDKit cheminformatics "
+        "toolkit can be found at: https://anaconda.org/rdkit/rdkit"
+    )
 
     def __init__(self):
         super().__init__()
 
-        self._toolkit_file_read_formats = ['SDF', 'MOL', 'SMI']  # TODO: Add TDT support
+        self._toolkit_file_read_formats = ["SDF", "MOL", "SMI"]  # TODO: Add TDT support
 
         if not self.is_available():
-            raise ToolkitUnavailableException(f'The required toolkit {self._toolkit_name} is not '
-                                              f'available. {self._toolkit_installation_instructions}')
+            raise ToolkitUnavailableException(
+                f"The required toolkit {self._toolkit_name} is not "
+                f"available. {self._toolkit_installation_instructions}"
+            )
         else:
             from rdkit import Chem
+
             # we have to make sure the toolkit can be loaded before formatting this dict
             # Note any new file write formats should be added here only
-            self._toolkit_file_write_formats = {'SDF': Chem.SDWriter, 'MOL': Chem.SDWriter, 'SMI': Chem.SmilesWriter,
-                                                'PDB': Chem.PDBWriter, 'TDT': Chem.TDTWriter}
+            self._toolkit_file_write_formats = {
+                "SDF": Chem.SDWriter,
+                "MOL": Chem.SDWriter,
+                "SMI": Chem.SmilesWriter,
+                "PDB": Chem.PDBWriter,
+                "TDT": Chem.TDTWriter,
+            }
 
     @property
     def toolkit_file_write_formats(self):
@@ -2265,7 +2456,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
         """
         try:
-            importlib.import_module('rdkit', 'Chem')
+            importlib.import_module("rdkit", "Chem")
             return True
         except ImportError:
             return False
@@ -2296,10 +2487,14 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         """
         # TODO: Add tests for the from_object functions
         from rdkit import Chem
+
         if isinstance(object, Chem.rdchem.Mol):
-            return self.from_rdkit(object,
-                                   allow_undefined_stereo=allow_undefined_stereo)
-        raise NotImplementedError('Cannot create Molecule from {} object'.format(type(object)))
+            return self.from_rdkit(
+                object, allow_undefined_stereo=allow_undefined_stereo
+            )
+        raise NotImplementedError(
+            "Cannot create Molecule from {} object".format(type(object))
+        )
 
     def from_pdb_and_smiles(self, file_path, smiles, allow_undefined_stereo=False):
         """
@@ -2336,20 +2531,25 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         from openforcefield.topology.molecule import Molecule, InvalidConformerError
 
         # Make the molecule from smiles
-        offmol = self.from_smiles(smiles,
-                                  allow_undefined_stereo=allow_undefined_stereo)
+        offmol = self.from_smiles(smiles, allow_undefined_stereo=allow_undefined_stereo)
 
         # Make another molecule from the PDB, allow stero errors here they are expected
-        pdbmol = self.from_rdkit(Chem.MolFromPDBFile(file_path, removeHs=False), allow_undefined_stereo=True)
+        pdbmol = self.from_rdkit(
+            Chem.MolFromPDBFile(file_path, removeHs=False), allow_undefined_stereo=True
+        )
 
         # check isomorphic and get the mapping if true the mapping will be
         # Dict[pdb_index: offmol_index] sorted by pdb_index
-        isomorphic, mapping = Molecule.are_isomorphic(pdbmol, offmol, return_atom_map=True,
-                                                      aromatic_matching=False,
-                                                      formal_charge_matching=False,
-                                                      bond_order_matching=False,
-                                                      atom_stereochemistry_matching=False,
-                                                      bond_stereochemistry_matching=False)
+        isomorphic, mapping = Molecule.are_isomorphic(
+            pdbmol,
+            offmol,
+            return_atom_map=True,
+            aromatic_matching=False,
+            formal_charge_matching=False,
+            bond_order_matching=False,
+            atom_stereochemistry_matching=False,
+            bond_stereochemistry_matching=False,
+        )
 
         if mapping is not None:
             new_mol = offmol.remap(mapping)
@@ -2360,12 +2560,9 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             return new_mol
 
         else:
-            raise InvalidConformerError('The PDB and SMILES structures do not match.')
+            raise InvalidConformerError("The PDB and SMILES structures do not match.")
 
-    def from_file(self,
-                  file_path,
-                  file_format,
-                  allow_undefined_stereo=False):
+    def from_file(self, file_path, file_format, allow_undefined_stereo=False):
         """
         Create an openforcefield.topology.Molecule from a file using this toolkit.
 
@@ -2392,36 +2589,48 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         file_format = file_format.upper()
 
         mols = list()
-        if (file_format == 'MOL') or (file_format == 'SDF'):
-            for rdmol in Chem.SupplierFromFilename(file_path, removeHs=False, sanitize=False, strictParsing=True):
+        if (file_format == "MOL") or (file_format == "SDF"):
+            for rdmol in Chem.SupplierFromFilename(
+                file_path, removeHs=False, sanitize=False, strictParsing=True
+            ):
                 if rdmol is None:
                     continue
 
                 # Sanitize the molecules (fails on nitro groups)
                 try:
-                    Chem.SanitizeMol(rdmol, Chem.SANITIZE_ALL ^ Chem.SANITIZE_SETAROMATICITY ^ Chem.SANITIZE_ADJUSTHS)
+                    Chem.SanitizeMol(
+                        rdmol,
+                        Chem.SANITIZE_ALL
+                        ^ Chem.SANITIZE_SETAROMATICITY
+                        ^ Chem.SANITIZE_ADJUSTHS,
+                    )
                     Chem.AssignStereochemistryFrom3D(rdmol)
                 except ValueError as e:
-                    logger.warning(rdmol.GetProp('_Name') + ' ' + str(e))
+                    logger.warning(rdmol.GetProp("_Name") + " " + str(e))
                     continue
                 Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
-                mol = self.from_rdkit(rdmol, allow_undefined_stereo=allow_undefined_stereo)
+                mol = self.from_rdkit(
+                    rdmol, allow_undefined_stereo=allow_undefined_stereo
+                )
                 mols.append(mol)
 
-        elif (file_format == 'SMI'):
+        elif file_format == "SMI":
             # TODO: We have to do some special stuff when we import SMILES (currently
             # just adding H's, but could get fancier in the future). It might be
             # worthwhile to parse the SMILES file ourselves and pass each SMILES
             # through the from_smiles function instead
             for rdmol in Chem.SmilesMolSupplier(file_path, titleLine=False):
                 rdmol = Chem.AddHs(rdmol)
-                mol = self.from_rdkit(rdmol, allow_undefined_stereo=allow_undefined_stereo)
+                mol = self.from_rdkit(
+                    rdmol, allow_undefined_stereo=allow_undefined_stereo
+                )
                 mols.append(mol)
 
-        elif (file_format == 'PDB'):
+        elif file_format == "PDB":
             raise Exception(
                 "RDKit can not safely read PDBs on their own. Information about bond order and aromaticity "
-                "is likely to be lost. To read a PDB using RDKit use Molecule.from_pdb_and_smiles()")
+                "is likely to be lost. To read a PDB using RDKit use Molecule.from_pdb_and_smiles()"
+            )
             # TODO: See if we can implement PDB+mol/smi combinations to get complete bond information.
             #  testing to see if we can make a molecule from smiles and then use the PDB conformer as the geometry
             #  and just reorder the molecule
@@ -2433,10 +2642,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
         return mols
 
-    def from_file_obj(self,
-                      file_obj,
-                      file_format,
-                      allow_undefined_stereo=False):
+    def from_file_obj(self, file_obj, file_format, allow_undefined_stereo=False):
         """
         Return an openforcefield.topology.Molecule from a file-like object (an object with a ".read()" method using
         this toolkit.
@@ -2469,20 +2675,21 @@ class RDKitToolkitWrapper(ToolkitWrapper):
                 mol = self.from_rdkit(rdmol)
                 mols.append(mol)
 
-        if (file_format == 'SMI'):
+        if file_format == "SMI":
             # TODO: Find a cleaner way to parse SMILES lines
             file_data = file_obj.read()
-            lines = [line.strip() for line in file_data.split('\n')]
+            lines = [line.strip() for line in file_data.split("\n")]
             # remove blank lines
-            lines.remove('')
+            lines.remove("")
             for line in lines:
                 mol = self.from_smiles(line)
                 mols.append(mol)
 
-        elif file_format == 'PDB':
+        elif file_format == "PDB":
             raise Exception(
                 "RDKit can not safely read PDBs on their own. Information about bond order and aromaticity "
-                "is likely to be lost. To read a PDB using RDKit use Molecule.from_pdb_and_smiles()")
+                "is likely to be lost. To read a PDB using RDKit use Molecule.from_pdb_and_smiles()"
+            )
             # TODO: See if we can implement PDB+mol/smi combinations to get complete bond information.
             # https://github.com/openforcefield/openforcefield/issues/121
             # file_data = file_obj.read()
@@ -2518,8 +2725,10 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             writer.close()
         # if we can not write to that file type catch the error here
         except KeyError:
-            raise ValueError(f'The requested file type ({file_format}) is not supported to be written using '
-                             f'RDKitToolkitWrapper.')
+            raise ValueError(
+                f"The requested file type ({file_format}) is not supported to be written using "
+                f"RDKitToolkitWrapper."
+            )
 
     def to_file(self, molecule, file_path, file_format):
         """
@@ -2540,10 +2749,14 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         """
 
         # open a file object and pass to the object writer
-        with open(file_path, 'w') as file_obj:
-            self.to_file_obj(molecule=molecule, file_obj=file_obj, file_format=file_format)
+        with open(file_path, "w") as file_obj:
+            self.to_file_obj(
+                molecule=molecule, file_obj=file_obj, file_format=file_format
+            )
 
-    def enumerate_stereoisomers(self, molecule, undefined_only=False, max_isomers=20, rationalise=True):
+    def enumerate_stereoisomers(
+        self, molecule, undefined_only=False, max_isomers=20, rationalise=True
+    ):
         """
         Enumerate the stereocenters and bonds of the current molecule.
 
@@ -2568,7 +2781,10 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
         """
         from rdkit import Chem
-        from rdkit.Chem.EnumerateStereoisomers import EnumerateStereoisomers, StereoEnumerationOptions
+        from rdkit.Chem.EnumerateStereoisomers import (
+            EnumerateStereoisomers,
+            StereoEnumerationOptions,
+        )
 
         # create the molecule
         rdmol = self.to_rdkit(molecule=molecule)
@@ -2578,8 +2794,11 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         Chem.FindPotentialStereoBonds(rdmol)
 
         # set up the options
-        stereo_opts = StereoEnumerationOptions(tryEmbedding=rationalise, onlyUnassigned=undefined_only,
-                                               maxIsomers=max_isomers)
+        stereo_opts = StereoEnumerationOptions(
+            tryEmbedding=rationalise,
+            onlyUnassigned=undefined_only,
+            maxIsomers=max_isomers,
+        )
 
         isomers = tuple(EnumerateStereoisomers(rdmol, options=stereo_opts))
 
@@ -2624,7 +2843,9 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         molecules = []
         for taut in tautomers:
             taut_hs = Chem.AddHs(taut)
-            mol = self.from_smiles(Chem.MolToSmiles(taut_hs), allow_undefined_stereo=True)
+            mol = self.from_smiles(
+                Chem.MolToSmiles(taut_hs), allow_undefined_stereo=True
+            )
             if mol != molecule:
                 molecules.append(mol)
 
@@ -2646,6 +2867,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         """
 
         from rdkit import Chem
+
         rdmol = self.to_rdkit(molecule)
 
         # get the canonical ordering with hydrogens first
@@ -2694,6 +2916,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             The SMILES of the input molecule.
         """
         from rdkit import Chem
+
         rdmol = self.to_rdkit(molecule)
 
         if not explicit_hydrogens:
@@ -2701,11 +2924,13 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             rdmol = Chem.RemoveHs(rdmol)
 
         if mapped:
-            assert explicit_hydrogens is True, "Mapped smiles require all hydrogens and " \
-                                               "stereochemistry to be defined to retain order"
+            assert explicit_hydrogens is True, (
+                "Mapped smiles require all hydrogens and "
+                "stereochemistry to be defined to retain order"
+            )
 
             # if we only want to map specific atoms check for an atom map
-            atom_map = molecule._properties.get('atom_map', None)
+            atom_map = molecule._properties.get("atom_map", None)
             if atom_map is not None:
                 # make sure there are no repeated indices
                 map_ids = set(atom_map.values())
@@ -2730,9 +2955,13 @@ class RDKitToolkitWrapper(ToolkitWrapper):
                     except KeyError:
                         continue
 
-        return Chem.MolToSmiles(rdmol, isomericSmiles=isomeric, allHsExplicit=explicit_hydrogens)
+        return Chem.MolToSmiles(
+            rdmol, isomericSmiles=isomeric, allHsExplicit=explicit_hydrogens
+        )
 
-    def from_smiles(self, smiles, hydrogens_are_explicit=False, allow_undefined_stereo=False):
+    def from_smiles(
+        self, smiles, hydrogens_are_explicit=False, allow_undefined_stereo=False
+    ):
         """
         Create a Molecule from a SMILES string using the RDKit toolkit.
 
@@ -2762,13 +2991,16 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         for atom in rdmol.GetAtoms():
             if atom.GetAtomMapNum() != 0:
                 # set the map back to zero but hide the index in the atom prop data
-                atom.SetProp('_map_idx', str(atom.GetAtomMapNum()))
+                atom.SetProp("_map_idx", str(atom.GetAtomMapNum()))
                 # set it back to zero
                 atom.SetAtomMapNum(0)
 
         # TODO: I think UpdatePropertyCache(strict=True) is called anyway in Chem.SanitizeMol().
         rdmol.UpdatePropertyCache(strict=False)
-        Chem.SanitizeMol(rdmol, Chem.SANITIZE_ALL ^ Chem.SANITIZE_ADJUSTHS ^ Chem.SANITIZE_SETAROMATICITY)
+        Chem.SanitizeMol(
+            rdmol,
+            Chem.SANITIZE_ALL ^ Chem.SANITIZE_ADJUSTHS ^ Chem.SANITIZE_SETAROMATICITY,
+        )
         Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
 
         # Chem.MolFromSmiles adds bond directions (i.e. ENDDOWNRIGHT/ENDUPRIGHT), but
@@ -2776,8 +3008,10 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         Chem.AssignStereochemistry(rdmol)
 
         # Throw an exception/warning if there is unspecified stereochemistry.
-        if allow_undefined_stereo==False:
-            self._detect_undefined_stereo(rdmol, err_msg_prefix='Unable to make OFFMol from SMILES: ')
+        if allow_undefined_stereo == False:
+            self._detect_undefined_stereo(
+                rdmol, err_msg_prefix="Unable to make OFFMol from SMILES: "
+            )
 
         # Add explicit hydrogens if they aren't there already
         if not hydrogens_are_explicit:
@@ -2791,10 +3025,10 @@ class RDKitToolkitWrapper(ToolkitWrapper):
                         f"SMILES '{smiles}' as having implicit hydrogen. If this SMILES is intended to "
                         f"express all explicit hydrogens in the molecule, then you should construct the "
                         f"desired molecule as an RDMol with no implicit hydrogens, and then use "
-                        f"Molecule.from_rdkit() to create the desired OFFMol.")
+                        f"Molecule.from_rdkit() to create the desired OFFMol."
+                    )
 
-        molecule = self.from_rdkit(rdmol,
-                                   allow_undefined_stereo=allow_undefined_stereo)
+        molecule = self.from_rdkit(rdmol, allow_undefined_stereo=allow_undefined_stereo)
 
         return molecule
 
@@ -2818,17 +3052,23 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         """
 
         from rdkit import Chem
+
         # this seems to always remove the hydrogens
         rdmol = Chem.MolFromInchi(inchi, sanitize=False, removeHs=False)
 
         # try and catch an InChI parsing error
         if rdmol is None:
-            raise RuntimeError('There was an issue parsing the InChI string, please check and try again.')
+            raise RuntimeError(
+                "There was an issue parsing the InChI string, please check and try again."
+            )
 
         # process the molecule
         # TODO do we need this with inchi?
         rdmol.UpdatePropertyCache(strict=False)
-        Chem.SanitizeMol(rdmol, Chem.SANITIZE_ALL ^ Chem.SANITIZE_ADJUSTHS ^ Chem.SANITIZE_SETAROMATICITY)
+        Chem.SanitizeMol(
+            rdmol,
+            Chem.SANITIZE_ALL ^ Chem.SANITIZE_ADJUSTHS ^ Chem.SANITIZE_SETAROMATICITY,
+        )
         Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
 
         # add hydrogens back here
@@ -2838,7 +3078,9 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
         return molecule
 
-    def generate_conformers(self, molecule, n_conformers=1, rms_cutoff=None, clear_existing=True):
+    def generate_conformers(
+        self, molecule, n_conformers=1, rms_cutoff=None, clear_existing=True
+    ):
         """
         Generate molecule conformers using RDKit.
 
@@ -2865,8 +3107,9 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
         """
         from rdkit.Chem import AllChem
+
         if rms_cutoff is None:
-            rms_cutoff = 1. * unit.angstrom
+            rms_cutoff = 1.0 * unit.angstrom
         rdmol = self.to_rdkit(molecule)
         # TODO: This generates way more conformations than omega, given the same nConfs and RMS threshold. Is there some way to set an energy cutoff as well?
         AllChem.EmbedMultipleConfs(
@@ -2874,7 +3117,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             numConfs=n_conformers,
             pruneRmsThresh=rms_cutoff / unit.angstrom,
             randomSeed=1,
-            #params=AllChem.ETKDG()
+            # params=AllChem.ETKDG()
         )
         molecule2 = self.from_rdkit(rdmol, allow_undefined_stereo=True)
 
@@ -2926,9 +3169,16 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         # Sanitizing the molecule. We handle aromaticity and chirality manually.
         # This SanitizeMol(...) calls cleanUp, updatePropertyCache, symmetrizeSSSR,
         # assignRadicals, setConjugation, and setHybridization.
-        Chem.SanitizeMol(rdmol, (Chem.SANITIZE_ALL ^ Chem.SANITIZE_SETAROMATICITY ^
-                                 Chem.SANITIZE_ADJUSTHS ^ Chem.SANITIZE_CLEANUPCHIRALITY ^
-                                 Chem.SANITIZE_KEKULIZE))
+        Chem.SanitizeMol(
+            rdmol,
+            (
+                Chem.SANITIZE_ALL
+                ^ Chem.SANITIZE_SETAROMATICITY
+                ^ Chem.SANITIZE_ADJUSTHS
+                ^ Chem.SANITIZE_CLEANUPCHIRALITY
+                ^ Chem.SANITIZE_KEKULIZE
+            ),
+        )
         Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
         # SetAromaticity set aromatic bonds to 1.5, but Molecule.bond_order is an
         # integer (contrarily to fractional_bond_order) so we need the Kekule order.
@@ -2941,15 +3191,18 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         Chem.AssignStereochemistry(rdmol, cleanIt=False)
 
         # Check for undefined stereochemistry.
-        self._detect_undefined_stereo(rdmol, raise_warning=allow_undefined_stereo,
-                                      err_msg_prefix="Unable to make OFFMol from RDMol: ")
+        self._detect_undefined_stereo(
+            rdmol,
+            raise_warning=allow_undefined_stereo,
+            err_msg_prefix="Unable to make OFFMol from RDMol: ",
+        )
 
         # Create a new openforcefield Molecule
         offmol = Molecule()
 
         # If RDMol has a title save it
         if rdmol.HasProp("_Name"):
-            #raise Exception('{}'.format(rdmol.GetProp('name')))
+            # raise Exception('{}'.format(rdmol.GetProp('name')))
             offmol.name = rdmol.GetProp("_Name")
         else:
             offmol.name = ""
@@ -2970,51 +3223,54 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             # if the molecule was made from a mapped smiles this has been hidden
             # so that it does not affect the sterochemistry tags
             try:
-                map_id = int(rda.GetProp('_map_idx'))
+                map_id = int(rda.GetProp("_map_idx"))
             except KeyError:
                 map_id = rda.GetAtomMapNum()
 
             # create a new atom
-            #atomic_number = oemol.NewAtom(rda.GetAtomicNum())
+            # atomic_number = oemol.NewAtom(rda.GetAtomicNum())
             atomic_number = rda.GetAtomicNum()
             formal_charge = rda.GetFormalCharge() * unit.elementary_charge
             is_aromatic = rda.GetIsAromatic()
-            if rda.HasProp('_Name'):
-                name = rda.GetProp('_Name')
+            if rda.HasProp("_Name"):
+                name = rda.GetProp("_Name")
             else:
                 # check for PDB names
                 try:
                     name = rda.GetMonomerInfo().GetName().strip()
                 except AttributeError:
-                    name = ''
+                    name = ""
 
             # If chiral, store the chirality to be set later
             stereochemistry = None
-            #tag = rda.GetChiralTag()
-            if rda.HasProp('_CIPCode'):
-                stereo_code = rda.GetProp('_CIPCode')
-                #if tag == Chem.CHI_TETRAHEDRAL_CCW:
-                if stereo_code == 'R':
-                    stereochemistry = 'R'
-                #if tag == Chem.CHI_TETRAHEDRAL_CW:
-                elif stereo_code == 'S':
-                    stereochemistry = 'S'
+            # tag = rda.GetChiralTag()
+            if rda.HasProp("_CIPCode"):
+                stereo_code = rda.GetProp("_CIPCode")
+                # if tag == Chem.CHI_TETRAHEDRAL_CCW:
+                if stereo_code == "R":
+                    stereochemistry = "R"
+                # if tag == Chem.CHI_TETRAHEDRAL_CW:
+                elif stereo_code == "S":
+                    stereochemistry = "S"
                 else:
-                    raise UndefinedStereochemistryError("In from_rdkit: Expected atom stereochemistry of R or S. "
-                                                        "Got {} instead.".format(stereo_code))
+                    raise UndefinedStereochemistryError(
+                        "In from_rdkit: Expected atom stereochemistry of R or S. "
+                        "Got {} instead.".format(stereo_code)
+                    )
 
             atom_index = offmol.add_atom(
                 atomic_number,
                 formal_charge,
                 is_aromatic,
                 name=name,
-                stereochemistry=stereochemistry)
+                stereochemistry=stereochemistry,
+            )
             map_atoms[rd_idx] = atom_index
             atom_mapping[atom_index] = map_id
 
         # if we have a full atom map add it to the molecule, 0 indicates a missing mapping or no mapping
         if 0 not in atom_mapping.values():
-            offmol._properties['atom_map'] = atom_mapping
+            offmol._properties["atom_map"] = atom_mapping
 
         # Similar to chirality, stereochemistry of bonds in OE is set relative to their neighbors
         for rdb in rdmol.GetBonds():
@@ -3029,8 +3285,9 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             order = int(order)
 
             # create a new bond
-            bond_index = offmol.add_bond(map_atoms[a1], map_atoms[a2], order,
-                                         is_aromatic)
+            bond_index = offmol.add_bond(
+                map_atoms[a1], map_atoms[a2], order, is_aromatic
+            )
             map_bonds[rdb_idx] = bond_index
 
         # Now fill in the cached (structure-dependent) properties. We have to have the 2D structure of the molecule
@@ -3043,18 +3300,19 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             stereochemistry = None
             tag = rdb.GetStereo()
             if tag == Chem.BondStereo.STEREOZ:
-                stereochemistry = 'Z'
+                stereochemistry = "Z"
             elif tag == Chem.BondStereo.STEREOE:
-                stereochemistry = 'E'
+                stereochemistry = "E"
             elif tag == Chem.BondStereo.STEREOTRANS or tag == Chem.BondStereo.STEREOCIS:
                 raise ValueError(
-                    "Expected RDKit bond stereochemistry of E or Z, got {} instead"
-                    .format(tag))
+                    "Expected RDKit bond stereochemistry of E or Z, got {} instead".format(
+                        tag
+                    )
+                )
             offb._stereochemistry = stereochemistry
             fractional_bond_order = None
             if rdb.HasProp("fractional_bond_order"):
-                fractional_bond_order = rdb.GetDoubleProp(
-                    'fractional_bond_order')
+                fractional_bond_order = rdb.GetDoubleProp("fractional_bond_order")
             offb.fractional_bond_order = fractional_bond_order
 
         # TODO: Save conformer(s), if present
@@ -3063,22 +3321,21 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             for conf in rdmol.GetConformers():
                 n_atoms = offmol.n_atoms
                 # TODO: Will this always be angstrom when loading from RDKit?
-                positions = unit.Quantity(
-                    np.zeros((n_atoms, 3)), unit.angstrom)
+                positions = unit.Quantity(np.zeros((n_atoms, 3)), unit.angstrom)
                 for rd_idx, off_idx in map_atoms.items():
                     atom_coords = conf.GetPositions()[rd_idx, :] * unit.angstrom
                     positions[off_idx, :] = atom_coords
                 offmol.add_conformer(positions)
 
         partial_charges = unit.Quantity(
-            np.zeros(offmol.n_atoms, dtype=np.float), unit=unit.elementary_charge)
+            np.zeros(offmol.n_atoms, dtype=np.float), unit=unit.elementary_charge
+        )
 
         any_atom_has_partial_charge = False
         for rd_idx, rd_atom in enumerate(rdmol.GetAtoms()):
             off_idx = map_atoms[rd_idx]
             if rd_atom.HasProp("PartialCharge"):
-                charge = rd_atom.GetDoubleProp(
-                    "PartialCharge") * unit.elementary_charge
+                charge = rd_atom.GetDoubleProp("PartialCharge") * unit.elementary_charge
                 partial_charges[off_idx] = charge
                 any_atom_has_partial_charge = True
             else:
@@ -3130,7 +3387,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         # Set name
         # TODO: What is the best practice for how this should be named?
         if not (molecule.name is None):
-            rdmol.SetProp('_Name', molecule.name)
+            rdmol.SetProp("_Name", molecule.name)
 
         # TODO: Set other properties
         for name, value in molecule.properties.items():
@@ -3159,14 +3416,16 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
         for index, atom in enumerate(molecule.atoms):
             rdatom = Chem.Atom(atom.atomic_number)
-            rdatom.SetFormalCharge(atom.formal_charge.value_in_unit(unit.elementary_charge))
+            rdatom.SetFormalCharge(
+                atom.formal_charge.value_in_unit(unit.elementary_charge)
+            )
             rdatom.SetIsAromatic(atom.is_aromatic)
-            rdatom.SetProp('_Name', atom.name)
+            rdatom.SetProp("_Name", atom.name)
 
             ## Stereo handling code moved to after bonds are added
-            if atom.stereochemistry == 'S':
+            if atom.stereochemistry == "S":
                 rdatom.SetChiralTag(Chem.CHI_TETRAHEDRAL_CW)
-            elif atom.stereochemistry == 'R':
+            elif atom.stereochemistry == "R":
                 rdatom.SetChiralTag(Chem.CHI_TETRAHEDRAL_CCW)
 
             rd_index = rdmol.AddAtom(rdatom)
@@ -3177,12 +3436,16 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             assert index == rd_index
 
         for bond in molecule.bonds:
-            atom_indices = (bond.atom1.molecule_atom_index, bond.atom2.molecule_atom_index)
+            atom_indices = (
+                bond.atom1.molecule_atom_index,
+                bond.atom2.molecule_atom_index,
+            )
             rdmol.AddBond(*atom_indices)
             rdbond = rdmol.GetBondBetweenAtoms(*atom_indices)
             if not (bond.fractional_bond_order is None):
-                rdbond.SetDoubleProp("fractional_bond_order",
-                                     bond.fractional_bond_order)
+                rdbond.SetDoubleProp(
+                    "fractional_bond_order", bond.fractional_bond_order
+                )
             # Assign bond type, which is based on order unless it is aromatic
             if bond.is_aromatic:
                 rdbond.SetBondType(_bondtypes[1.5])
@@ -3191,10 +3454,13 @@ class RDKitToolkitWrapper(ToolkitWrapper):
                 rdbond.SetBondType(_bondtypes[bond.bond_order])
                 rdbond.SetIsAromatic(False)
 
-        Chem.SanitizeMol(rdmol, Chem.SANITIZE_ALL ^ Chem.SANITIZE_ADJUSTHS ^ Chem.SANITIZE_SETAROMATICITY)
+        Chem.SanitizeMol(
+            rdmol,
+            Chem.SANITIZE_ALL ^ Chem.SANITIZE_ADJUSTHS ^ Chem.SANITIZE_SETAROMATICITY,
+        )
 
         # Fix for aromaticity being lost
-        if aromaticity_model == 'OEAroModel_MDL':
+        if aromaticity_model == "OEAroModel_MDL":
             Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
         else:
             raise ValueError(f"Aromaticity model {aromaticity_model} not recognized")
@@ -3217,7 +3483,10 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             # We need to do force and cleanIt to recalculate CIP stereo.
             Chem.AssignStereochemistry(rdmol, force=True, cleanIt=True)
             # If our random initial assignment worked, then we're set.
-            if rdatom.HasProp('_CIPCode') and rdatom.GetProp("_CIPCode") == atom.stereochemistry:
+            if (
+                rdatom.HasProp("_CIPCode")
+                and rdatom.GetProp("_CIPCode") == atom.stereochemistry
+            ):
                 continue
 
             # Otherwise, set it to CCW.
@@ -3225,19 +3494,25 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             # We need to do force and cleanIt to recalculate CIP stereo.
             Chem.AssignStereochemistry(rdmol, force=True, cleanIt=True)
             # Hopefully this worked, otherwise something's wrong
-            if rdatom.HasProp('_CIPCode') and rdatom.GetProp("_CIPCode") == atom.stereochemistry:
+            if (
+                rdatom.HasProp("_CIPCode")
+                and rdatom.GetProp("_CIPCode") == atom.stereochemistry
+            ):
                 continue
 
             # Keep track of undefined stereo atoms. We'll force stereochemistry
             # at the end to avoid the next AssignStereochemistry to overwrite.
-            if not rdatom.HasProp('_CIPCode'):
+            if not rdatom.HasProp("_CIPCode"):
                 undefined_stereo_atoms[rdatom] = atom.stereochemistry
                 continue
 
             # Something is wrong.
-            err_msg = ("Unknown atom stereochemistry encountered in to_rdkit. "
-                       "Desired stereochemistry: {}. Set stereochemistry {}".format(
-                atom.stereochemistry, rdatom.GetProp("_CIPCode")))
+            err_msg = (
+                "Unknown atom stereochemistry encountered in to_rdkit. "
+                "Desired stereochemistry: {}. Set stereochemistry {}".format(
+                    atom.stereochemistry, rdatom.GetProp("_CIPCode")
+                )
+            )
             raise RuntimeError(err_msg)
 
         # Copy bond stereo info from molecule to rdmol.
@@ -3249,8 +3524,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
                 rdmol_conformer = Chem.Conformer()
                 for atom_idx in range(molecule.n_atoms):
                     x, y, z = conformer[atom_idx, :].value_in_unit(unit.angstrom)
-                    rdmol_conformer.SetAtomPosition(atom_idx,
-                                                    Geometry.Point3D(x, y, z))
+                    rdmol_conformer.SetAtomPosition(atom_idx, Geometry.Point3D(x, y, z))
                 rdmol.AddConformer(rdmol_conformer, assignId=True)
 
         # Retain charges, if present
@@ -3261,12 +3535,11 @@ class RDKitToolkitWrapper(ToolkitWrapper):
                 charge_unitless = charge.value_in_unit(unit.elementary_charge)
                 rdk_indexed_charges[atom_idx] = charge_unitless
             for atom_idx, rdk_atom in enumerate(rdmol.GetAtoms()):
-                rdk_atom.SetDoubleProp('PartialCharge',
-                                       rdk_indexed_charges[atom_idx])
+                rdk_atom.SetDoubleProp("PartialCharge", rdk_indexed_charges[atom_idx])
 
             # Note: We could put this outside the "if" statement, which would result in all partial charges in the
             #       resulting file being set to "n/a" if they weren't set in the Open Force Field Molecule
-            Chem.CreateAtomDoublePropertyList(rdmol, 'PartialCharge')
+            Chem.CreateAtomDoublePropertyList(rdmol, "PartialCharge")
 
         # Cleanup the rdmol
         rdmol.UpdatePropertyCache(strict=False)
@@ -3276,7 +3549,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         # can't figure out. This must be done last as calling AssignStereochemistry
         # again will delete these properties (see #196).
         for rdatom, stereochemistry in undefined_stereo_atoms.items():
-            rdatom.SetProp('_CIPCode', stereochemistry)
+            rdatom.SetProp("_CIPCode", stereochemistry)
 
         # Return non-editable version
         return Chem.Mol(rdmol)
@@ -3305,9 +3578,10 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         """
 
         from rdkit import Chem
+
         rdmol = self.to_rdkit(molecule)
         if fixed_hydrogens:
-            inchi = Chem.MolToInchi(rdmol, options='-FixedH')
+            inchi = Chem.MolToInchi(rdmol, options="-FixedH")
         else:
             inchi = Chem.MolToInchi(rdmol)
         return inchi
@@ -3336,9 +3610,10 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         """
 
         from rdkit import Chem
+
         rdmol = self.to_rdkit(molecule)
         if fixed_hydrogens:
-            inchi_key = Chem.MolToInchiKey(rdmol, options='-FixedH')
+            inchi_key = Chem.MolToInchiKey(rdmol, options="-FixedH")
         else:
             inchi_key = Chem.MolToInchiKey(rdmol)
         return inchi_key
@@ -3369,6 +3644,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         """
         from rdkit import Chem
         from openforcefield.typing.chemistry import SMIRKSParsingError
+
         ss = Chem.MolFromSmarts(smarts)
 
         if ss is None:
@@ -3390,8 +3666,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         return unique_tags, connections
 
     @staticmethod
-    def _find_smarts_matches(rdmol, smirks,
-                             aromaticity_model='OEAroModel_MDL'):
+    def _find_smarts_matches(rdmol, smirks, aromaticity_model="OEAroModel_MDL"):
         """Find all sets of atoms in the provided RDKit molecule that match the provided SMARTS string.
 
         Parameters
@@ -3423,20 +3698,19 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         # Make a copy of the molecule
         rdmol = Chem.Mol(rdmol)
         # Use designated aromaticity model
-        if aromaticity_model == 'OEAroModel_MDL':
-            Chem.SanitizeMol(rdmol,
-                             Chem.SANITIZE_ALL ^ Chem.SANITIZE_SETAROMATICITY)
+        if aromaticity_model == "OEAroModel_MDL":
+            Chem.SanitizeMol(rdmol, Chem.SANITIZE_ALL ^ Chem.SANITIZE_SETAROMATICITY)
             Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
         else:
             # Only the OEAroModel_MDL is supported for now
-            raise ValueError(
-                'Unknown aromaticity model: {}'.aromaticity_models)
+            raise ValueError("Unknown aromaticity model: {}".aromaticity_models)
 
         # Set up query.
-        qmol = Chem.MolFromSmarts(smirks)  #cannot catch the error
+        qmol = Chem.MolFromSmarts(smirks)  # cannot catch the error
         if qmol is None:
             raise ValueError(
-                'RDKit could not parse the SMIRKS string "{}"'.format(smirks))
+                'RDKit could not parse the SMIRKS string "{}"'.format(smirks)
+            )
 
         # Create atom mapping for query molecule
         idx_map = dict()
@@ -3452,17 +3726,15 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         # choose the largest unsigned int without overflow
         # since the C++ signature is a uint
         max_matches = np.iinfo(np.uintc).max
-        for match in rdmol.GetSubstructMatches(qmol, uniquify=False,
-                maxMatches=max_matches):
+        for match in rdmol.GetSubstructMatches(
+            qmol, uniquify=False, maxMatches=max_matches
+        ):
             mas = [match[x] for x in map_list]
             matches.append(tuple(mas))
 
         return matches
 
-    def find_smarts_matches(self,
-                            molecule,
-                            smarts,
-                            aromaticity_model='OEAroModel_MDL'):
+    def find_smarts_matches(self, molecule, smarts, aromaticity_model="OEAroModel_MDL"):
         """
         Find all SMARTS matches for the specified molecule, using the specified aromaticity model.
 
@@ -3482,7 +3754,8 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         """
         rdmol = self.to_rdkit(molecule, aromaticity_model=aromaticity_model)
         return self._find_smarts_matches(
-            rdmol, smarts, aromaticity_model='OEAroModel_MDL')
+            rdmol, smarts, aromaticity_model="OEAroModel_MDL"
+        )
 
     # --------------------------------
     # Stereochemistry RDKit utilities.
@@ -3524,8 +3797,9 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         # Find all atoms with undefined stereo.
         undefined_atom_indices = []
         for atom_idx, atom in enumerate(rdmol.GetAtoms()):
-            if (atom.GetChiralTag() == Chem.ChiralType.CHI_UNSPECIFIED and
-                    atom.HasProp('_ChiralityPossible')):
+            if atom.GetChiralTag() == Chem.ChiralType.CHI_UNSPECIFIED and atom.HasProp(
+                "_ChiralityPossible"
+            ):
                 undefined_atom_indices.append(atom_idx)
         return undefined_atom_indices
 
@@ -3576,7 +3850,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         return undefined_bond_indices
 
     @classmethod
-    def _detect_undefined_stereo(cls, rdmol, err_msg_prefix='', raise_warning=False):
+    def _detect_undefined_stereo(cls, rdmol, err_msg_prefix="", raise_warning=False):
         """Raise UndefinedStereochemistryError if the RDMol has undefined stereochemistry.
 
         Parameters
@@ -3611,9 +3885,10 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         if len(undefined_atom_indices) > 0:
             msg += "Undefined chiral centers are:\n"
             for undefined_atom_idx in undefined_atom_indices:
-                msg += ' - Atom {symbol} (index {index})\n'.format(
+                msg += " - Atom {symbol} (index {index})\n".format(
                     symbol=rdmol.GetAtomWithIdx(undefined_atom_idx).GetSymbol(),
-                    index=undefined_atom_idx)
+                    index=undefined_atom_idx,
+                )
 
         # Details about undefined bond.
         if len(undefined_bond_indices) > 0:
@@ -3621,17 +3896,20 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             for undefined_bond_idx in undefined_bond_indices:
                 bond = rdmol.GetBondWithIdx(undefined_bond_idx)
                 atom1, atom2 = bond.GetBeginAtom(), bond.GetEndAtom()
-                msg += ' - Bond {bindex} (atoms {aindex1}-{aindex2} of element ({symbol1}-{symbol2})\n'.format(
+                msg += " - Bond {bindex} (atoms {aindex1}-{aindex2} of element ({symbol1}-{symbol2})\n".format(
                     bindex=undefined_bond_idx,
-                    aindex1=atom1.GetIdx(), aindex2=atom2.GetIdx(),
-                    symbol1=atom1.GetSymbol(), symbol2=atom2.GetSymbol())
+                    aindex1=atom1.GetIdx(),
+                    aindex2=atom2.GetIdx(),
+                    symbol1=atom1.GetSymbol(),
+                    symbol2=atom2.GetSymbol(),
+                )
 
         if msg is not None:
             if raise_warning:
-                msg = 'Warning (not error because allow_undefined_stereo=True): '
+                msg = "Warning (not error because allow_undefined_stereo=True): "
                 logger.warning(msg)
             else:
-                msg = 'Unable to make OFFMol from RDMol: ' + msg
+                msg = "Unable to make OFFMol from RDMol: " + msg
                 raise UndefinedStereochemistryError(msg)
 
     @staticmethod
@@ -3659,7 +3937,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             # Check that we haven't flipped this bond already.
             if bond_atom_indices in flipped:
                 # This should never happen.
-                raise RuntimeError('Cannot flip the bond direction consistently.')
+                raise RuntimeError("Cannot flip the bond direction consistently.")
 
             # Flip the bond.
             if b.GetBondDir() == Chem.BondDir.ENDUPRIGHT:
@@ -3672,7 +3950,10 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             if bond_atom_indices in paired:
                 for paired_rdbond in paired[bond_atom_indices]:
                     # Don't flip the bond that was flipped in the upper-level recursion.
-                    if (paired_rdbond.GetBeginAtomIdx(), paired_rdbond.GetEndAtomIdx()) != ignored:
+                    if (
+                        paired_rdbond.GetBeginAtomIdx(),
+                        paired_rdbond.GetEndAtomIdx(),
+                    ) != ignored:
                         # Don't flip this bond in the next recursion.
                         _flip(paired_rdbond, paired, flipped, ignored=bond_atom_indices)
 
@@ -3694,17 +3975,27 @@ class RDKitToolkitWrapper(ToolkitWrapper):
                 continue
 
             # Isolate stereo RDKit bond object.
-            rdbond_atom_indices = (bond.atom1.molecule_atom_index,
-                                   bond.atom2.molecule_atom_index)
+            rdbond_atom_indices = (
+                bond.atom1.molecule_atom_index,
+                bond.atom2.molecule_atom_index,
+            )
             stereo_rdbond = rdmol.GetBondBetweenAtoms(*rdbond_atom_indices)
 
             # Collect all neighboring rdbonds of atom1 and atom2.
-            neighbor_rdbonds1 = [rdmol.GetBondBetweenAtoms(n.molecule_atom_index,
-                                                           bond.atom1.molecule_atom_index)
-                                 for n in bond.atom1.bonded_atoms if n != bond.atom2]
-            neighbor_rdbonds2 = [rdmol.GetBondBetweenAtoms(bond.atom2.molecule_atom_index,
-                                                           n.molecule_atom_index)
-                                 for n in bond.atom2.bonded_atoms if n != bond.atom1]
+            neighbor_rdbonds1 = [
+                rdmol.GetBondBetweenAtoms(
+                    n.molecule_atom_index, bond.atom1.molecule_atom_index
+                )
+                for n in bond.atom1.bonded_atoms
+                if n != bond.atom2
+            ]
+            neighbor_rdbonds2 = [
+                rdmol.GetBondBetweenAtoms(
+                    bond.atom2.molecule_atom_index, n.molecule_atom_index
+                )
+                for n in bond.atom2.bonded_atoms
+                if n != bond.atom1
+            ]
 
             # Select only 1 neighbor bond per atom out of the two.
             neighbor_rdbonds = []
@@ -3732,8 +4023,8 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             Chem.AssignStereochemistry(rdmol, cleanIt=True, force=True)
 
             # Verify that the current directions give us the desired stereochemistries.
-            assert bond.stereochemistry in {'E', 'Z'}
-            if bond.stereochemistry == 'E':
+            assert bond.stereochemistry in {"E", "Z"}
+            if bond.stereochemistry == "E":
                 desired_rdk_stereo_code = Chem.rdchem.BondStereo.STEREOE
             else:
                 desired_rdk_stereo_code = Chem.rdchem.BondStereo.STEREOZ
@@ -3748,12 +4039,14 @@ class RDKitToolkitWrapper(ToolkitWrapper):
                 assert stereo_rdbond.GetStereo() == desired_rdk_stereo_code
 
             # Update paired bonds map.
-            neighbor_bond_indices = [(rdb.GetBeginAtomIdx(), rdb.GetEndAtomIdx()) for rdb in neighbor_rdbonds]
+            neighbor_bond_indices = [
+                (rdb.GetBeginAtomIdx(), rdb.GetEndAtomIdx()) for rdb in neighbor_rdbonds
+            ]
             for i, bond_indices in enumerate(neighbor_bond_indices):
                 try:
-                    paired_bonds[bond_indices].append(neighbor_rdbonds[1-i])
+                    paired_bonds[bond_indices].append(neighbor_rdbonds[1 - i])
                 except KeyError:
-                    paired_bonds[bond_indices] = [neighbor_rdbonds[1-i]]
+                    paired_bonds[bond_indices] = [neighbor_rdbonds[1 - i]]
 
 
 class AmberToolsToolkitWrapper(ToolkitWrapper):
@@ -3762,9 +4055,12 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
 
     .. warning :: This API is experimental and subject to change.
     """
-    _toolkit_name = 'AmberTools'
-    _toolkit_installation_instructions = 'The AmberTools toolkit (free and open source) can be found at ' \
-                                         'https://anaconda.org/omnia/ambertools'
+
+    _toolkit_name = "AmberTools"
+    _toolkit_installation_instructions = (
+        "The AmberTools toolkit (free and open source) can be found at "
+        "https://anaconda.org/omnia/ambertools"
+    )
 
     def __init__(self):
         super().__init__()
@@ -3773,8 +4069,10 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
         self._toolkit_file_write_formats = []
 
         if not self.is_available():
-            raise ToolkitUnavailableException(f'The required toolkit {self._toolkit_name} is not '
-                                              f'available. {self._toolkit_installation_instructions}')
+            raise ToolkitUnavailableException(
+                f"The required toolkit {self._toolkit_name} is not "
+                f"available. {self._toolkit_installation_instructions}"
+            )
 
         # TODO: Find AMBERHOME or executable home, checking miniconda if needed
         # Store an instance of an RDKitToolkitWrapper for file I/O
@@ -3797,15 +4095,17 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
         if ANTECHAMBER_PATH is None:
             return False
         # AmberToolsToolkitWrapper needs RDKit to do basically anything, since its interface requires SDF I/O
-        if not(RDKitToolkitWrapper.is_available()):
+        if not (RDKitToolkitWrapper.is_available()):
             return False
         return True
 
-    def assign_partial_charges(self,
-                               molecule,
-                               partial_charge_method=None,
-                               use_conformers=None,
-                               strict_n_conformers=False):
+    def assign_partial_charges(
+        self,
+        molecule,
+        partial_charge_method=None,
+        use_conformers=None,
+        strict_n_conformers=False,
+    ):
         """
         Compute partial charges with AmberTools using antechamber/sqm, and assign
         the new values to the partial_charges attribute.
@@ -3841,28 +4141,31 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
         from openforcefield.topology import Molecule
 
         if partial_charge_method is None:
-            partial_charge_method = 'am1-mulliken'
+            partial_charge_method = "am1-mulliken"
         else:
             # Standardize method name for string comparisons
             partial_charge_method = partial_charge_method.lower()
 
-        SUPPORTED_CHARGE_METHODS = {'am1bcc': {'antechamber_keyword':'bcc',
-                                               'min_confs': 1,
-                                               'max_confs': 1,
-                                               'rec_confs': 1,
-                                               },
-                                    'am1-mulliken': {'antechamber_keyword': 'mul',
-                                                     'min_confs': 1,
-                                                     'max_confs': 1,
-                                                     'rec_confs': 1,
-                                                     },
-                                    'gasteiger': {'antechamber_keyword': 'gas',
-                                                  'min_confs': 0,
-                                                  'max_confs': 0,
-                                                  'rec_confs': 0,
-                                                  }
-                                    }
-
+        SUPPORTED_CHARGE_METHODS = {
+            "am1bcc": {
+                "antechamber_keyword": "bcc",
+                "min_confs": 1,
+                "max_confs": 1,
+                "rec_confs": 1,
+            },
+            "am1-mulliken": {
+                "antechamber_keyword": "mul",
+                "min_confs": 1,
+                "max_confs": 1,
+                "rec_confs": 1,
+            },
+            "gasteiger": {
+                "antechamber_keyword": "gas",
+                "min_confs": 0,
+                "max_confs": 0,
+                "rec_confs": 0,
+            },
+        }
 
         if partial_charge_method not in SUPPORTED_CHARGE_METHODS:
             raise ChargeMethodUnavailableError(
@@ -3876,22 +4179,26 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
         mol_copy = Molecule(molecule)
 
         if use_conformers is None:
-            if charge_method['rec_confs'] == 0:
+            if charge_method["rec_confs"] == 0:
                 mol_copy._conformers = None
             else:
-                mol_copy.generate_conformers(n_conformers=charge_method['rec_confs'],
-                                             rms_cutoff=0.25*unit.angstrom,
-                                             toolkit_registry=RDKitToolkitWrapper())
+                mol_copy.generate_conformers(
+                    n_conformers=charge_method["rec_confs"],
+                    rms_cutoff=0.25 * unit.angstrom,
+                    toolkit_registry=RDKitToolkitWrapper(),
+                )
             # TODO: What's a "best practice" RMS cutoff to use here?
         else:
             mol_copy._conformers = None
             for conformer in use_conformers:
                 mol_copy.add_conformer(conformer)
-            self._check_n_conformers(mol_copy,
-                                     partial_charge_method=partial_charge_method,
-                                     min_confs=charge_method['min_confs'],
-                                     max_confs=charge_method['max_confs'],
-                                     strict_n_conformers=strict_n_conformers)
+            self._check_n_conformers(
+                mol_copy,
+                partial_charge_method=partial_charge_method,
+                min_confs=charge_method["min_confs"],
+                max_confs=charge_method["max_confs"],
+                strict_n_conformers=strict_n_conformers,
+            )
 
         # Find the path to antechamber
         # TODO: How should we implement find_executable?
@@ -3906,28 +4213,66 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
                 # Write out molecule in SDF format
                 ## TODO: How should we handle multiple conformers?
                 self._rdkit_toolkit_wrapper.to_file(
-                    mol_copy, 'molecule.sdf', file_format='sdf')
+                    mol_copy, "molecule.sdf", file_format="sdf"
+                )
                 # Compute desired charges
                 # TODO: Add error handling if antechamber chokes
                 # TODO: Add something cleaner than os.system
-                short_charge_method = charge_method['antechamber_keyword']
-                subprocess.check_output([
-                    "antechamber", "-i", "molecule.sdf", "-fi", "sdf", "-o", "charged.mol2", "-fo",
-                    "mol2", "-pf", "yes", "-dr", "n", "-c", short_charge_method, "-nc", str(net_charge)]
-                 )
+                short_charge_method = charge_method["antechamber_keyword"]
+                subprocess.check_output(
+                    [
+                        "antechamber",
+                        "-i",
+                        "molecule.sdf",
+                        "-fi",
+                        "sdf",
+                        "-o",
+                        "charged.mol2",
+                        "-fo",
+                        "mol2",
+                        "-pf",
+                        "yes",
+                        "-dr",
+                        "n",
+                        "-c",
+                        short_charge_method,
+                        "-nc",
+                        str(net_charge),
+                    ]
+                )
                 # Write out just charges
-                subprocess.check_output([
-                    "antechamber", "-dr", "n", "-i", "charged.mol2", "-fi", "mol2", "-o", "charges2.mol2", "-fo",
-                    "mol2", "-c", "wc",  "-cf", "charges.txt", "-pf", "yes"])
+                subprocess.check_output(
+                    [
+                        "antechamber",
+                        "-dr",
+                        "n",
+                        "-i",
+                        "charged.mol2",
+                        "-fi",
+                        "mol2",
+                        "-o",
+                        "charges2.mol2",
+                        "-fo",
+                        "mol2",
+                        "-c",
+                        "wc",
+                        "-cf",
+                        "charges.txt",
+                        "-pf",
+                        "yes",
+                    ]
+                )
                 # Check to ensure charges were actually produced
-                if not os.path.exists('charges.txt'):
+                if not os.path.exists("charges.txt"):
                     # TODO: copy files into local directory to aid debugging?
                     raise ChargeCalculationError(
                         "Antechamber/sqm partial charge calculation failed on "
                         "molecule {} (SMILES {})".format(
-                            molecule.name, molecule.to_smiles()))
+                            molecule.name, molecule.to_smiles()
+                        )
+                    )
                 # Read the charges
-                with open('charges.txt', 'r') as infile:
+                with open("charges.txt", "r") as infile:
                     contents = infile.read()
                 text_charges = contents.split()
                 charges = np.zeros([molecule.n_atoms], np.float64)
@@ -3937,7 +4282,9 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
         charges = unit.Quantity(charges, unit.elementary_charge)
         molecule.partial_charges = charges
 
-    def compute_partial_charges_am1bcc(self, molecule, use_conformers=None, strict_n_conformers=False):
+    def compute_partial_charges_am1bcc(
+        self, molecule, use_conformers=None, strict_n_conformers=False
+    ):
         """
         Compute partial charges with AmberTools using antechamber/sqm. This will calculate AM1-BCC charges on the first
         conformer only.
@@ -3963,14 +4310,19 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
         """
 
         import warnings
-        warnings.warn("compute_partial_charges_am1bcc will be deprecated in an upcoming release. "
-                      "Use assign_partial_charges(partial_charge_method='am1bcc') instead.",
-                      DeprecationWarning)
 
-        self.assign_partial_charges(molecule,
-                                    partial_charge_method="AM1BCC",
-                                    use_conformers=use_conformers,
-                                    strict_n_conformers=strict_n_conformers)
+        warnings.warn(
+            "compute_partial_charges_am1bcc will be deprecated in an upcoming release. "
+            "Use assign_partial_charges(partial_charge_method='am1bcc') instead.",
+            DeprecationWarning,
+        )
+
+        self.assign_partial_charges(
+            molecule,
+            partial_charge_method="AM1BCC",
+            use_conformers=use_conformers,
+            strict_n_conformers=strict_n_conformers,
+        )
         return molecule.partial_charges
 
     def _modify_sqm_in_to_request_bond_orders(self, file_path):
@@ -4000,14 +4352,16 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
         # First, split the sqm.in text at the "/" mark at the end of the header
         datasp = data.split("/")
         # Insert the "printbondorders" directive in a new line and re-add the "/"
-        datasp.insert(1, 'printbondorders=1, \n /')
+        datasp.insert(1, "printbondorders=1, \n /")
         # Reassemble the file text
-        new_data = ''.join(datasp)
+        new_data = "".join(datasp)
         # Write the new file contents, overwriting the original file.
-        with open(file_path, 'w') as of:
+        with open(file_path, "w") as of:
             of.write(new_data)
 
-    def _get_fractional_bond_orders_from_sqm_out(self, file_path, validate_elements=None):
+    def _get_fractional_bond_orders_from_sqm_out(
+        self, file_path, validate_elements=None
+    ):
         """
         Process a SQM output file containing bond orders, and return a dict of the form
         dict[atom_1_index, atom_2_index] = fractional_bond_order
@@ -4042,16 +4396,16 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
 
         data = open(file_path).read()
 
-        begin_sep = ''' Bond Orders
+        begin_sep = """ Bond Orders
  
   QMMM:    NUM1 ELEM1 NUM2 ELEM2      BOND_ORDER
-'''
-        end_sep = '''
+"""
+        end_sep = """
 
            --------- Calculation Completed ----------
-'''
+"""
         # Extract the chunk of text between begin_sep and end_sep, and split it by newline
-        fbo_lines = data.split(begin_sep)[1].split(end_sep)[0].split('\n')
+        fbo_lines = data.split(begin_sep)[1].split(end_sep)[0].split("\n")
 
         # Iterate over the lines and populate the dict to return
         bond_orders = dict()
@@ -4065,14 +4419,16 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
 
             # If validate_elements was provided, ensure that the ordering of element symbols is what we expected
             if validate_elements is not None:
-                if ((atom_element_1 != validate_elements[atom_index_1-1]) or
-                    (atom_element_2 != validate_elements[atom_index_2-1])):
-                    #raise ValueError('\n'.join(fbo_lines))
-                    raise ValueError(f'Elements or indexing in sqm output differ from expectation. '
-                                     f'Expected {validate_elements[atom_index_1]} with index {atom_index_1} and '
-                                     f'{validate_elements[atom_index_2]} with index {atom_index_2}, '
-                                     f'but SQM output has {atom_element_1} and {atom_element_2} for the same atoms.')
-
+                if (atom_element_1 != validate_elements[atom_index_1 - 1]) or (
+                    atom_element_2 != validate_elements[atom_index_2 - 1]
+                ):
+                    # raise ValueError('\n'.join(fbo_lines))
+                    raise ValueError(
+                        f"Elements or indexing in sqm output differ from expectation. "
+                        f"Expected {validate_elements[atom_index_1]} with index {atom_index_1} and "
+                        f"{validate_elements[atom_index_2]} with index {atom_index_2}, "
+                        f"but SQM output has {atom_element_1} and {atom_element_2} for the same atoms."
+                    )
 
             # To make lookup easier, we identify bonds as integer tuples with the lowest atom index
             # first and the highest second.
@@ -4080,7 +4436,9 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
             bond_orders[index_tuple] = bond_order
         return bond_orders
 
-    def assign_fractional_bond_orders(self, molecule, bond_order_model=None, use_conformers=None):
+    def assign_fractional_bond_orders(
+        self, molecule, bond_order_model=None, use_conformers=None
+    ):
         """
         Update and store list of bond orders this molecule. Bond orders are stored on each
         bond, in the `bond.fractional_bond_order` attribute.
@@ -4098,12 +4456,17 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
             of conformers will be generated by an available ToolkitWrapper.
          """
         from openforcefield.topology import Molecule
+
         # Find the path to antechamber
         # TODO: How should we implement find_executable?
         ANTECHAMBER_PATH = find_executable("antechamber")
         if ANTECHAMBER_PATH is None:
-            raise (IOError("Antechamber not found, cannot run "
-                           "AmberToolsToolkitWrapper.assign_fractional_bond_orders()"))
+            raise (
+                IOError(
+                    "Antechamber not found, cannot run "
+                    "AmberToolsToolkitWrapper.assign_fractional_bond_orders()"
+                )
+            )
 
         # Make a copy since we'll be messing with this molecule's conformers
         temp_mol = Molecule(molecule)
@@ -4122,22 +4485,27 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
                 "molecule.generate_conformers() before calling molecule.assign_fractional_bond_orders"
             )
         if len(temp_mol.conformers) > 1:
-            logger.warning(f"Warning: In AmberToolsToolkitWrapper.assign_fractional_bond_orders: "
-                           f"Molecule '{molecule.name}' has more than one conformer, but this function "
-                           f"will only generate fractional bond orders for the first one.")
-
+            logger.warning(
+                f"Warning: In AmberToolsToolkitWrapper.assign_fractional_bond_orders: "
+                f"Molecule '{molecule.name}' has more than one conformer, but this function "
+                f"will only generate fractional bond orders for the first one."
+            )
 
         # Compute bond orders
-        bond_order_model_to_antechamber_keyword = {'am1-wiberg': 'mul'}
-        supported_bond_order_models = list(bond_order_model_to_antechamber_keyword.keys())
+        bond_order_model_to_antechamber_keyword = {"am1-wiberg": "mul"}
+        supported_bond_order_models = list(
+            bond_order_model_to_antechamber_keyword.keys()
+        )
         if bond_order_model is None:
-            bond_order_model = 'am1-wiberg'
+            bond_order_model = "am1-wiberg"
 
         bond_order_model = bond_order_model.lower()
 
         if bond_order_model not in supported_bond_order_models:
-            raise ValueError(f"Bond order model '{bond_order_model}' is not supported by AmberToolsToolkitWrapper. "
-                             f"Supported models are {supported_bond_order_models}")
+            raise ValueError(
+                f"Bond order model '{bond_order_model}' is not supported by AmberToolsToolkitWrapper. "
+                f"Supported models are {supported_bond_order_models}"
+            )
         ac_charge_keyword = bond_order_model_to_antechamber_keyword[bond_order_model]
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -4145,14 +4513,29 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
                 net_charge = temp_mol.total_charge
                 # Write out molecule in SDF format
                 self._rdkit_toolkit_wrapper.to_file(
-                    temp_mol, 'molecule.sdf', file_format='sdf')
+                    temp_mol, "molecule.sdf", file_format="sdf"
+                )
                 # Prepare sqm.in file as if we were going to run charge calc
                 # TODO: Add error handling if antechamber chokes
-                subprocess.check_output([
-                    "antechamber", "-i", "molecule.sdf", "-fi", "sdf", "-o",
-                    "sqm.in", "-fo", "sqmcrt", "-pf", "yes", "-c", ac_charge_keyword,
-                    "-nc", str(net_charge)
-                ])
+                subprocess.check_output(
+                    [
+                        "antechamber",
+                        "-i",
+                        "molecule.sdf",
+                        "-fi",
+                        "sdf",
+                        "-o",
+                        "sqm.in",
+                        "-fo",
+                        "sqmcrt",
+                        "-pf",
+                        "yes",
+                        "-c",
+                        ac_charge_keyword,
+                        "-nc",
+                        str(net_charge),
+                    ]
+                )
                 # Modify sqm.in to request bond order calculation
                 self._modify_sqm_in_to_request_bond_orders("sqm.in")
                 # Run sqm to get bond orders
@@ -4160,8 +4543,9 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
                 # Ensure that antechamber/sqm did not change the indexing by checking against
                 # an ordered list of element symbols for this molecule
                 expected_elements = [at.element.symbol for at in molecule.atoms]
-                bond_orders = self._get_fractional_bond_orders_from_sqm_out('sqm.out',
-                                                                            validate_elements=expected_elements)
+                bond_orders = self._get_fractional_bond_orders_from_sqm_out(
+                    "sqm.out", validate_elements=expected_elements
+                )
 
         # Note that sqm calculate WBOs for ALL PAIRS of atoms, not just those that have
         # bonds defined in the original molecule. So here we iterate over the bonds in
@@ -4170,14 +4554,15 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
             # The atom index tuples that act as bond indices are ordered from lowest to highest by
             # _get_fractional_bond_orders_from_sqm_out, so here we make sure that we look them up in
             # sorted order as well
-            sorted_atom_indices = sorted(tuple([bond.atom1_index+1, bond.atom2_index+1]))
+            sorted_atom_indices = sorted(
+                tuple([bond.atom1_index + 1, bond.atom2_index + 1])
+            )
             bond.fractional_bond_order = bond_orders[tuple(sorted_atom_indices)]
 
 
-
-#=============================================================================================
+# =============================================================================================
 # Toolkit registry
-#=============================================================================================
+# =============================================================================================
 
 
 class ToolkitRegistry:
@@ -4220,10 +4605,12 @@ class ToolkitRegistry:
     .. warning :: This API is experimental and subject to change.
     """
 
-    def __init__(self,
-                 register_imported_toolkit_wrappers=False,
-                 toolkit_precedence=None,
-                 exception_if_unavailable=True):
+    def __init__(
+        self,
+        register_imported_toolkit_wrappers=False,
+        toolkit_precedence=None,
+        exception_if_unavailable=True,
+    ):
         """
         Create an empty toolkit registry.
 
@@ -4244,8 +4631,10 @@ class ToolkitRegistry:
 
         if toolkit_precedence is None:
             toolkit_precedence = [
-                OpenEyeToolkitWrapper, RDKitToolkitWrapper,
-                AmberToolsToolkitWrapper, BuiltInToolkitWrapper
+                OpenEyeToolkitWrapper,
+                RDKitToolkitWrapper,
+                AmberToolsToolkitWrapper,
+                BuiltInToolkitWrapper,
             ]
 
         if register_imported_toolkit_wrappers:
@@ -4260,7 +4649,9 @@ class ToolkitRegistry:
                 toolkit_precedence.append(toolkit)
 
         for toolkit in toolkit_precedence:
-            self.register_toolkit(toolkit, exception_if_unavailable=exception_if_unavailable)
+            self.register_toolkit(
+                toolkit, exception_if_unavailable=exception_if_unavailable
+            )
 
     @property
     def registered_toolkits(self):
@@ -4277,9 +4668,7 @@ class ToolkitRegistry:
         """
         return list(self._toolkits)
 
-    def register_toolkit(self,
-                         toolkit_wrapper,
-                         exception_if_unavailable=True):
+    def register_toolkit(self, toolkit_wrapper, exception_if_unavailable=True):
         """
         Register the provided toolkit wrapper class, instantiating an object of it.
 
@@ -4303,18 +4692,22 @@ class ToolkitRegistry:
             try:
                 toolkit_wrapper = toolkit_wrapper()
             except ToolkitUnavailableException:
-                msg = "Unable to load toolkit '{}'. ".format(toolkit_wrapper._toolkit_name)
+                msg = "Unable to load toolkit '{}'. ".format(
+                    toolkit_wrapper._toolkit_name
+                )
                 if exception_if_unavailable:
                     raise ToolkitUnavailableException(msg)
                 else:
-                    if 'OpenEye' in msg:
-                        msg += "The Open Force Field Toolkit does not require the OpenEye Toolkits, and can " \
-                               "use RDKit/AmberTools instead. However, if you have a valid license for the " \
-                               "OpenEye Toolkits, consider installing them for faster performance and additional " \
-                               "file format support: " \
-                               "https://docs.eyesopen.com/toolkits/python/quickstart-python/linuxosx.html " \
-                               "OpenEye offers free Toolkit licenses for academics: " \
-                               "https://www.eyesopen.com/academic-licensing"
+                    if "OpenEye" in msg:
+                        msg += (
+                            "The Open Force Field Toolkit does not require the OpenEye Toolkits, and can "
+                            "use RDKit/AmberTools instead. However, if you have a valid license for the "
+                            "OpenEye Toolkits, consider installing them for faster performance and additional "
+                            "file format support: "
+                            "https://docs.eyesopen.com/toolkits/python/quickstart-python/linuxosx.html "
+                            "OpenEye offers free Toolkit licenses for academics: "
+                            "https://www.eyesopen.com/academic-licensing"
+                        )
                     logger.warning(f"Warning: {msg}")
                 return
 
@@ -4384,8 +4777,9 @@ class ToolkitRegistry:
         """
         if not isinstance(toolkit_wrapper, ToolkitWrapper):
             msg = "Something other than a ToolkitWrapper object was passed to ToolkitRegistry.add_toolkit()\n"
-            msg += "Given object {} of type {}".format(toolkit_wrapper,
-                                                       type(toolkit_wrapper))
+            msg += "Given object {} of type {}".format(
+                toolkit_wrapper, type(toolkit_wrapper)
+            )
             raise InvalidToolkitError(msg)
         self._toolkits.append(toolkit_wrapper)
 
@@ -4432,8 +4826,9 @@ class ToolkitRegistry:
         # No toolkit was found to provide the requested capability
         # TODO: Can we help developers by providing a check for typos in expected method names?
         msg = 'No registered toolkits can provide the capability "{}".\n'.format(
-            method_name)
-        msg += 'Available toolkits are: {}\n'.format(self.registered_toolkits)
+            method_name
+        )
+        msg += "Available toolkits are: {}\n".format(self.registered_toolkits)
         raise NotImplementedError(msg)
 
     # TODO: Can we instead register available methods directly with `ToolkitRegistry`, so we can just use `ToolkitRegistry.method()`?
@@ -4494,29 +4889,31 @@ class ToolkitRegistry:
 
         # No toolkit was found to provide the requested capability
         # TODO: Can we help developers by providing a check for typos in expected method names?
-        msg = f'No registered toolkits can provide the capability "{method_name}" ' \
-              f'for args "{args}" and kwargs "{kwargs}"\n'
+        msg = (
+            f'No registered toolkits can provide the capability "{method_name}" '
+            f'for args "{args}" and kwargs "{kwargs}"\n'
+        )
 
-        msg += 'Available toolkits are: {}\n'.format(self.registered_toolkits)
+        msg += "Available toolkits are: {}\n".format(self.registered_toolkits)
         # Append information about toolkits that implemented the method, but could not handle the provided parameters
         for toolkit, error in errors:
-            msg += ' {} {} : {}\n'.format(toolkit, type(error),  error)
+            msg += " {} {} : {}\n".format(toolkit, type(error), error)
         raise ValueError(msg)
 
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL TOOLKIT REGISTRY
-#=============================================================================================
+# =============================================================================================
 
 # Create global toolkit registry, where all available toolkits are registered
 # TODO: Should this be all lowercase since it's not a constant?
 GLOBAL_TOOLKIT_REGISTRY = ToolkitRegistry(
-    register_imported_toolkit_wrappers=True,
-    exception_if_unavailable=False)
+    register_imported_toolkit_wrappers=True, exception_if_unavailable=False
+)
 
-#=============================================================================================
+# =============================================================================================
 # SET GLOBAL TOOLKIT-AVAIABLE VARIABLES
-#=============================================================================================
+# =============================================================================================
 
 OPENEYE_AVAILABLE = False
 RDKIT_AVAILABLE = False
@@ -4531,26 +4928,31 @@ for toolkit in GLOBAL_TOOLKIT_REGISTRY.registered_toolkits:
     elif type(toolkit) is AmberToolsToolkitWrapper:
         AMBERTOOLS_AVAILABLE = True
 
-#=============================================================================================
+# =============================================================================================
 # WARN IF INSUFFICIENT TOOLKITS INSTALLED
-#=============================================================================================
+# =============================================================================================
 
 # Define basic toolkits that handle essential file I/O
 
 BASIC_CHEMINFORMATICS_TOOLKITS = [RDKitToolkitWrapper, OpenEyeToolkitWrapper]
 
 # Ensure we have at least one basic toolkit
-if sum([
-        tk.is_available()
-        for tk in GLOBAL_TOOLKIT_REGISTRY.registered_toolkits
-        if type(tk) in BASIC_CHEMINFORMATICS_TOOLKITS
-]) == 0:
-    msg = 'WARNING: No basic cheminformatics toolkits are available.\n'
-    msg += 'At least one basic toolkit is required to handle SMARTS matching and file I/O. \n'
-    msg += 'Please install at least one of the following basic toolkits:\n'
+if (
+    sum(
+        [
+            tk.is_available()
+            for tk in GLOBAL_TOOLKIT_REGISTRY.registered_toolkits
+            if type(tk) in BASIC_CHEMINFORMATICS_TOOLKITS
+        ]
+    )
+    == 0
+):
+    msg = "WARNING: No basic cheminformatics toolkits are available.\n"
+    msg += "At least one basic toolkit is required to handle SMARTS matching and file I/O. \n"
+    msg += "Please install at least one of the following basic toolkits:\n"
     for wrapper in all_subclasses(ToolkitWrapper):
         if wrapper.toolkit_name is not None:
-            msg += '{} : {}\n'.format(
-                wrapper._toolkit_name,
-                wrapper._toolkit_installation_instructions)
+            msg += "{} : {}\n".format(
+                wrapper._toolkit_name, wrapper._toolkit_installation_instructions
+            )
     print(msg)

--- a/openforcefield/utils/utils.py
+++ b/openforcefield/utils/utils.py
@@ -5,33 +5,33 @@ Utility subroutines
 """
 
 __all__ = [
-    'MessageException',
-    'IncompatibleUnitError',
-    'inherit_docstrings',
-    'all_subclasses',
-    'temporary_cd',
-    'get_data_file_path',
-    'unit_to_string',
-    'quantity_to_string',
-    'string_to_unit',
-    'string_to_quantity',
-    'object_to_quantity',
-    'check_units_are_compatible',
-    'extract_serialized_units_from_dict',
-    'attach_units',
-    'detach_units',
-    'serialize_numpy',
-    'deserialize_numpy',
-    'convert_all_quantities_to_string',
-    'convert_all_strings_to_quantity',
-    'convert_0_1_smirnoff_to_0_2',
-    'convert_0_2_smirnoff_to_0_3',
-    'get_molecule_parameterIDs',
+    "MessageException",
+    "IncompatibleUnitError",
+    "inherit_docstrings",
+    "all_subclasses",
+    "temporary_cd",
+    "get_data_file_path",
+    "unit_to_string",
+    "quantity_to_string",
+    "string_to_unit",
+    "string_to_quantity",
+    "object_to_quantity",
+    "check_units_are_compatible",
+    "extract_serialized_units_from_dict",
+    "attach_units",
+    "detach_units",
+    "serialize_numpy",
+    "deserialize_numpy",
+    "convert_all_quantities_to_string",
+    "convert_all_strings_to_quantity",
+    "convert_0_1_smirnoff_to_0_2",
+    "convert_0_2_smirnoff_to_0_3",
+    "get_molecule_parameterIDs",
 ]
 
-#=============================================================================================
+# =============================================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# =============================================================================================
 
 import functools
 
@@ -39,19 +39,21 @@ from simtk import unit
 import logging
 import contextlib
 
-#=============================================================================================
+# =============================================================================================
 # CONFIGURE LOGGER
-#=============================================================================================
+# =============================================================================================
 
 logger = logging.getLogger(__name__)
 
 
-#=============================================================================================
+# =============================================================================================
 # COMMON EXCEPTION TYPES
-#=============================================================================================
+# =============================================================================================
+
 
 class MessageException(Exception):
     """A base class for exceptions that print out a string given in their constructor"""
+
     def __init__(self, msg):
         super().__init__(self, msg)
         self.msg = msg
@@ -64,6 +66,7 @@ class IncompatibleUnitError(MessageException):
     """
     Exception for when a parameter is in the wrong units for a ParameterHandler's unit system
     """
+
     pass
 
 
@@ -71,11 +74,14 @@ class IncompatibleUnitError(MessageException):
 # UTILITY SUBROUTINES
 # =============================================================================================
 
+
 def inherit_docstrings(cls):
     """Inherit docstrings from parent class"""
     from inspect import getmembers, isfunction
+
     for name, func in getmembers(cls, isfunction):
-        if func.__doc__: continue
+        if func.__doc__:
+            continue
         for parent in cls.__mro__[1:]:
             if hasattr(parent, name):
                 func.__doc__ = getattr(parent, name).__doc__
@@ -87,6 +93,7 @@ def all_subclasses(cls):
     return cls.__subclasses__() + [
         g for s in cls.__subclasses__() for g in all_subclasses(s)
     ]
+
 
 @contextlib.contextmanager
 def temporary_cd(dir_path):
@@ -102,12 +109,14 @@ def temporary_cd(dir_path):
     ...     pass  # do something in dir_path
     """
     import os
+
     prev_dir = os.getcwd()
     os.chdir(os.path.abspath(dir_path))
     try:
         yield
     finally:
         os.chdir(prev_dir)
+
 
 def get_data_file_path(relative_path):
     """Get the full path to one of the reference files in testsystems.
@@ -122,11 +131,13 @@ def get_data_file_path(relative_path):
 
     from pkg_resources import resource_filename
     import os
-    fn = resource_filename('openforcefield', os.path.join(
-        'data', relative_path))
+
+    fn = resource_filename("openforcefield", os.path.join("data", relative_path))
 
     if not os.path.exists(fn):
-        raise ValueError(f"Sorry! {fn} does not exist. If you just added it, you'll have to re-install")
+        raise ValueError(
+            f"Sorry! {fn} does not exist. If you just added it, you'll have to re-install"
+        )
 
     return fn
 
@@ -155,17 +166,18 @@ def unit_to_string(input_unit):
     for unit_component in input_unit.iter_base_or_scaled_units():
         unit_component_name = unit_component[0].name
         # Convert, for example "elementary charge" --> "elementary_charge"
-        unit_component_name = unit_component_name.replace(' ', '_')
+        unit_component_name = unit_component_name.replace(" ", "_")
         if unit_component[1] == 1:
-            contribution = '{}'.format(unit_component_name)
+            contribution = "{}".format(unit_component_name)
         else:
-            contribution = '{}**{}'.format(unit_component_name, int(unit_component[1]))
+            contribution = "{}**{}".format(unit_component_name, int(unit_component[1]))
         if unit_string is None:
             unit_string = contribution
         else:
-            unit_string += ' * {}'.format(contribution)
+            unit_string += " * {}".format(contribution)
 
     return unit_string
+
 
 def quantity_to_string(input_quantity):
     """
@@ -183,6 +195,7 @@ def quantity_to_string(input_quantity):
 
     """
     import numpy as np
+
     if input_quantity is None:
         return None
     unitless_value = input_quantity.value_in_unit(input_quantity.unit)
@@ -191,8 +204,9 @@ def quantity_to_string(input_quantity):
     if isinstance(unitless_value, np.ndarray):
         unitless_value = list(unitless_value)
     unit_string = unit_to_string(input_quantity.unit)
-    output_string = '{} * {}'.format(unitless_value, unit_string)
+    output_string = "{} * {}".format(unitless_value, unit_string)
     return output_string
+
 
 def _ast_eval(node):
     """
@@ -205,15 +219,21 @@ def _ast_eval(node):
     import ast
     import operator as op
 
-    operators = {ast.Add: op.add, ast.Sub: op.sub, ast.Mult: op.mul,
-        ast.Div: op.truediv, ast.Pow: op.pow, ast.BitXor: op.xor,
-        ast.USub: op.neg}
+    operators = {
+        ast.Add: op.add,
+        ast.Sub: op.sub,
+        ast.Mult: op.mul,
+        ast.Div: op.truediv,
+        ast.Pow: op.pow,
+        ast.BitXor: op.xor,
+        ast.USub: op.neg,
+    }
 
-    if isinstance(node, ast.Num): # <number>
+    if isinstance(node, ast.Num):  # <number>
         return node.n
-    elif isinstance(node, ast.BinOp): # <left> <operator> <right>
+    elif isinstance(node, ast.BinOp):  # <left> <operator> <right>
         return operators[type(node.op)](_ast_eval(node.left), _ast_eval(node.right))
-    elif isinstance(node, ast.UnaryOp): # <operator> <operand> e.g., -1
+    elif isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1
         return operators[type(node.op)](_ast_eval(node.operand))
     elif isinstance(node, ast.Name):
         # see if this is a simtk unit
@@ -243,21 +263,23 @@ def string_to_unit(unit_string):
         The deserialized unit from the string
     """
     import ast
-    output_unit = _ast_eval(ast.parse(unit_string, mode='eval').body)
+
+    output_unit = _ast_eval(ast.parse(unit_string, mode="eval").body)
     return output_unit
 
-    #if (serialized['unitless_value'] is None) and (serialized['unit'] is None):
+    # if (serialized['unitless_value'] is None) and (serialized['unit'] is None):
     #    return None
-    #quantity_unit = None
-    #for unit_name, power in serialized['unit']:
+    # quantity_unit = None
+    # for unit_name, power in serialized['unit']:
     #    unit_name = unit_name.replace(
     #        ' ', '_')  # Convert eg. 'elementary charge' to 'elementary_charge'
     #    if quantity_unit is None:
     #        quantity_unit = (getattr(unit, unit_name)**power)
     #    else:
     #        quantity_unit *= (getattr(unit, unit_name)**power)
-    #quantity = unit.Quantity(serialized['unitless_value'], quantity_unit)
-    #return quantity
+    # quantity = unit.Quantity(serialized['unitless_value'], quantity_unit)
+    # return quantity
+
 
 def string_to_quantity(quantity_string):
     """
@@ -277,8 +299,10 @@ def string_to_quantity(quantity_string):
         return None
     # This can be the exact same as string_to_unit
     import ast
-    output_quantity = _ast_eval(ast.parse(quantity_string, mode='eval').body)
+
+    output_quantity = _ast_eval(ast.parse(quantity_string, mode="eval").body)
     return output_quantity
+
 
 def convert_all_strings_to_quantity(smirnoff_data):
     """
@@ -375,13 +399,16 @@ def object_to_quantity(object):
     # If we can't find a custom type, we treat this as a generic iterator.
     return [object_to_quantity(sub_obj) for sub_obj in object]
 
+
 @object_to_quantity.register(unit.Quantity)
 def _(obj):
     return obj
 
+
 @object_to_quantity.register(str)
 def _(obj):
     return string_to_quantity(obj)
+
 
 @object_to_quantity.register(int)
 @object_to_quantity.register(float)
@@ -410,22 +437,28 @@ def check_units_are_compatible(object_name, object, unit_to_check, context=None)
 
     # If context is not provided, explicitly make it a blank string
     if context is None:
-        context = ''
+        context = ""
     # Otherwise add a space after the end of it to correct message printing
     else:
-        context += ' '
+        context += " "
 
     if isinstance(object, list):
         for sub_object in object:
-            check_units_are_compatible(object_name, sub_object, unit_to_check, context=context)
+            check_units_are_compatible(
+                object_name, sub_object, unit_to_check, context=context
+            )
     elif isinstance(object, unit.Quantity):
         if not object.unit.is_compatible(unit_to_check):
-            msg = f"{context}{object_name} with " \
-                  f"value {object} is incompatible with expected unit {unit_to_check}"
+            msg = (
+                f"{context}{object_name} with "
+                f"value {object} is incompatible with expected unit {unit_to_check}"
+            )
             raise IncompatibleUnitError(msg)
     else:
-        msg = f"{context}{object_name} with " \
-              f"value {object} is incompatible with expected unit {unit_to_check}"
+        msg = (
+            f"{context}{object_name} with "
+            f"value {object} is incompatible with expected unit {unit_to_check}"
+        )
         raise IncompatibleUnitError(msg)
 
 
@@ -451,18 +484,20 @@ def extract_serialized_units_from_dict(input_dict):
 
     # TODO: Should this scheme also convert "1" to int(1) and "8.0" to float(8.0)?
     from collections import OrderedDict
+
     attached_units = OrderedDict()
     unitless_dict = input_dict.copy()
     keys_to_delete = []
     for key in input_dict.keys():
-        if key.endswith('_unit'):
+        if key.endswith("_unit"):
             parameter_name = key[:-5]
             parameter_units_string = input_dict[key]
             try:
                 parameter_units = string_to_unit(parameter_units_string)
             except Exception as e:
-                e.msg = "Could not parse units {}\n".format(
-                    parameter_units_string) + e.msg
+                e.msg = (
+                    "Could not parse units {}\n".format(parameter_units_string) + e.msg
+                )
                 raise e
             attached_units[parameter_name] = parameter_units
             # Remember this key and delete it later (we break the dict if we delete a key in the loop)
@@ -497,7 +532,9 @@ def attach_units(unitless_dict, attached_units):
         if parameter_name in temp_dict.keys():
             parameter_attrib_string = temp_dict[parameter_name]
             try:
-                temp_dict[parameter_name] = float(parameter_attrib_string) * units_to_attach
+                temp_dict[parameter_name] = (
+                    float(parameter_attrib_string) * units_to_attach
+                )
             except ValueError as e:
                 e.msg = (
                     "Expected numeric value for parameter '{}',"
@@ -511,16 +548,16 @@ def attach_units(unitless_dict, attached_units):
             indexed_parameter_name = parameter_name + str(c)
             parameter_attrib_string = temp_dict[indexed_parameter_name]
             try:
-                temp_dict[indexed_parameter_name] = float(
-                          parameter_attrib_string) * units_to_attach
+                temp_dict[indexed_parameter_name] = (
+                    float(parameter_attrib_string) * units_to_attach
+                )
             except ValueError as e:
                 e.msg = "Expected numeric value for parameter '{}', instead found '{}' when trying to attach units '{}'\n".format(
-                    indexed_parameter_name, parameter_attrib_string,
-                    units_to_attach)
+                    indexed_parameter_name, parameter_attrib_string, units_to_attach
+                )
                 raise e
             c += 1
     return temp_dict
-
 
 
 def detach_units(unit_bearing_dict, output_units=None):
@@ -562,21 +599,21 @@ def detach_units(unit_bearing_dict, output_units=None):
             continue
 
         # If conversion is needed, see if the user has requested an output unit
-        unit_key = key + '_unit'
+        unit_key = key + "_unit"
 
         if unit_key in output_units:
             output_unit = output_units[unit_key]
         else:
             output_unit = value.unit
         if not (output_unit.is_compatible(value.unit)):
-            raise ValueError("Requested output unit {} is not compatible with "
-                             "quantity unit {} .".format(output_unit, value.unit))
+            raise ValueError(
+                "Requested output unit {} is not compatible with "
+                "quantity unit {} .".format(output_unit, value.unit)
+            )
         unitless_dict[key] = value.value_in_unit(output_unit)
         unit_dict[unit_key] = output_unit
 
     return unitless_dict, unit_dict
-
-
 
 
 def serialize_numpy(np_array):
@@ -599,7 +636,7 @@ def serialize_numpy(np_array):
         The shape of the serialized array
     """
 
-    bigendian_array = np_array.newbyteorder('>')
+    bigendian_array = np_array.newbyteorder(">")
     serialized = bigendian_array.tobytes()
     shape = np_array.shape
     return serialized, shape
@@ -624,11 +661,13 @@ def deserialize_numpy(serialized_np, shape):
     """
 
     import numpy as np
-    dt = np.dtype('float')
-    dt.newbyteorder('>')  # set to big-endian
+
+    dt = np.dtype("float")
+    dt.newbyteorder(">")  # set to big-endian
     np_array = np.frombuffer(serialized_np, dtype=dt)
     np_array = np_array.reshape(shape)
     return np_array
+
 
 def convert_0_2_smirnoff_to_0_3(smirnoff_data_0_2):
     """
@@ -651,13 +690,13 @@ def convert_0_2_smirnoff_to_0_3(smirnoff_data_0_2):
     # Legacy forcefields sometimes specify the NonbondedForce's sigma_unit value, but then provide
     # atom size as rmin_half. Here we correct for this behavior by explicitly defining both as
     # the same unit if either one is defined.
-    if 'vdW' in smirnoff_data_0_2['SMIRNOFF'].keys():
-        rmh_unit = smirnoff_data_0_2['SMIRNOFF']['vdW'].get('rmin_half_unit', None)
-        sig_unit = smirnoff_data_0_2['SMIRNOFF']['vdW'].get('sigma_unit', None)
+    if "vdW" in smirnoff_data_0_2["SMIRNOFF"].keys():
+        rmh_unit = smirnoff_data_0_2["SMIRNOFF"]["vdW"].get("rmin_half_unit", None)
+        sig_unit = smirnoff_data_0_2["SMIRNOFF"]["vdW"].get("sigma_unit", None)
         if (rmh_unit is not None) and (sig_unit is None):
-            smirnoff_data_0_2['SMIRNOFF']['vdW']['sigma_unit'] = rmh_unit
+            smirnoff_data_0_2["SMIRNOFF"]["vdW"]["sigma_unit"] = rmh_unit
         elif (sig_unit is not None) and (rmh_unit is None):
-            smirnoff_data_0_2['SMIRNOFF']['vdW']['rmin_half_unit'] = sig_unit
+            smirnoff_data_0_2["SMIRNOFF"]["vdW"]["rmin_half_unit"] = sig_unit
         # If both are None, or both are defined, don't overwrite anything
         else:
             pass
@@ -669,30 +708,35 @@ def convert_0_2_smirnoff_to_0_3(smirnoff_data_0_2):
     # we should have used "k*(1+cos(periodicity*theta-phase))" all along, since "charmm" technically
     # implies that we would support a harmonic potential for torsion terms with periodicity 0
     # More at: https://github.com/openforcefield/openforcefield/issues/303#issuecomment-490156779
-    if 'ProperTorsions' in smirnoff_data['SMIRNOFF']:
-        if 'potential' in smirnoff_data['SMIRNOFF']['ProperTorsions']:
-            if smirnoff_data['SMIRNOFF']['ProperTorsions']['potential'] == 'charmm':
-                smirnoff_data['SMIRNOFF']['ProperTorsions']['potential'] = 'k*(1+cos(periodicity*theta-phase))'
-    if 'ImproperTorsions' in smirnoff_data['SMIRNOFF']:
-        if 'potential' in smirnoff_data['SMIRNOFF']['ImproperTorsions']:
-            if smirnoff_data['SMIRNOFF']['ImproperTorsions']['potential'] == 'charmm':
-                smirnoff_data['SMIRNOFF']['ImproperTorsions']['potential'] = 'k*(1+cos(periodicity*theta-phase))'
+    if "ProperTorsions" in smirnoff_data["SMIRNOFF"]:
+        if "potential" in smirnoff_data["SMIRNOFF"]["ProperTorsions"]:
+            if smirnoff_data["SMIRNOFF"]["ProperTorsions"]["potential"] == "charmm":
+                smirnoff_data["SMIRNOFF"]["ProperTorsions"][
+                    "potential"
+                ] = "k*(1+cos(periodicity*theta-phase))"
+    if "ImproperTorsions" in smirnoff_data["SMIRNOFF"]:
+        if "potential" in smirnoff_data["SMIRNOFF"]["ImproperTorsions"]:
+            if smirnoff_data["SMIRNOFF"]["ImproperTorsions"]["potential"] == "charmm":
+                smirnoff_data["SMIRNOFF"]["ImproperTorsions"][
+                    "potential"
+                ] = "k*(1+cos(periodicity*theta-phase))"
 
     # Add per-section tag
-    sections_not_to_version_0_3 = ['Author', 'Date', 'version', 'aromaticity_model']
-    for l1_tag in smirnoff_data['SMIRNOFF'].keys():
+    sections_not_to_version_0_3 = ["Author", "Date", "version", "aromaticity_model"]
+    for l1_tag in smirnoff_data["SMIRNOFF"].keys():
         if l1_tag not in sections_not_to_version_0_3:
 
-            if smirnoff_data['SMIRNOFF'][l1_tag] is None:
+            if smirnoff_data["SMIRNOFF"][l1_tag] is None:
                 # Handle empty entries, such as the ToolkitAM1BCC handler.
-                smirnoff_data['SMIRNOFF'][l1_tag] = {}
+                smirnoff_data["SMIRNOFF"][l1_tag] = {}
 
-            smirnoff_data['SMIRNOFF'][l1_tag]['version'] = 0.3
+            smirnoff_data["SMIRNOFF"][l1_tag]["version"] = 0.3
 
     # Update top-level tag
-    smirnoff_data['SMIRNOFF']['version'] = 0.3
+    smirnoff_data["SMIRNOFF"]["version"] = 0.3
 
     return smirnoff_data
+
 
 def convert_0_1_smirnoff_to_0_2(smirnoff_data_0_1):
     """
@@ -712,12 +756,13 @@ def convert_0_1_smirnoff_to_0_2(smirnoff_data_0_1):
     """
     smirnoff_data = smirnoff_data_0_1.copy()
 
-    l0_replacement_dict = {'SMIRFF': 'SMIRNOFF'}
-    l1_replacement_dict = {'HarmonicBondForce': 'Bonds',
-                           'HarmonicAngleForce': 'Angles',
-                           'PeriodicTorsionForce': 'ProperTorsions',
-                           'NonbondedForce': 'vdW'
-                           }
+    l0_replacement_dict = {"SMIRFF": "SMIRNOFF"}
+    l1_replacement_dict = {
+        "HarmonicBondForce": "Bonds",
+        "HarmonicAngleForce": "Angles",
+        "PeriodicTorsionForce": "ProperTorsions",
+        "NonbondedForce": "vdW",
+    }
     for old_l0_tag, new_l0_tag in l0_replacement_dict.items():
         # Convert first-level smirnoff_data tags.
         # Right now this just changes the SMIRFF tag to SMIRNOFF
@@ -728,93 +773,105 @@ def convert_0_1_smirnoff_to_0_2(smirnoff_data_0_1):
     # SMIRFF tag will have been converted to SMIRNOFF here
     # Convert second-level tags here
     for old_l1_tag, new_l1_tag in l1_replacement_dict.items():
-        if old_l1_tag in  smirnoff_data['SMIRNOFF'].keys():
-            smirnoff_data['SMIRNOFF'][new_l1_tag] = smirnoff_data['SMIRNOFF'][old_l1_tag]
-            del smirnoff_data['SMIRNOFF'][old_l1_tag]
+        if old_l1_tag in smirnoff_data["SMIRNOFF"].keys():
+            smirnoff_data["SMIRNOFF"][new_l1_tag] = smirnoff_data["SMIRNOFF"][
+                old_l1_tag
+            ]
+            del smirnoff_data["SMIRNOFF"][old_l1_tag]
 
     # Add 'potential' field to each l1 tag
-    default_potential = {'Bonds': 'harmonic',
-                         'Angles': 'harmonic',
-                         'ProperTorsions': 'charmm',
-                         # Note that "charmm" isn't actually correct, and was later changed
-                         # in the 0.3 spec. More info at
-                         # https://github.com/openforcefield/openforcefield/pull/311#commitcomment-33494506
-                         'vdW': 'Lennard-Jones-12-6'
-                         }
-    for l1_tag in smirnoff_data['SMIRNOFF'].keys():
+    default_potential = {
+        "Bonds": "harmonic",
+        "Angles": "harmonic",
+        "ProperTorsions": "charmm",
+        # Note that "charmm" isn't actually correct, and was later changed
+        # in the 0.3 spec. More info at
+        # https://github.com/openforcefield/openforcefield/pull/311#commitcomment-33494506
+        "vdW": "Lennard-Jones-12-6",
+    }
+    for l1_tag in smirnoff_data["SMIRNOFF"].keys():
         if l1_tag in default_potential.keys():
             # Ensure that it isn't there already (shouldn't happen, but better to be safe)
-            if 'potential' in smirnoff_data['SMIRNOFF'][l1_tag].keys():
+            if "potential" in smirnoff_data["SMIRNOFF"][l1_tag].keys():
                 assert smirnoff_data[l1_tag].keys == default_potential[l1_tag]
                 continue
             # Issue an informative warning about assumptions made during conversion.
-            logger.warning(f"0.1 SMIRNOFF spec file does not contain 'potential' attribute for '{l1_tag}' tag. "
-                           f"The SMIRNOFF spec converter is assuming it has a value of '{default_potential[l1_tag]}'")
-            smirnoff_data['SMIRNOFF'][l1_tag]['potential'] = default_potential[l1_tag]
-
+            logger.warning(
+                f"0.1 SMIRNOFF spec file does not contain 'potential' attribute for '{l1_tag}' tag. "
+                f"The SMIRNOFF spec converter is assuming it has a value of '{default_potential[l1_tag]}'"
+            )
+            smirnoff_data["SMIRNOFF"][l1_tag]["potential"] = default_potential[l1_tag]
 
     # Separate improper torsions from propers
-    if 'ProperTorsions' in smirnoff_data['SMIRNOFF']:
-        if 'Improper' in smirnoff_data['SMIRNOFF']['ProperTorsions']:
+    if "ProperTorsions" in smirnoff_data["SMIRNOFF"]:
+        if "Improper" in smirnoff_data["SMIRNOFF"]["ProperTorsions"]:
             # First generate an ImproperTorsions header, taking the relevant values from the ProperTorsions header
-            improper_section = {'k_unit': smirnoff_data['SMIRNOFF']['ProperTorsions']['k_unit'],
-                                'phase_unit': smirnoff_data['SMIRNOFF']['ProperTorsions']['phase_unit'],
-                                'potential': smirnoff_data['SMIRNOFF']['ProperTorsions']['potential'],
-                                'Improper': smirnoff_data['SMIRNOFF']['ProperTorsions']['Improper']
-                                }
+            improper_section = {
+                "k_unit": smirnoff_data["SMIRNOFF"]["ProperTorsions"]["k_unit"],
+                "phase_unit": smirnoff_data["SMIRNOFF"]["ProperTorsions"]["phase_unit"],
+                "potential": smirnoff_data["SMIRNOFF"]["ProperTorsions"]["potential"],
+                "Improper": smirnoff_data["SMIRNOFF"]["ProperTorsions"]["Improper"],
+            }
 
             # Then, attach the newly-made ImproperTorsions section
-            smirnoff_data['SMIRNOFF']['ImproperTorsions'] = improper_section
-            del smirnoff_data['SMIRNOFF']['ProperTorsions']['Improper']
-
-
+            smirnoff_data["SMIRNOFF"]["ImproperTorsions"] = improper_section
+            del smirnoff_data["SMIRNOFF"]["ProperTorsions"]["Improper"]
 
     # Add Electrostatics tag, setting several values to their defaults and
     # warning about assumptions that are being made
-    electrostatics_section = {'method': 'PME',
-                              'scale12': 0.0,
-                              'scale13': 0.0,
-                              'scale15': 1.0,
-                              'cutoff': 9.0,
-                              'cutoff_unit': 'angstrom'
-                              }
-    logger.warning("0.1 SMIRNOFF spec did not allow the 'Electrostatics' tag. Adding it in 0.2 spec conversion, and "
-                   "assuming the following values:")
+    electrostatics_section = {
+        "method": "PME",
+        "scale12": 0.0,
+        "scale13": 0.0,
+        "scale15": 1.0,
+        "cutoff": 9.0,
+        "cutoff_unit": "angstrom",
+    }
+    logger.warning(
+        "0.1 SMIRNOFF spec did not allow the 'Electrostatics' tag. Adding it in 0.2 spec conversion, and "
+        "assuming the following values:"
+    )
     for key, val in electrostatics_section.items():
         logger.warning(f"\t{key}: {val}")
 
     # Take electrostatics 1-4 scaling term from 0.1 spec's NonBondedForce tag
-    electrostatics_section['scale14'] = smirnoff_data['SMIRNOFF']['vdW']['coulomb14scale']
-    del smirnoff_data['SMIRNOFF']['vdW']['coulomb14scale']
-    smirnoff_data['SMIRNOFF']['Electrostatics'] = electrostatics_section
+    electrostatics_section["scale14"] = smirnoff_data["SMIRNOFF"]["vdW"][
+        "coulomb14scale"
+    ]
+    del smirnoff_data["SMIRNOFF"]["vdW"]["coulomb14scale"]
+    smirnoff_data["SMIRNOFF"]["Electrostatics"] = electrostatics_section
 
     # Change vdW's lj14scale to 14scale, add other scaling terms
-    vdw_section_additions = {'method': "cutoff",
-                             'combining_rules': "Lorentz-Berthelot",
-                             'scale12': "0.0",
-                             'scale13': "0.0",
-                             'scale15': "1",
-                             'switch_width': "1.0",
-                             'switch_width_unit': "angstrom",
-                             'cutoff': "9.0",
-                             'cutoff_unit': "angstrom"
-                             }
+    vdw_section_additions = {
+        "method": "cutoff",
+        "combining_rules": "Lorentz-Berthelot",
+        "scale12": "0.0",
+        "scale13": "0.0",
+        "scale15": "1",
+        "switch_width": "1.0",
+        "switch_width_unit": "angstrom",
+        "cutoff": "9.0",
+        "cutoff_unit": "angstrom",
+    }
     for key, val in vdw_section_additions.items():
-        if not key in smirnoff_data['SMIRNOFF']['vdW'].keys():
-            logger.warning(f"0.1 SMIRNOFF spec file does not contain '{key}' attribute for 'NonBondedMethod/vdW'' tag. "
-                           f"The SMIRNOFF spec converter is assuming it has a value of '{val}'")
-            smirnoff_data['SMIRNOFF']['vdW'][key] = val
+        if not key in smirnoff_data["SMIRNOFF"]["vdW"].keys():
+            logger.warning(
+                f"0.1 SMIRNOFF spec file does not contain '{key}' attribute for 'NonBondedMethod/vdW'' tag. "
+                f"The SMIRNOFF spec converter is assuming it has a value of '{val}'"
+            )
+            smirnoff_data["SMIRNOFF"]["vdW"][key] = val
 
     # Rename L-J 1-4 scaling term from 0.1 spec's NonBondedForce tag to vdW's scale14
-    smirnoff_data['SMIRNOFF']['vdW']['scale14'] = smirnoff_data['SMIRNOFF']['vdW']['lj14scale']
-    del smirnoff_data['SMIRNOFF']['vdW']['lj14scale']
-
+    smirnoff_data["SMIRNOFF"]["vdW"]["scale14"] = smirnoff_data["SMIRNOFF"]["vdW"][
+        "lj14scale"
+    ]
+    del smirnoff_data["SMIRNOFF"]["vdW"]["lj14scale"]
 
     # Add <ToolkitAM1BCC/> tag
-    smirnoff_data['SMIRNOFF']['ToolkitAM1BCC'] = {}
+    smirnoff_data["SMIRNOFF"]["ToolkitAM1BCC"] = {}
 
     # Update top-level tag
-    smirnoff_data['SMIRNOFF']['version'] = 0.2
+    smirnoff_data["SMIRNOFF"]["version"] = 0.2
 
     return smirnoff_data
 
@@ -838,10 +895,11 @@ def recursive_attach_unit_strings(smirnoff_data, units_to_attach):
     unit_appended_smirnoff_data: dict
     """
     import re
+
     # Make a copy of units_to_attach so we don't modify the original (otherwise things like k_unit could
     # leak between sections)
     units_to_attach = units_to_attach.copy()
-    #smirnoff_data = smirnoff_data.copy()
+    # smirnoff_data = smirnoff_data.copy()
 
     # If we're working with a dict, see if there are any new unit entries and store them,
     # then operate recursively on the values in the dict.
@@ -852,7 +910,7 @@ def recursive_attach_unit_strings(smirnoff_data, units_to_attach):
         # key:value pair they will be attached to, so we need to complete this check
         # before we are able to check other items in the dict.
         for key, value in list(smirnoff_data.items()):
-            if key[-5:] == '_unit':
+            if key[-5:] == "_unit":
                 units_to_attach[key[:-5]] = value
                 del smirnoff_data[key]
 
@@ -862,14 +920,16 @@ def recursive_attach_unit_strings(smirnoff_data, units_to_attach):
             # We use regular expressions to catch possible indexed attributes
             attach_unit = None
             for unit_key, unit_string in units_to_attach.items():
-                if re.match(f'{unit_key}[0-9]*', key):
+                if re.match(f"{unit_key}[0-9]*", key):
                     attach_unit = unit_string
 
             if attach_unit is not None:
                 smirnoff_data[key] = str(smirnoff_data[key]) + " * " + attach_unit
 
             # And recursively act on value, in case it's a deeper level of hierarchy
-            smirnoff_data[key] = recursive_attach_unit_strings(smirnoff_data[key], units_to_attach)
+            smirnoff_data[key] = recursive_attach_unit_strings(
+                smirnoff_data[key], units_to_attach
+            )
 
     # If it's a list, operate on each member of the list
     elif isinstance(smirnoff_data, list):
@@ -881,6 +941,7 @@ def recursive_attach_unit_strings(smirnoff_data, units_to_attach):
         pass
 
     return smirnoff_data
+
 
 def get_molecule_parameterIDs(molecules, forcefield):
     """Process a list of molecules with a specified SMIRNOFF ffxml file and determine which parameters are used by
@@ -909,16 +970,25 @@ def get_molecule_parameterIDs(molecules, forcefield):
     """
 
     from openforcefield.topology import Topology
+
     # Create storage
     parameters_by_molecule = dict()
     parameters_by_ID = dict()
 
     # Generate isomeric SMILES for each molecule, ensuring all molecules are unique
-    isosmiles = [ molecule.to_smiles() for molecule in molecules ]
+    isosmiles = [molecule.to_smiles() for molecule in molecules]
     already_seen = set()
-    duplicates = set(smiles for smiles in isosmiles if smiles in already_seen or already_seen.add(smiles))
+    duplicates = set(
+        smiles
+        for smiles in isosmiles
+        if smiles in already_seen or already_seen.add(smiles)
+    )
     if len(duplicates) > 0:
-        raise ValueError("Error: get_molecule_parameterIDs has been provided a list of oemols which contains some duplicates: {}".format(duplicates))
+        raise ValueError(
+            "Error: get_molecule_parameterIDs has been provided a list of oemols which contains some duplicates: {}".format(
+                duplicates
+            )
+        )
 
     # Assemble molecules into a Topology
     topology = Topology()
@@ -951,4 +1021,3 @@ def get_molecule_parameterIDs(molecules, forcefield):
                     parameters_by_ID[pid].add(smi)
 
     return parameters_by_molecule, parameters_by_ID
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,12 +8,6 @@ omit =
     # Omit generated versioneer
     openforcefield/_version.py
 
-[yapf]
-# YAPF, in .style.yapf files this shows up as "[style]" header
-COLUMN_LIMIT = 119
-INDENT_WIDTH = 4
-USE_TABS = False
-
 [flake8]
 # Flake8, PyFlakes, etc
 max-line-length = 119


### PR DESCRIPTION
Split out from #650. `isort` and `black` have some small disagreements that could be resolved here but I would rather deal with those later while resolving some `flake8` complaints. The changes here are roughly the minimum to get this adopted as quickly as possible, and I tried to keep the commit history discrete if we wish to roll anything back.


- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
