### PR TITLE
Replace private attribute access in various ParameterHandlers' create_force methods

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -35,6 +35,9 @@ Bugfixes
 """"""""
 - `PR #745 <https://github.com/openforcefield/openforcefield/pull/745>`_: Fixes bug when
   serializing molecule with conformers to JSON.
+- `PR #756 <https://github.com/openforcefield/openforcefield/pull/756>`_: Fixes bug when running
+  :py:meth:`vdWHandler.create_force <openforcefield.typing.engines.smirnoff.parameters.vdWHandler.create_force>`
+  using a ``vdWHandler`` that was initialized using the API.
 
 
 

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -778,16 +778,16 @@ if RDKitToolkitWrapper.is_available() and AmberToolsToolkitWrapper.is_available(
 class TestForceField:
     """Test the ForceField class"""
 
-    def test_get_available_force_fields_loadable(self, full_path, force_field_file):
+    def test_get_available_force_fields(self):
         """Ensure get_available_force_fields returns some expected data"""
-        available_force_fields = get_available_force_fields(full_path=False)
+        available_force_fields = get_available_force_fields(full_paths=False)
 
         # Incomplete list of some expected force fields
         expected_force_fields = [
             "smirnoff99Frosst-1.0.0.offxml",
             "smirnoff99Frosst-1.1.0.offxml",
             "openff-1.0.0.offxml",
-            "openff_unconstrainted-1.0.0.offxml",
+            "openff_unconstrained-1.0.0.offxml",
             "openff-1.1.0.offxml",
             "openff-1.2.0.offxml",
         ]

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -14,11 +14,12 @@ Test classes and function in module openforcefield.typing.engines.smirnoff.param
 # GLOBAL IMPORTS
 # ======================================================================
 
-import pytest
 import numpy
+import pytest
 from numpy.testing import assert_almost_equal
 from simtk import unit
 
+from openforcefield.topology import Molecule
 from openforcefield.typing.engines.smirnoff import SMIRNOFFVersionError
 from openforcefield.typing.engines.smirnoff.parameters import (
     BondHandler,
@@ -36,12 +37,11 @@ from openforcefield.typing.engines.smirnoff.parameters import (
     ParameterType,
     ProperTorsionHandler,
     SMIRNOFFSpecError,
-    vdWHandler,
     VirtualSiteHandler,
     _linear_inter_or_extrapolate,
     _ParameterAttributeHandler,
+    vdWHandler,
 )
-from openforcefield.topology import Molecule
 from openforcefield.utils import IncompatibleUnitError, detach_units
 from openforcefield.utils.collections import ValidatedList
 

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -1701,14 +1701,16 @@ class TestProperTorsionHandler:
             potential="k*(1+cos(periodicity*theta-phase))", skip_version_check=True
         )
 
+
 class TestvdWHandler:
     def test_create_force_defaults(self):
         """Test that create_force works on a vdWHandler with all default values"""
         from simtk import openmm
+
         # Create a dummy topology containing only argon and give it a set of
         # box vectors.
         topology = Molecule.from_smiles("[Ar]").to_topology()
-        topology.box_vectors =  unit.Quantity(numpy.eye(3) * 20 * unit.angstrom)
+        topology.box_vectors = unit.Quantity(numpy.eye(3) * 20 * unit.angstrom)
 
         # create a VdW handler with only parameters for argon.
         vdw_handler = vdWHandler(version=0.3)
@@ -1716,12 +1718,13 @@ class TestvdWHandler:
             {
                 "smirks": "[#18:1]",
                 "epsilon": 1.0 * unit.kilojoules_per_mole,
-                "sigma": 1.0 * unit.angstrom
+                "sigma": 1.0 * unit.angstrom,
             }
         )
 
         omm_sys = openmm.System()
         vdw_handler.create_force(omm_sys, topology)
