### PR TITLE
Fix missing sigma/rmin_half attrs

### DIFF
--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -1699,6 +1699,35 @@ class TestProperTorsionHandler:
         )
 
 
+class TestvdWType:
+    """
+    Test the behavior of vdWType
+    """
+
+    def test_sigma_rmin_half(self):
+        """Test the setter/getter behavior or sigma and rmin_half"""
+        from openforcefield.typing.engines.smirnoff.parameters import vdWHandler
+
+        data = {
+            "smirks": "[*:1]",
+            "sigma": 0.5 * unit.angstrom,
+            "epsilon": 0.5 * unit.kilocalorie_per_mole,
+        }
+        param = vdWHandler.vdWType(**data)
+
+        assert param.sigma is not None
+        assert param.rmin_half is not None
+        assert param.sigma == param.rmin_half / 2 ** (1 / 6)
+
+        param.sigma = 0.8 * unit.angstrom
+
+        assert param.sigma == param.rmin_half / 2 ** (1 / 6)
+
+        param.rmin_half = 0.8 * unit.angstrom
+
+        assert param.sigma == param.rmin_half / 2 ** (1 / 6)
+
+
 class TestVirtualSiteHandler:
     """
     Test the creation of a VirtualSiteHandler and the implemented VirtualSiteTypes

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -1058,7 +1058,7 @@ class _ParameterAttributeHandler:
 
         return smirnoff_data
 
-    def to_dict(self, discard_cosmetic_attributes=False):
+    def to_dict(self, discard_cosmetic_attributes=False, duplicate_attributes=None):
         """
         Convert this object to dict format.
 
@@ -1070,6 +1070,9 @@ class _ParameterAttributeHandler:
         ----------
         discard_cosmetic_attributes : bool, optional. Default = False
             Whether to discard non-spec attributes of this object
+        duplicate_attributes : list of string, optional. Default = None
+            A list of names of attributes that redundantly decsribe
+            data and should be discarded during serializaiton
 
         Returns
         -------
@@ -1081,6 +1084,10 @@ class _ParameterAttributeHandler:
         # returned dict (call list() to make a copy). We discard
         # optional attributes that are set to None defaults.
         attribs_to_return = list(self._get_defined_parameter_attributes().keys())
+
+        if duplicate_attributes is not None:
+            for duplicate in duplicate_attributes:
+                attribs_to_return.pop(attribs_to_return.index(duplicate))
 
         # Start populating a dict of the attribs.
         indexed_attribs = set(self._get_indexed_parameter_attributes().keys())
@@ -3484,6 +3491,14 @@ class vdWHandler(_NonbondedHandler):
                 super().__setattr__("rmin_half", value * 2 ** (1 / 6))
 
             super().__setattr__(key=name, value=value)
+
+        def to_dict(
+            self, discard_cosmetic_attributes=False, duplicate_attributes=["sigma"]
+        ):
+            return super().to_dict(
+                discard_cosmetic_attributes=discard_cosmetic_attributes,
+                duplicate_attributes=duplicate_attributes,
+            )
 
     _TAGNAME = "vdW"  # SMIRNOFF tag name to process
     _INFOTYPE = vdWType  # info type to store

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -3474,6 +3474,17 @@ class vdWHandler(_NonbondedHandler):
 
             super().__init__(**kwargs)
 
+        def __setattr__(self, name, value):
+            if name == "rmin_half":
+                super().__setattr__(name, value)
+                super().__setattr__("sigma", value / 2 ** (1 / 6))
+
+            if name == "sigma":
+                super().__setattr__(name, value)
+                super().__setattr__("rmin_half", value * 2 ** (1 / 6))
+
+            super().__setattr__(key=name, value=value)
+
     _TAGNAME = "vdW"  # SMIRNOFF tag name to process
     _INFOTYPE = vdWType  # info type to store
     # _KWARGS = ['ewaldErrorTolerance',


### PR DESCRIPTION
#537 

TODO:
- [ ] Fix failing virtual site tests
- [ ] More dict tests
- [ ] Possibly switch default rep to display `sigma`, despite [our force fields](https://github.com/openforcefield/openforcefields/blob/92ab687198c02190b2bbe13b69a6604d217f31a1/openforcefields/offxml/openff-1.3.0.offxml) being shipped with `rmin_half`


Boilerplate:
- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)

