### PR TITLE
Access miniconda action from conda-incubator

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v1
         name: Install both RDKit and OpenEye toolkits
         if: ${{ matrix.cfg.rdkit == 'TRUE' && matrix.cfg.openeye == 'TRUE' }}
         with:
@@ -65,7 +65,7 @@ jobs:
           activate-environment: test
           environment-file: devtools/conda-envs/test_env.yaml
           auto-activate-base: false
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v1
         name: Install only RDKit
         if: ${{ matrix.cfg.rdkit == 'TRUE' && matrix.cfg.openeye == 'FALSE' }}
         with:
@@ -73,7 +73,7 @@ jobs:
           activate-environment: test
           environment-file: devtools/conda-envs/rdkit.yaml
           auto-activate-base: false
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v1
         name: Install with OpenEye toolkits
         if: ${{ matrix.cfg.rdkit == 'FALSE' && matrix.cfg.openeye == 'TRUE' }}
         with:

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -21,7 +21,7 @@ jobs:
           ulimit -a
 
       - name: Configure conda
-        uses: goanpeca/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v1
         with:
           python-version: 3.6
           activate-environment: release-build


### PR DESCRIPTION
The ownership of the `setup-miniconda` action recently changed from its main author to the `conda-incubator` organization, so GitHub Actions runners fail to access it. This change should point them to the right URL.