### PR TITLE
Call RDKit registry when generating conformers for AmberTools bond orders

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -17,6 +17,12 @@ New features
   to :py:class:`Atom <openforcefield.topology.molecule.Atom>` and
   :py:class:`Bond <openforcefield.topology.molecule.Bond>`
 
+Bugfixes
+"""""""""
+- `PR #737 <https://github.com/openforcefield/openforcefield/pull/737>`_: Prevents OpenEye from
+  incidentally being used in the conformer generation step of
+  :py:class:`AmberToolsToolkitWrapper.assign_fractional_bond_orders
+  <openforcefield.utils.toolkits.AmberToolsToolkitWrapper.assign_wiberg_bond_orders>`.
 
 0.7.2 - Bugfix and minor feature release
 ----------------------------------------

--- a/openforcefield/tests/test_toolkits.py
+++ b/openforcefield/tests/test_toolkits.py
@@ -2608,6 +2608,20 @@ class TestAmberToolsToolkitWrapper:
                     double_bond_has_wbo_near_2 = True
         assert double_bond_has_wbo_near_2
 
+    @requires_openeye
+    def test_assign_fractional_bond_orders_openeye_installed(self):
+        """Test that assign_fractional_bond_orders produces the same result
+        with and without OpenEye toolkits installed"""
+        mol = Molecule.from_smiles("CCO")
+        AmberToolsToolkitWrapper().assign_fractional_bond_orders(mol)
+        with_oe = [b.fractional_bond_order for b in mol.bonds]
+        GLOBAL_TOOLKIT_REGISTRY.deregister_toolkit(OpenEyeToolkitWrapper)
+        AmberToolsToolkitWrapper().assign_fractional_bond_orders(mol)
+        without_oe = [b.fractional_bond_order for b in mol.bonds]
+        GLOBAL_TOOLKIT_REGISTRY.register_toolkit(OpenEyeToolkitWrapper)
+
+        assert with_oe == without_oe
+
 
 class TestBuiltInToolkitWrapper:
     """Test the BuiltInToolkitWrapper"""

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -4581,7 +4581,10 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
         temp_mol = Molecule(molecule)
 
         if use_conformers is None:
-            temp_mol.generate_conformers(n_conformers=1)
+            temp_mol.generate_conformers(
+                n_conformers=1,
+                toolkit_registry=self._rdkit_toolkit_wrapper,
+            )
         else:
             temp_mol._conformers = None
             for conformer in use_conformers:


### PR DESCRIPTION
Fixes #736 

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
