### PR TITLE
Update force field in README and remove AlkEthOH

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,11 @@ topology = Topology.from_molecules(molecule)
 
 # Load the smirnoff99Frosst SMIRNOFF force field definition
 from openforcefield.typing.engines.smirnoff import ForceField
-forcefield = ForceField('test_forcefields/smirnoff99Frosst.offxml')
+forcefield = ForceField('openff-1.2.0.offxml')
 
 # Create an OpenMM system representing the molecule with SMIRNOFF-applied parameters
 openmm_system = forcefield.create_openmm_system(topology)
 
-# Load a SMIRNOFF small molecule forcefield for alkanes, ethers, and alcohols
-forcefield = ForceField('test_forcefields/Frosst_AlkEthOH_parmAtFrosst.offxml')
 ```
 Detailed examples of using SMIRNOFF with the toolkit can be found [in the documentation](https://open-forcefield-toolkit.readthedocs.io/en/latest/examples.html).
 


### PR DESCRIPTION
I noticed the force field in the README was quite old, and since this is the first thing people see when going to the project, I thought it would be useful to keep this up to date. I also removed a reference to AlkEthOH because, I think, that's also "historical" at this point (and the phrasing made it seem like that was the force field to use for small molecules containing those functional groups, whereas I believe everyone should be using the official force fields at this point).

- [N/A ] Tag issue being addressed
- [N/A ] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [N/A ] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [N/A ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [N/A ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
