### PR TITLE
Lazy import functions

### DIFF
--- a/openforcefield/tests/test_examples.py
+++ b/openforcefield/tests/test_examples.py
@@ -12,7 +12,6 @@ Test that the examples in the repo run without errors.
 # GLOBAL IMPORTS
 # ======================================================================
 
-import glob
 import os
 import pathlib
 import re

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -3874,13 +3874,7 @@ class TestForceFieldParameterAssignment:
   </Constraints>
 </SMIRNOFF>
 """
-        from simtk.openmm import app
-
-        from openforcefield.tests.utils import (
-            compare_system_energies,
-            evaluate_molecules_off,
-            get_context_potential_energy,
-        )
+        from openforcefield.tests.utils import evaluate_molecules_off
 
         off_ff = ForceField("test_forcefields/test_forcefield.offxml", tip5p_offxml)
 

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -1706,8 +1706,6 @@ class TestVirtualSiteHandler:
 
     def _test_variable_names(self, valid_kwargs, variable_names):
 
-        from openforcefield.typing.chemistry.environment import SMIRKSParsingError
-
         for name_to_change in variable_names:
             invalid_kwargs = valid_kwargs.copy()
             invalid_kwargs[

--- a/openforcefield/tests/test_toolkits.py
+++ b/openforcefield/tests/test_toolkits.py
@@ -720,8 +720,6 @@ class TestOpenEyeToolkitWrapper:
         """
         from io import StringIO
 
-        from openeye import oechem
-
         toolkit = OpenEyeToolkitWrapper()
         water = Molecule()
         water.add_atom(1, 0, False)

--- a/openforcefield/tests/test_topology.py
+++ b/openforcefield/tests/test_topology.py
@@ -748,12 +748,10 @@ class TestTopology(TestCase):
         Checks whether writing pdb with unitless positions, Angstrom positions,
         nanometer positions, result in the same output
         """
-        import filecmp
         from tempfile import NamedTemporaryFile
 
         from simtk.unit import nanometer
 
-        from openforcefield.tests.test_forcefield import create_ethanol
         from openforcefield.topology import Molecule, Topology
 
         topology = Topology()
@@ -803,10 +801,8 @@ class TestTopology(TestCase):
         """
         Checks if fileformat specifier is indpendent of upper/lowercase
         """
-        import os
         from tempfile import NamedTemporaryFile
 
-        from openforcefield.tests.test_forcefield import create_ethanol
         from openforcefield.topology import Molecule, Topology
 
         topology = Topology()
@@ -830,7 +826,6 @@ class TestTopology(TestCase):
         """
         Checks for invalid file format
         """
-        from openforcefield.tests.test_forcefield import create_ethanol
         from openforcefield.topology import Molecule, Topology
 
         topology = Topology()

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -5477,6 +5477,8 @@ class Molecule(FrozenMolecule):
                     "installed. Try conda install -c conda-forge nglview."
                 )
             if self.conformers:
+                from openforcefield.utils.viz import _OFFTrajectoryNGLView
+
                 trajectory_like = _OFFTrajectoryNGLView(self)
                 widget = nv.NGLWidget(trajectory_like)
                 return widget
@@ -5534,46 +5536,6 @@ class Molecule(FrozenMolecule):
             return display(self.visualize(backend="openeye"))
         except ValueError:
             pass
-
-
-try:
-    from nglview import Trajectory as _NGLViewTrajectory
-except ImportError:
-    _NGLViewTrajectory = object
-
-
-class _OFFTrajectoryNGLView(_NGLViewTrajectory):
-    """
-    Handling conformers of an OpenFF Molecule as frames in a trajectory. Only
-    to be used for NGLview visualization.
-
-    Parameters
-    ----------
-    molecule : openforcefield.topology.Molecule
-        The molecule (with conformers) to visualize
-    """
-
-    def __init__(self, molecule):
-        self.molecule = molecule
-        self.ext = "pdb"
-        self.params = {}
-        self.id = str(uuid.uuid4())
-
-    def get_coordinates(self, index):
-        return self.molecule.conformers[index] / unit.angstrom
-
-    @property
-    def n_frames(self):
-        return len(self.molecule.conformers)
-
-    def get_structure_string(self):
-        memfile = StringIO()
-        self.molecule.to_file(memfile, "pdb")
-        memfile.seek(0)
-        block = memfile.getvalue()
-        # FIXME: Prevent multi-model PDB export with a keyword in molecule.to_file()?
-        models = block.split("END\n", 1)
-        return models[0]
 
 
 class InvalidConformerError(Exception):

--- a/openforcefield/topology/molecule.py
+++ b/openforcefield/topology/molecule.py
@@ -34,25 +34,19 @@ Molecular chemical entity representation and routines to interface with cheminfo
 # =============================================================================================
 
 import operator
-import uuid
 import warnings
-from collections import Counter, OrderedDict
+from collections import OrderedDict
 from copy import deepcopy
-from io import StringIO
 
 import networkx as nx
 import numpy as np
-from networkx.algorithms.isomorphism import GraphMatcher
 from simtk import unit
 from simtk.openmm.app import Element, element
 
 import openforcefield
 from openforcefield.utils import (
     MessageException,
-    check_units_are_compatible,
-    deserialize_numpy,
     quantity_to_string,
-    serialize_numpy,
     string_to_quantity,
 )
 from openforcefield.utils.serialization import Serializable
@@ -286,6 +280,8 @@ class Atom(Particle):
 
     @formal_charge.setter
     def formal_charge(self, other):
+        from openforcefield.utils.utils import check_units_are_compatible
+
         """
         Set the atom's formal charge. Accepts either ints or simtk.unit.Quantity-wrapped ints with units of charge.
         """
@@ -1975,6 +1971,8 @@ class FrozenMolecule(Serializable):
             A dictionary representation of the molecule.
 
         """
