### PR TITLE
Update Topology.from_mdtraj

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -67,7 +67,7 @@ Bugfixes
   using a ``vdWHandler`` that was initialized using the API.
 - `PR #776 <https://github.com/openforcefield/openforcefield/pull/776>`_: Fixes a bug in which
   the :py:meth:`Topology.from_openmm <openforcefield.topology.Topology.from_openmm>` and
-  :py:meth:`Topology.from_openmm <openforcefield.topology.Topology.from_openmm>` methods would
+  :py:meth:`Topology.from_mdtraj <openforcefield.topology.Topology.from_mdtraj>` methods would
   dangerously allow `unique_molecules=None`.
 
 

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -32,7 +32,10 @@ Behavior Changed
   running these constructors using subclasses of :py:class:`FrozenMolecule <openforcefield.topology.Molecule>`
   would not return an instance of that subclass, but rather just an instance of a
   :py:class:`Molecule <openforcefield.topology.Molecule>`.
-
+- `PR #753 <https://github.com/openforcefield/openforcefield/pull/753>`_: ``ParameterLookupError``
+  is now raised when passing to
+  :py:meth:`ParameterList.index <openforcefield.typing.engines.smirnoff.parameters.ParameterList>`
+  a SMIRKS pattern not found in the parameter list.
 
 New features
 """"""""""""
@@ -62,13 +65,10 @@ Bugfixes
 - `PR #756 <https://github.com/openforcefield/openforcefield/pull/756>`_: Fixes bug when running
   :py:meth:`vdWHandler.create_force <openforcefield.typing.engines.smirnoff.parameters.vdWHandler.create_force>`
   using a ``vdWHandler`` that was initialized using the API.
-
-Behavior changed
-""""""""""""""""
-- `PR #753 <https://github.com/openforcefield/openforcefield/pull/753>`_: ``ParameterLookupError``
-  is now raised when passing to
-  :py:meth:`ParameterList.index <openforcefield.typing.engines.smirnoff.parameters.ParameterList>`
-  a SMIRKS pattern not found in the parameter list.
+- `PR #776 <https://github.com/openforcefield/openforcefield/pull/776>`_: Fixes a bug in which
+  the :py:meth:`Topology.from_openmm <openforcefield.topology.Topology.from_openmm>` and
+  :py:meth:`Topology.from_openmm <openforcefield.topology.Topology.from_openmm>` methods would
+  dangerously allow `unique_molecules=None`.
 
 
 0.8.0 - Virtual Sites

--- a/openforcefield/tests/test_topology.py
+++ b/openforcefield/tests/test_topology.py
@@ -609,7 +609,7 @@ class TestTopology(TestCase):
         with pytest.raises(
             MissingUniqueMoleculesError, match="requires a list of Molecule objects"
         ):
-            Topology.from_openmm(pdbfile.topology, unique_molecules=None)
+            Topology.from_openmm(pdbfile.topology)
 
         molecules = [create_ethanol(), create_cyclohexane()]
 
@@ -729,7 +729,7 @@ class TestTopology(TestCase):
         with pytest.raises(
             MissingUniqueMoleculesError, match="requires a list of Molecule objects"
         ):
-            Topology.from_mdtraj(trj.top, unique_molecules=None)
+            Topology.from_mdtraj(trj.top)
 
         unique_molecules = [
             Molecule.from_smiles(mol_name) for mol_name in ["C1CCCCC1", "CCO"]

--- a/openforcefield/topology/__init__.py
+++ b/openforcefield/topology/__init__.py
@@ -16,6 +16,7 @@ from openforcefield.topology.topology import (
     ImproperDict,
     InvalidBoxVectorsError,
     InvalidPeriodicityError,
+    MissingUniqueMoleculesError,
     NotBondedError,
     SortedDict,
     Topology,

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -1915,8 +1915,6 @@ class Topology(Serializable):
             The atomic elements and bond connectivity will be used to match the reference molecules
             to molecule graphs appearing in the OpenMM ``Topology``. If bond orders are present in the
             OpenMM ``Topology``, these will be used in matching as well.
-            If all bonds have bond orders assigned in ``mdtraj_topology``, these bond orders will be used to attempt to construct
-            the list of unique Molecules if the ``unique_molecules`` argument is omitted.
 
         Returns
         -------
@@ -2195,12 +2193,10 @@ class Topology(Serializable):
         mdtraj_topology : mdtraj.Topology
             An MDTraj Topology object
         unique_molecules : iterable of objects that can be used to construct unique Molecule objects
-            All unique molecules mult be provided, in any order, though multiple copies of each molecule are allowed.
+            All unique molecules must be provided, in any order, though multiple copies of each molecule are allowed.
             The atomic elements and bond connectivity will be used to match the reference molecules
             to molecule graphs appearing in the MDTraj ``Topology``. If bond orders are present in the
             MDTraj ``Topology``, these will be used in matching as well.
-            If all bonds have bond orders assigned in ``mdtraj_topology``, these bond orders will be used to attempt to construct
-            the list of unique Molecules if the ``unique_molecules`` argument is omitted.
 
         Returns
         -------
@@ -2242,13 +2238,10 @@ class Topology(Serializable):
         parmed_structure : parmed.Structure
             A ParmEd structure object
         unique_molecules : iterable of objects that can be used to construct unique Molecule objects
-            All unique molecules mult be provided, in any order, though multiple copies of each molecule are allowed.
+            All unique molecules must be provided, in any order, though multiple copies of each molecule are allowed.
             The atomic elements and bond connectivity will be used to match the reference molecules
             to molecule graphs appearing in the structure's ``topology`` object. If bond orders are present in the
             structure's ``topology`` object, these will be used in matching as well.
-            If all bonds have bond orders assigned in the structure's ``topology`` object,
-            these bond orders will be used to attempt to construct
-            the list of unique Molecules if the ``unique_molecules`` argument is omitted.
 
         Returns
         -------

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -73,6 +73,12 @@ class InvalidPeriodicityError(MessageException):
     """
 
 
+class MissingUniqueMoleculesError(MessageException):
+    """
+    Exception for a when unique_molecules is required but not found
+    """
+
+
 # =============================================================================================
 # PRIVATE SUBROUTINES
 # =============================================================================================
@@ -1926,6 +1932,12 @@ class Topology(Serializable):
         for omm_bond in openmm_topology.bonds():
             if omm_bond.order is None:
                 omm_has_bond_orders = False
+
+        if unique_molecules is None:
+            raise MissingUniqueMoleculesError(
+                "Topology.from_openmm requires a list of Molecule objects "
+                "passed as unique_molecules, but None was passed."
+            )
 
         # Convert all unique mols to graphs
         topology = cls()


### PR DESCRIPTION
Fixes #773 by
* raising an exception `MissingUniqueMoleculesError` when `unique_molecules=None` but shouldn't be (previously a cryptic error would be raised when trying to iterate over `None` inside of `from_openmm`)
* adding tests for `Topology.from_mdtraj`
* updating docstrings

I'm open to "removing" it from the public API by prepending the method with an underscore; I have no opinion on that decision either way.

- [ ] Can `from_openmm` safely infer molecules from an OpenMM Topology if `unique_molecules=None`? I can't tell if this was ever working
- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