+
 
 class TestVirtualSiteHandler:
     """

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -3506,7 +3506,7 @@ class vdWHandler(_NonbondedHandler):
         if new_scale12 != 0.0:
             raise SMIRNOFFSpecError(
                 "Current OFF toolkit is unable to handle scale12 values other than 0.0. "
-                "Specified 1-2 scaling was {}".format(self._scale12)
+                "Specified 1-2 scaling was {}".format(self.scale12)
             )
         return new_scale12
 
@@ -3515,7 +3515,7 @@ class vdWHandler(_NonbondedHandler):
         if new_scale13 != 0.0:
             raise SMIRNOFFSpecError(
                 "Current OFF toolkit is unable to handle scale13 values other than 0.0. "
-                "Specified 1-3 scaling was {}".format(self._scale13)
+                "Specified 1-3 scaling was {}".format(self.scale13)
             )
         return new_scale13
 
@@ -3524,7 +3524,7 @@ class vdWHandler(_NonbondedHandler):
         if new_scale15 != 1.0:
             raise SMIRNOFFSpecError(
                 "Current OFF toolkit is unable to handle scale15 values other than 1.0. "
-                "Specified 1-5 scaling was {}".format(self._scale15)
+                "Specified 1-5 scaling was {}".format(self.scale15)
             )
         return new_scale15
 
@@ -3560,7 +3560,7 @@ class vdWHandler(_NonbondedHandler):
         force = super().create_force(system, topology, **kwargs)
 
         # If we're using PME, then the only possible openMM Nonbonded type is LJPME
-        if self._method == "PME":
+        if self.method == "PME":
             # If we're given a nonperiodic box, we always set NoCutoff. Later we'll add support for CutoffNonPeriodic
             if topology.box_vectors is None:
                 force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
@@ -3573,14 +3573,14 @@ class vdWHandler(_NonbondedHandler):
                 force.setEwaldErrorTolerance(1.0e-4)
 
         # If method is cutoff, then we currently support openMM's PME for periodic system and NoCutoff for nonperiodic
-        elif self._method == "cutoff":
+        elif self.method == "cutoff":
             # If we're given a nonperiodic box, we always set NoCutoff. Later we'll add support for CutoffNonPeriodic
             if topology.box_vectors is None:
                 force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
             else:
                 force.setNonbondedMethod(openmm.NonbondedForce.PME)
                 force.setUseDispersionCorrection(True)
-                force.setCutoffDistance(self._cutoff)
+                force.setCutoffDistance(self.cutoff)
 
         # Iterate over all defined Lennard-Jones types, allowing later matches to override earlier ones.
         atom_matches = self.find_matches(topology)
@@ -3634,7 +3634,7 @@ class vdWHandler(_NonbondedHandler):
 
                 # TODO: Don't mess with electrostatic scaling here. Have a separate electrostatics handler.
                 force.createExceptionsFromBonds(
-                    bond_particle_indices, 0.83333, self._scale14
+                    bond_particle_indices, 0.83333, self.scale14
                 )
                 # force.createExceptionsFromBonds(bond_particle_indices, self.coulomb14scale, self._scale14)
 
@@ -3665,7 +3665,7 @@ class ElectrostaticsHandler(_NonbondedHandler):
         if new_scale12 != 0.0:
             raise SMIRNOFFSpecError(
                 "Current OFF toolkit is unable to handle scale12 values other than 0.0. "
-                "Specified 1-2 scaling was {}".format(self._scale12)
+                "Specified 1-2 scaling was {}".format(self.scale12)
             )
         return new_scale12
 
@@ -3674,7 +3674,7 @@ class ElectrostaticsHandler(_NonbondedHandler):
         if new_scale13 != 0.0:
             raise SMIRNOFFSpecError(
                 "Current OFF toolkit is unable to handle scale13 values other than 0.0. "
-                "Specified 1-3 scaling was {}".format(self._scale13)
+                "Specified 1-3 scaling was {}".format(self.scale13)
             )
         return new_scale13
 
@@ -3683,13 +3683,13 @@ class ElectrostaticsHandler(_NonbondedHandler):
         if new_scale15 != 1.0:
             raise SMIRNOFFSpecError(
                 "Current OFF toolkit is unable to handle scale15 values other than 1.0. "
-                "Specified 1-5 scaling was {}".format(self._scale15)
+                "Specified 1-5 scaling was {}".format(self.scale15)
             )
         return new_scale15
 
     @switch_width.converter
     def switch_width(self, attr, new_switch_width):
-        if self._switch_width != 0.0 * unit.angstrom:
+        if self.switch_width != 0.0 * unit.angstrom:
             raise IncompatibleParameterError(
                 "The current implementation of the Open Force Field toolkit can not "
                 "support an electrostatic switching width. Currently only `0.0 angstroms` "
@@ -3843,16 +3843,16 @@ class ElectrostaticsHandler(_NonbondedHandler):
         # First, check whether the vdWHandler set the nonbonded method to LJPME, because that means
         # that electrostatics also has to be PME
         if (current_nb_method == openmm.NonbondedForce.LJPME) and (
-            self._method != "PME"
+            self.method != "PME"
         ):
             raise IncompatibleParameterError(
                 "In current Open Force Field toolkit implementation, if vdW "
                 "treatment is set to LJPME, electrostatics must also be PME "
-                "(electrostatics treatment currently set to {}".format(self._method)
+                "(electrostatics treatment currently set to {}".format(self.method)
             )
 
         # Then, set nonbonded methods based on method keyword
-        if self._method == "PME":
+        if self.method == "PME":
             # Check whether the topology is nonperiodic, in which case we always switch to NoCutoff
             # (vdWHandler will have already set this to NoCutoff)
             # TODO: This is an assumption right now, and a bad one. See issue #219
@@ -3874,7 +3874,7 @@ class ElectrostaticsHandler(_NonbondedHandler):
             settings_matched = True
 
         # If vdWHandler set the nonbonded method to NoCutoff, then we don't need to change anything
-        elif self._method == "Coulomb":
+        elif self.method == "Coulomb":
             if topology.box_vectors is None:
                 # (vdWHandler will have already set this to NoCutoff)
                 assert current_nb_method == openmm.NonbondedForce.NoCutoff
@@ -3888,7 +3888,7 @@ class ElectrostaticsHandler(_NonbondedHandler):
                 )
 
         # If the vdWHandler set the nonbonded method to PME, then ensure that it has the same cutoff
-        elif self._method == "reaction-field":
+        elif self.method == "reaction-field":
             if topology.box_vectors is None:
                 # (vdWHandler will have already set this to NoCutoff)
                 assert current_nb_method == openmm.NonbondedForce.NoCutoff
@@ -3907,7 +3907,7 @@ class ElectrostaticsHandler(_NonbondedHandler):
                 "method ({}), and topology periodicity ({}) selections. Additional "
                 "options for nonbonded treatment may be added in future versions "
                 "of the Open Force Field toolkit.".format(
-                    self._method, topology.box_vectors is not None
+                    self.method, topology.box_vectors is not None
                 )
             )
 


### PR DESCRIPTION
- [x] Fix #733, and fixed several other instances of directly accessing private attributes that should be handled by the `ParameterAttribute` class.
- [x] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [x] Clean up FF loading test that was being skipped due to having an identical name
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