+        from openforcefield.utils.utils import serialize_numpy
+
         molecule_dict = OrderedDict()
         molecule_dict["name"] = self._name
         ## From Jeff: If we go the properties-as-dict route, then _properties should, at
@@ -2060,6 +2058,7 @@ class FrozenMolecule(Serializable):
             A dictionary representation of the molecule.
         """
         # TODO: Provide useful exception messages if there are any failures
+        from openforcefield.utils.utils import deserialize_numpy
 
         self._initialize()
         self.name = molecule_dict["name"]
@@ -2630,6 +2629,8 @@ class FrozenMolecule(Serializable):
 
         mol1_netx = to_networkx(mol1)
         mol2_netx = to_networkx(mol2)
+        from networkx.algorithms.isomorphism import GraphMatcher
+
         GM = GraphMatcher(
             mol1_netx, mol2_netx, node_match=node_match_func, edge_match=edge_match_func
         )
@@ -3678,6 +3679,8 @@ class FrozenMolecule(Serializable):
         NotImplementedError : if the molecule is not of one of the specified types.
         """
 
+        import networkx as nx
+
         from openforcefield.topology import TopologyMolecule
 
         # check for networkx then assuming we have a Molecule or TopologyMolecule instance just try and
@@ -3705,6 +3708,8 @@ class FrozenMolecule(Serializable):
         # https://en.wikipedia.org/wiki/Chemical_formula#Hill_system
 
         # create the counter dictionary using chemical symbols
+        from collections import Counter
+
         atom_symbol_counts = Counter(
             Element.getByAtomicNumber(atom_num).symbol for atom_num in atom_nums
         )

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -2243,8 +2243,6 @@ class Topology(Serializable):
         topology : openforcefield.Topology
             An openforcefield Topology object
         """
-        import parmed
-
         # TODO: Implement functionality
         raise NotImplementedError
 
@@ -2260,8 +2258,6 @@ class Topology(Serializable):
         parmed_structure : parmed.Structure
             A ParmEd Structure objecft
         """
-        import parmed
-
         # TODO: Implement functionality
         raise NotImplementedError
 

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -37,13 +37,13 @@ import os
 import pathlib
 from collections import OrderedDict
 
-from simtk import openmm, unit
+from simtk import openmm
 
 from openforcefield.topology.molecule import DEFAULT_AROMATICITY_MODEL
 from openforcefield.typing.engines.smirnoff.io import ParameterIOHandler
 from openforcefield.typing.engines.smirnoff.parameters import ParameterHandler
 from openforcefield.typing.engines.smirnoff.plugins import load_handler_plugins
