### PR TITLE
Fix parsing vdW parameters from dict of string

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -7,6 +7,17 @@ Releases follow the ``major.minor.micro`` scheme recommended by `PEP440 <https:/
 * ``minor`` increments add features but do not break API compatibility
 * ``micro`` increments represent bugfix releases or improvements in documentation
 
+0.8.2 - Current development
+---------------------------
+
+Bugfixes
+""""""""
+- `PR #789 <https://github.com/openforcefield/openforcefield/pull/xyz>`_: Fixes bug
+  when creating
+  :py:class:`vdWHandler.vdWType <openforcefield.typing.engines.smirnoff.parameters.vdWHandler.vdWType>`
+  from scratch using dicts of strings.
+
+
 0.8.1 - Bugfix and minor feature release
 ----------------------------------------
 

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -1737,7 +1737,7 @@ class TestvdWHandler:
         }
         vdw_handler.add_parameter(param)
 
-        assert vdw_handler.get_parameter({"smirks": "[*:1]"}).id == "n99"
+        assert vdw_handler.get_parameter({"smirks": "[*:1]"})[0].id == "n99"
 
 
 class TestvdWType:

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -1728,6 +1728,11 @@ class TestvdWHandler:
         vdw_handler.create_force(omm_sys, topology)
 
     def test_add_param_str(self):
+        """
+        Ensure that string input is supported, given the added complication that the 
+        sigma/rmin_half setters silently set each other's value.
+        See https://github.com/openforcefield/openforcefield/issues/788
+        """
         vdw_handler = vdWHandler(version=0.3)
         param = {
             "epsilon": "0.5 * kilocalorie/mole",

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -1734,15 +1734,23 @@ class TestvdWHandler:
         See https://github.com/openforcefield/openforcefield/issues/788
         """
         vdw_handler = vdWHandler(version=0.3)
-        param = {
+        param1 = {
             "epsilon": "0.5 * kilocalorie/mole",
             "rmin_half": "1.2 * angstrom",
             "smirks": "[*:1]",
             "id": "n99",
         }
-        vdw_handler.add_parameter(param)
+        param2 = {
+            "epsilon": "0.1 * kilocalorie/mole",
+            "sigma": "0.8 * angstrom",
+            "smirks": "[#1:1]",
+            "id": "n00",
+        }
+        vdw_handler.add_parameter(param1)
+        vdw_handler.add_parameter(param2)
 
         assert vdw_handler.get_parameter({"smirks": "[*:1]"})[0].id == "n99"
+        assert vdw_handler.get_parameter({"smirks": "[#1:1]"})[0].id == "n00"
 
 
 class TestvdWType:

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -1729,7 +1729,7 @@ class TestvdWHandler:
 
     def test_add_param_str(self):
         """
-        Ensure that string input is supported, given the added complication that the 
+        Ensure that string input is supported, given the added complication that the
         sigma/rmin_half setters silently set each other's value.
         See https://github.com/openforcefield/openforcefield/issues/788
         """

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -1727,6 +1727,18 @@ class TestvdWHandler:
         omm_sys = openmm.System()
         vdw_handler.create_force(omm_sys, topology)
 
+    def test_add_param_str(self):
+        vdw_handler = vdWHandler(version=0.3)
+        param = {
+            "epsilon": "0.5 * kilocalorie/mole",
+            "rmin_half": "1.2 * angstrom",
+            "smirks": "[*:1]",
+            "id": "n99",
+        }
+        vdw_handler.add_parameter(param)
+
+        assert vdw_handler.get_parameter({"smirks": "[*:1]"}).id == "n99"
+
 
 class TestvdWType:
     """

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -3511,10 +3511,14 @@ class vdWHandler(_NonbondedHandler):
         def __setattr__(self, name, value):
             super().__setattr__(key=name, value=value)
             if name == "rmin_half":
+                if type(value) == str:
+                    value = object_to_quantity(value)
                 super().__setattr__("sigma", value / 2 ** (1 / 6))
                 self._extra_nb_var = "sigma"
 
             if name == "sigma":
+                if type(value) == str:
+                    value = object_to_quantity(value)
                 super().__setattr__("rmin_half", value * 2 ** (1 / 6))
                 self._extra_nb_var = "rmin_half"
 


### PR DESCRIPTION
Resolves #788 
- [ ] `convert_and_validate` vs. `object_to_quantity`?
- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
