### PR TITLE
Remove pins to previous major versions of pytest and coverage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,6 +53,7 @@ jobs:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
       PACKAGE: openforcefield
       PYTEST_ARGS: -r fE --tb=short --cov=openforcefield --cov-config=setup.cfg --cov-append --cov-report=xml
+      NB_ARGS: -v --nbval-lax --ignore=examples/deprecated
 
     steps:
       - uses: actions/checkout@v2
@@ -157,15 +158,14 @@ jobs:
       - name: Run example notebooks
         shell: bash -l {0}
         run: |
-          PYTEST_ARGS+=" --nbval-lax --ignore=examples/deprecated"
-          PYTEST_ARGS+=" --ignore=examples/using_smirnoff_in_amber_or_gromacs"
+          NB_ARGS+=" --ignore=examples/using_smirnoff_in_amber_or_gromacs"
           if [[ "$RDKIT" == false ]]; then
-            PYTEST_ARGS+=" --ignore=examples/check_dataset_parameter_coverage"
-            PYTEST_ARGS+=" --ignore=examples/conformer_energies"
-            PYTEST_ARGS+=" --ignore=examples/QCArchive_interface"
-            PYTEST_ARGS+=" --ignore=examples/visualization"
+            NB_ARGS+=" --ignore=examples/check_dataset_parameter_coverage"
+            NB_ARGS+=" --ignore=examples/conformer_energies"
+            NB_ARGS+=" --ignore=examples/QCArchive_interface"
+            NB_ARGS+=" --ignore=examples/visualization"
           fi
-          pytest $PYTEST_ARGS examples/
+          pytest $NB_ARGS examples/
 
       - name: Run code snippets in docs
         shell: bash -l {0}

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -10,11 +10,11 @@ dependencies:
   - pip
 
     # Testing
-  - pytest < 6.0
+  - pytest
   - pytest-cov
   - nbval
   - codecov
-  - coverage < 5.0
+  - coverage
   - numpy
   - networkx
   - ambertools

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -9,11 +9,11 @@ dependencies:
   - pip
 
     # Testing
-  - pytest < 6.0
+  - pytest
   - pytest-cov
   - nbval
   - codecov
-  - coverage < 5.0
+  - coverage
   - numpy
   - networkx
   - ambertools

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -10,11 +10,11 @@ dependencies:
   - pip
 
     # Testing
-  - pytest < 6.0
+  - pytest
   - pytest-cov
   - nbval
   - codecov
-  - coverage < 5.0
+  - coverage
   - numpy
   - networkx
   - ambertools


### PR DESCRIPTION
Toward the end of #615, pytest bumped a major version (6.x) and some pytest-adjacent packages had yet to roll out updates for compatibility, so I pinned to `pytest <6` (980f21802730e9b1e67a6eb65d6417f5477cd279). That was in July, and I believe everything has been updated since then. During the 0.8.1 release, I noticed this pin was not removed, and this PR does that. My development environment, and probably others', does not have this pin, so I don't expect tests to fail.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