-from openforcefield.utils import (
+from openforcefield.utils.utils import (
     MessageException,
     all_subclasses,
     convert_0_1_smirnoff_to_0_2,
@@ -955,8 +955,6 @@ class ForceField:
         allow_cosmetic_attributes : bool, optional. Default = False
             Whether to permit non-spec kwargs in smirnoff_data.
         """
-        from collections import defaultdict
-
         import packaging.version
 
         # Check that the SMIRNOFF version of this data structure is supported by this ForceField implementation

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -60,8 +60,9 @@ from simtk import openmm, unit
 from openforcefield.topology import ImproperDict, SortedDict, Topology, ValenceDict
 from openforcefield.topology.molecule import Molecule
 from openforcefield.typing.chemistry import ChemicalEnvironment
-from openforcefield.utils import (
-    GLOBAL_TOOLKIT_REGISTRY,
+from openforcefield.utils.collections import ValidatedDict, ValidatedList
+from openforcefield.utils.toolkits import GLOBAL_TOOLKIT_REGISTRY
+from openforcefield.utils.utils import (
     IncompatibleUnitError,
     MessageException,
     all_subclasses,
@@ -69,7 +70,6 @@ from openforcefield.utils import (
     extract_serialized_units_from_dict,
     object_to_quantity,
 )
-from openforcefield.utils.collections import ValidatedDict, ValidatedList
 
 # =============================================================================================
 # CONFIGURE LOGGER
@@ -3773,11 +3773,7 @@ class ElectrostaticsHandler(_NonbondedHandler):
         return False
 
     def create_force(self, system, topology, **kwargs):
-        from openforcefield.topology import (
-            FrozenMolecule,
-            TopologyAtom,
-            TopologyVirtualSite,
-        )
+        from openforcefield.topology import TopologyAtom, TopologyVirtualSite
 
         force = super().create_force(system, topology, **kwargs)
 
@@ -4006,8 +4002,6 @@ class LibraryChargeHandler(_NonbondedHandler):
         return self._find_matches(entity, transformed_dict_cls=dict)
 
     def create_force(self, system, topology, **kwargs):
-        from openforcefield.topology import FrozenMolecule
-
         force = super().create_force(system, topology, **kwargs)
 
         # Iterate over all defined library charge parameters, allowing later matches to override earlier ones.
@@ -4103,11 +4097,7 @@ class ToolkitAM1BCCHandler(_NonbondedHandler):
     def create_force(self, system, topology, **kwargs):
         import warnings
 
-        from openforcefield.topology import (
-            FrozenMolecule,
-            TopologyAtom,
-            TopologyVirtualSite,
-        )
+        from openforcefield.topology import TopologyAtom, TopologyVirtualSite
         from openforcefield.utils.toolkits import GLOBAL_TOOLKIT_REGISTRY
 
         force = super().create_force(system, topology, **kwargs)
@@ -4296,11 +4286,7 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
     def create_force(self, system, topology, **kwargs):
         import warnings
 
-        from openforcefield.topology import (
-            FrozenMolecule,
-            TopologyAtom,
-            TopologyVirtualSite,
-        )
+        from openforcefield.topology import TopologyAtom, TopologyVirtualSite
 
         # We only want one instance of this force type
         existing = [system.getForce(i) for i in range(system.getNumForces())]

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -65,7 +65,7 @@ from functools import wraps
 import numpy as np
 from simtk import unit
 
-from openforcefield.utils import (
+from openforcefield.utils.utils import (
     MessageException,
     all_subclasses,
     inherit_docstrings,
@@ -1816,7 +1816,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         >>> iupac_name = toolkit.to_iupac(molecule)
 
         """
-        from openeye import oechem, oeiupac
+        from openeye import oeiupac
 
         oemol = self.to_openeye(molecule)
 

--- a/openforcefield/utils/utils.py
+++ b/openforcefield/utils/utils.py
@@ -434,7 +434,6 @@ def check_units_are_compatible(object_name, object, unit_to_check, context=None)
     ------
     IncompatibleUnitError
     """
-    from simtk import unit
 
     # If context is not provided, explicitly make it a blank string
     if context is None:
@@ -585,7 +584,6 @@ def detach_units(unit_bearing_dict, output_units=None):
         A dictionary in which keys are keys of simtk.unit.Quantity values in unit_bearing_dict,
         but suffixed with "_unit". Values are simtk.unit.Unit .
     """
-    from simtk import unit
 
     if output_units is None:
         output_units = {}

--- a/openforcefield/utils/viz.py
+++ b/openforcefield/utils/viz.py
@@ -1,3 +1,8 @@
+import uuid
+from io import StringIO
+
+from simtk import unit
+
 try:
     from nglview import Trajectory as _NGLViewTrajectory
 except ImportError:

--- a/openforcefield/utils/viz.py
+++ b/openforcefield/utils/viz.py
@@ -1,0 +1,38 @@
+try:
+    from nglview import Trajectory as _NGLViewTrajectory
+except ImportError:
+    _NGLViewTrajectory = object
+
+
+class _OFFTrajectoryNGLView(_NGLViewTrajectory):
+    """
+    Handling conformers of an OpenFF Molecule as frames in a trajectory. Only
+    to be used for NGLview visualization.
+
+    Parameters
+    ----------
+    molecule : openforcefield.topology.Molecule
+        The molecule (with conformers) to visualize
+    """
+
+    def __init__(self, molecule):
+        self.molecule = molecule
+        self.ext = "pdb"
+        self.params = {}
+        self.id = str(uuid.uuid4())
+
+    def get_coordinates(self, index):
+        return self.molecule.conformers[index] / unit.angstrom
+
+    @property
+    def n_frames(self):
+        return len(self.molecule.conformers)
+
+    def get_structure_string(self):
+        memfile = StringIO()
+        self.molecule.to_file(memfile, "pdb")
+        memfile.seek(0)
+        block = memfile.getvalue()
+        # FIXME: Prevent multi-model PDB export with a keyword in molecule.to_file()?
+        models = block.split("END\n", 1)
+        return models[0]


### PR DESCRIPTION
Resolves #155 

I went through most of the core modules and looked for imports that did not need to be global or did not need to be there at all (F401). I used https://github.com/nschloe/tuna to asses which imports are the slowest. The results are pretty stochastic, but the heaviest now are, roughly in order:
1. SciPy stack
2. NetworkX
3. Cheminformatics toolkits
4. OpenMM
5. versioning module

Right now, these core core imports average around 1.0-1.1 seconds on my machine:

```python3
from openforcefield.topology import Molecule, Topology
from openforcefield.typing.engines.smirnoff import ForceField
```

The major change here is moving the `nglview` import into a separate module. Previously, it was being checked every time something from `openforcefield.topology` was imported, even though only a fraction of the time will a visualization method be called. This should save around 0.7s seconds in the majority of workflows.

- [ ] Better comparison of import times
- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
